### PR TITLE
fix(uploadButton): accept mimeTypes join & allow multiple files to pass

### DIFF
--- a/.changeset/olive-doors-kick.md
+++ b/.changeset/olive-doors-kick.md
@@ -1,0 +1,5 @@
+---
+"@uploadthing/react": patch
+---
+
+fix(uploadButton): accept mimeTypes join & allow multiple files to be passed

--- a/packages/react/src/component.tsx
+++ b/packages/react/src/component.tsx
@@ -40,7 +40,7 @@ export function UploadButton<TRouter extends void | FileRouter = void>(props: {
         <input
           className="ut-hidden"
           type="file"
-          multiple={props.multiple ?? true}
+          multiple={props.multiple}
           accept={generateMimeTypes(fileTypes ?? []).join(", ")}
           onChange={(e) => {
             e.target.files && startUpload(Array.from(e.target.files));

--- a/packages/react/src/component.tsx
+++ b/packages/react/src/component.tsx
@@ -47,7 +47,7 @@ export function UploadButton<TRouter extends void | FileRouter = void>(props: {
           }}
         />
         <span className="ut-px-3 ut-py-2 ut-text-white">
-          {isUploading ? <Spinner /> : `Choose File${multiple ? `(s)` : `` }`}
+          {isUploading ? <Spinner /> : `Choose File${ props.multiple ? `(s)` : `` }`}
         </span>
       </label>
       <div className="ut-h-[1.25rem]">

--- a/packages/react/src/component.tsx
+++ b/packages/react/src/component.tsx
@@ -47,7 +47,7 @@ export function UploadButton<TRouter extends void | FileRouter = void>(props: {
           }}
         />
         <span className="ut-px-3 ut-py-2 ut-text-white">
-          {isUploading ? <Spinner /> : `Choose File`}
+          {isUploading ? <Spinner /> : `Choose File${multiple ? `(s)` : `` }`}
         </span>
       </label>
       <div className="ut-h-[1.25rem]">

--- a/packages/react/src/component.tsx
+++ b/packages/react/src/component.tsx
@@ -17,6 +17,7 @@ type EndpointHelper<TRouter extends void | FileRouter> = void extends TRouter
 export function UploadButton<TRouter extends void | FileRouter = void>(props: {
   endpoint: EndpointHelper<TRouter>;
   onClientUploadComplete?: () => void;
+  multiple?: boolean;
 }) {
   const { startUpload, isUploading, permittedFileInfo } =
     useUploadThing<string>({
@@ -32,9 +33,8 @@ export function UploadButton<TRouter extends void | FileRouter = void>(props: {
         <input
           className="ut-hidden"
           type="file"
-          accept={
-            fileTypes ? generateMimeTypes(fileTypes).join(",") : undefined
-          }
+          multiple={props.multiple ?? true}
+          accept={generateMimeTypes(fileTypes ?? []).join(", ")}
           onChange={(e) => {
             e.target.files && startUpload(Array.from(e.target.files));
           }}


### PR DESCRIPTION
This will allow multiple files to be passed when using the uploadButton comp (let the user select more than 1 file optionally)
this also fixes the mimeTypes for uploadButton (it was joined with "," when it should have been ", " therefore it didn't work and you could pass any file you want)

closes https://github.com/pingdotgg/uploadthing/issues/37