### PR TITLE
feat: node.js export

### DIFF
--- a/packages/uploadthing/package.json
+++ b/packages/uploadthing/package.json
@@ -11,7 +11,7 @@
     "./server": {
       "import": "./dist/server.mjs",
       "types": "./dist/server.d.ts",
-      "node": "./dist/server.mjs"
+      "default": "./dist/server.mjs"
     },
     "./next": {
       "import": "./dist/next.mjs",

--- a/packages/uploadthing/package.json
+++ b/packages/uploadthing/package.json
@@ -10,7 +10,8 @@
     },
     "./server": {
       "import": "./dist/server.mjs",
-      "types": "./dist/server.d.ts"
+      "types": "./dist/server.d.ts",
+      "node": "./dist/server.mjs"
     },
     "./next": {
       "import": "./dist/next.mjs",


### PR DESCRIPTION
Currently the `server` export is missing the `node` export for Node.js
I needed to patch this to add support in my websocket server which was running on Node.js