### PR TITLE
Use await when invoking callback

### DIFF
--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -175,7 +175,7 @@ export const buildRequestHandler = <
 
     if (uploadthingHook && uploadthingHook === "callback") {
       // This is when we receive the webhook from uploadthing
-      uploadable.resolver({
+      await uploadable.resolver({
         file: reqBody.file,
         metadata: reqBody.metadata,
       });


### PR DESCRIPTION
When UploadThing's webhook makes a request to the callback URL, the request handler does not `await` the user supplied callback function. It is expected that users will supply an async callback to persist state in their database or otherwise process the new file, and therefore it is appropriate to `await` it.

This does not cause any issues in dev mode, but when hosting on Vercel in production it will cause the callback function to be prematurely terminated (probably at the first time it yields?), causing buggy behavior.