### PR TITLE
feat: generateComponents function for React & Solid

### DIFF
--- a/.changeset/honest-seas-rush.md
+++ b/.changeset/honest-seas-rush.md
@@ -1,0 +1,6 @@
+---
+"@uploadthing/react": patch
+"@uploadthing/solid": patch
+---
+
+feat: generateSolidComponents & generateReactComponents functions

--- a/.changeset/honest-seas-rush.md
+++ b/.changeset/honest-seas-rush.md
@@ -1,6 +1,7 @@
 ---
-"@uploadthing/react": patch
-"@uploadthing/solid": patch
+"@uploadthing/react": minor
+"@uploadthing/solid": minor
 ---
 
-feat: generateSolidComponents & generateReactComponents functions
+feat: `generateComponents` functions for solid and react allows to pass the
+generic `FileRouter` once instead of for everytime the component is used

--- a/docs/src/pages/nextjs/appdir.mdx
+++ b/docs/src/pages/nextjs/appdir.mdx
@@ -67,7 +67,12 @@ export const { GET, POST } = createNextRouteHandler({
 });
 ```
 
-### Creating The UploadThing Components
+### Creating The UploadThing Components (optional)
+
+Generating components let's you pass your generic `FileRouter` once and then
+have typesafe components everywhere, instead of having to pass the generic
+everytime you mount a component, but you can also import the components
+individually from `@uploadthing/react`.
 
 ```ts copy filename="src/utils/uploadthing.ts"
 import { generateComponents } from "@uploadthing/react";

--- a/docs/src/pages/nextjs/appdir.mdx
+++ b/docs/src/pages/nextjs/appdir.mdx
@@ -67,6 +67,17 @@ export const { GET, POST } = createNextRouteHandler({
 });
 ```
 
+### Creating The UploadThing Components
+
+```ts copy filename="src/utils/uploadthing.ts"
+import { generateComponents } from "@uploadthing/react";
+
+import type { OurFileRouter } from "~/server/uploadthing";
+
+export const { UploadButton, UploadDropzone, Uploader } =
+  generateComponents<OurFileRouter>();
+```
+
 ### Use the FileRouter in your app
 
 The `@uploadthing/react` package includes an "UploadButton" component that you
@@ -78,14 +89,12 @@ can simply drop into your app, and start uploading files immediately.
 // You need to import our styles for the button to look right. Best to import in the root /layout.tsx but this is fine
 import "@uploadthing/react/styles.css";
 
-import { UploadButton } from "@uploadthing/react";
-
-import { OurFileRouter } from "./api/uploadthing/core";
+import { UploadButton } from "~/utils/uploadthing";
 
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-between p-24">
-      <UploadButton<OurFileRouter>
+      <UploadButton
         endpoint="imageUploader"
         onClientUploadComplete={(res) => {
           // Do something with the response

--- a/docs/src/pages/nextjs/pagedir.mdx
+++ b/docs/src/pages/nextjs/pagedir.mdx
@@ -87,7 +87,12 @@ const handler = createNextPageApiHandler({
 export default handler;
 ```
 
-### Creating The UploadThing Components
+### Creating The UploadThing Components (optional)
+
+Generating components let's you pass your generic `FileRouter` once and then
+have typesafe components everywhere, instead of having to pass the generic
+everytime you mount a component, but you can also import the components
+individually from `@uploadthing/react`.
 
 ```ts copy filename="src/utils/uploadthing.ts"
 import { generateComponents } from "@uploadthing/react";

--- a/docs/src/pages/nextjs/pagedir.mdx
+++ b/docs/src/pages/nextjs/pagedir.mdx
@@ -23,7 +23,8 @@ module.exports = nextConfig;
 <Steps>
 ### Creating your first FileRoute
 
-All files uploaded to uploadthing are associated with a FileRoute. Think of a FileRoute similar to an endpoint, it has:
+All files uploaded to uploadthing are associated with a FileRoute. Think of a
+FileRoute similar to an endpoint, it has:
 
 - Permitted types ["image", "video", etc]
 - Max file size
@@ -32,7 +33,8 @@ All files uploaded to uploadthing are associated with a FileRoute. Think of a Fi
 
 ```ts copy
 /** server/uploadthing.ts */
-import type { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from "next";
+
 import { createUploadthing, type FileRouter } from "uploadthing/next-legacy";
 
 const f = createUploadthing();
@@ -85,21 +87,31 @@ const handler = createNextPageApiHandler({
 export default handler;
 ```
 
-### Use the FileRouter in your app
+### Creating The UploadThing Components
 
-The `@uploadthing/react` package includes an "UploadButton" component that you can simply drop into your app, and start uploading files immediately.
-
-```tsx copy
-import { UploadButton } from "@uploadthing/react";
+```ts copy filename="src/utils/uploadthing.ts"
+import { generateComponents } from "@uploadthing/react";
 
 import type { OurFileRouter } from "~/server/uploadthing";
+
+export const { UploadButton, UploadDropzone, Uploader } =
+  generateComponents<OurFileRouter>();
+```
+
+### Use the FileRouter in your app
+
+The `@uploadthing/react` package includes an "UploadButton" component that you
+can simply drop into your app, and start uploading files immediately.
+
+```tsx copy
+import { UploadButton } from "~/utils/uploadthing";
 // You need to import our styles for the button to look right. Best to import in the root /_app.tsx but this is fine
 import "@uploadthing/react/styles.css";
 
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-between p-24">
-      <UploadButton<OurFileRouter>
+      <UploadButton
         endpoint="imageUploader"
         onClientUploadComplete={(res) => {
           // Do something with the response

--- a/docs/src/pages/solid.mdx
+++ b/docs/src/pages/solid.mdx
@@ -138,28 +138,36 @@ export const { GET, POST } = createServerHandler({
 });
 ```
 
+### Creating The UploadThing Client
+
+```ts copy filename="src/utils/uploadthing.ts"
+import { generateComponents } from "@uploadthing/solid";
+
+import type { OurFileRouter } from "~/server/uploadthing";
+
+const url = `http://localhost:${process.env.PORT ?? 3000}`;
+
+export const { UploadButton, UploadDropzone, Uploader } =
+  generateComponents<OurFileRouter>(url);
+```
+
 ### Use the FileRouter in your app
 
 The `@uploadthing/solid` package includes an "Uploader" component that you can
 simply drop into your app, and start uploading files immediately.
 
-```tsx copy
+```tsx copy filename="src/routes/index.tsx"
 import type { VoidComponent } from "solid-js";
 
-import { Uploader } from "@uploadthing/solid";
-
+import { Uploader } from "~/utils/uploadthing";
 // You need to import our styles for the button to look right. Best to import in the root /layout.tsx but this is fine
 import "@uploadthing/solid/styles.css";
-
-import type { OurFileRouter } from "~/server/uploadthing";
 
 const Home: VoidComponent = () => {
   return (
     <main class="flex min-h-screen flex-col items-center justify-center gap-16 p-24">
-      <Uploader<OurFileRouter>
+      <Uploader
         endpoint="withoutMdwr"
-        // needed when server side rendering
-        url="http://localhost:9898"
         onClientUploadComplete={(res) => {
           console.log(`onClientUploadComplete`, res);
           alert("Upload Completed");

--- a/docs/src/pages/solid.mdx
+++ b/docs/src/pages/solid.mdx
@@ -138,7 +138,7 @@ export const { GET, POST } = createServerHandler({
 });
 ```
 
-### Creating The UploadThing Client
+### Creating The UploadThing Components
 
 ```ts copy filename="src/utils/uploadthing.ts"
 import { generateComponents } from "@uploadthing/solid";

--- a/docs/src/pages/solid.mdx
+++ b/docs/src/pages/solid.mdx
@@ -138,7 +138,12 @@ export const { GET, POST } = createServerHandler({
 });
 ```
 
-### Creating The UploadThing Components
+### Creating The UploadThing Components (optional)
+
+Generating components let's you pass your generic `FileRouter` once and then
+have typesafe components everywhere, instead of having to pass the generic
+everytime you mount a component, but you can also import the components
+individually from `@uploadthing/solid`.
 
 ```ts copy filename="src/utils/uploadthing.ts"
 import { generateComponents } from "@uploadthing/solid";

--- a/examples/appdir/src/app/page.tsx
+++ b/examples/appdir/src/app/page.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { UploadButton, UploadDropzone } from "@uploadthing/react";
-
-import type { OurFileRouter } from "~/server/uploadthing";
+import { UploadButton, UploadDropzone } from "~/utils/uploadthing";
 
 export default function Home() {
   return (
@@ -12,7 +10,7 @@ export default function Home() {
           {`Upload a file using a button:`}
         </span>
 
-        <UploadButton<OurFileRouter>
+        <UploadButton
           endpoint="withoutMdwr"
           onClientUploadComplete={(res) => {
             // Do something with the response
@@ -28,7 +26,7 @@ export default function Home() {
         <span className="text-center text-4xl font-bold">
           {`...or using a dropzone:`}
         </span>
-        <UploadDropzone<OurFileRouter>
+        <UploadDropzone
           endpoint="withoutMdwr"
           onClientUploadComplete={(res) => {
             // Do something with the response

--- a/examples/appdir/src/utils/uploadthing.ts
+++ b/examples/appdir/src/utils/uploadthing.ts
@@ -1,0 +1,6 @@
+import { generateComponents } from "@uploadthing/react";
+
+import type { OurFileRouter } from "~/server/uploadthing";
+
+export const { UploadButton, UploadDropzone, Uploader } =
+  generateComponents<OurFileRouter>();

--- a/examples/pagedir/src/pages/index.tsx
+++ b/examples/pagedir/src/pages/index.tsx
@@ -1,8 +1,6 @@
 import { Inter } from "next/font/google";
 
-import { UploadButton, UploadDropzone } from "@uploadthing/react";
-
-import type { OurFileRouter } from "~/server/uploadthing";
+import { UploadButton, UploadDropzone } from "~/utils/uploadthing";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -16,7 +14,7 @@ export default function Home() {
           {`Upload a file using a button:`}
         </span>
 
-        <UploadButton<OurFileRouter>
+        <UploadButton
           endpoint="withoutMdwr"
           onClientUploadComplete={(res) => {
             // Do something with the response
@@ -32,7 +30,7 @@ export default function Home() {
         <span className="text-center text-4xl font-bold">
           {`...or using a dropzone:`}
         </span>
-        <UploadDropzone<OurFileRouter>
+        <UploadDropzone
           endpoint="withoutMdwr"
           onClientUploadComplete={(res) => {
             // Do something with the response

--- a/examples/pagedir/src/utils/uploadthing.ts
+++ b/examples/pagedir/src/utils/uploadthing.ts
@@ -1,0 +1,6 @@
+import { generateComponents } from "@uploadthing/react";
+
+import type { OurFileRouter } from "~/server/uploadthing";
+
+export const { UploadButton, UploadDropzone, Uploader } =
+  generateComponents<OurFileRouter>();

--- a/examples/solid/src/routes/index.tsx
+++ b/examples/solid/src/routes/index.tsx
@@ -9,8 +9,6 @@ const Home: VoidComponent = () => {
     <main class="flex min-h-screen flex-col items-center justify-center gap-16 p-24">
       <Uploader
         endpoint="withoutMdwr"
-        // needed when server side rendering
-        url="http://localhost:9898"
         onClientUploadComplete={(res) => {
           console.log(`onClientUploadComplete`, res);
           alert("Upload Completed");

--- a/examples/solid/src/routes/index.tsx
+++ b/examples/solid/src/routes/index.tsx
@@ -1,15 +1,13 @@
 import type { VoidComponent } from "solid-js";
 
-import { Uploader } from "@uploadthing/solid";
-
 import "@uploadthing/solid/styles.css";
 
-import type { OurFileRouter } from "~/server/uploadthing";
+import { Uploader } from "~/utils/uploadthing";
 
 const Home: VoidComponent = () => {
   return (
     <main class="flex min-h-screen flex-col items-center justify-center gap-16 p-24">
-      <Uploader<OurFileRouter>
+      <Uploader
         endpoint="withoutMdwr"
         // needed when server side rendering
         url="http://localhost:9898"

--- a/examples/solid/src/utils/uploadthing.ts
+++ b/examples/solid/src/utils/uploadthing.ts
@@ -1,0 +1,6 @@
+import { generateSolidComponents } from "@uploadthing/solid";
+
+import type { OurFileRouter } from "~/server/uploadthing";
+
+export const { UploadButton, UploadDropzone, Uploader } =
+  generateSolidComponents<OurFileRouter>();

--- a/examples/solid/src/utils/uploadthing.ts
+++ b/examples/solid/src/utils/uploadthing.ts
@@ -2,5 +2,7 @@ import { generateSolidComponents } from "@uploadthing/solid";
 
 import type { OurFileRouter } from "~/server/uploadthing";
 
+const url = "http://localhost:9898";
+
 export const { UploadButton, UploadDropzone, Uploader } =
-  generateSolidComponents<OurFileRouter>();
+  generateSolidComponents<OurFileRouter>(url);

--- a/examples/solid/src/utils/uploadthing.ts
+++ b/examples/solid/src/utils/uploadthing.ts
@@ -1,8 +1,8 @@
-import { generateSolidComponents } from "@uploadthing/solid";
+import { generateComponents } from "@uploadthing/solid";
 
 import type { OurFileRouter } from "~/server/uploadthing";
 
 const url = "http://localhost:9898";
 
 export const { UploadButton, UploadDropzone, Uploader } =
-  generateSolidComponents<OurFileRouter>(url);
+  generateComponents<OurFileRouter>(url);

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -2,3 +2,4 @@ import "./styles.css";
 
 export { UploadButton } from "./src/component";
 export { UploadDropzone } from "./src/component";
+export { generateComponents } from "./src/component";

--- a/packages/react/src/component.tsx
+++ b/packages/react/src/component.tsx
@@ -1,4 +1,3 @@
-import { get } from "http";
 import { useCallback, useRef, useState } from "react";
 import type { FileWithPath } from "react-dropzone";
 import { useDropzone } from "react-dropzone";
@@ -187,9 +186,7 @@ export const UploadDropzone = <
       onUploadError: props.onUploadError,
     });
 
-  const { fileTypes, multiple } = generatePermittedFileTypes(
-    permittedFileInfo?.config,
-  );
+  const { fileTypes } = generatePermittedFileTypes(permittedFileInfo?.config);
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
@@ -197,11 +194,6 @@ export const UploadDropzone = <
   });
 
   const ready = fileTypes.length > 0;
-
-  const getUploadButtonText = (fileTypes: string[]) => {
-    if (!(fileTypes.length > 0)) return "Loading...";
-    return `Choose File${multiple ? `(s)` : ``}`;
-  };
 
   return (
     <div
@@ -295,3 +287,21 @@ export const Uploader = <TRouter extends void | FileRouter = void>(props: {
     </>
   );
 };
+
+export function generateReactComponents<TRouter extends FileRouter>() {
+  return {
+    UploadButton: (
+      props: React.ComponentProps<typeof UploadButton<TRouter>>,
+    ) => {
+      return <UploadButton {...props} />;
+    },
+    UploadDropzone: (
+      props: React.ComponentProps<typeof UploadDropzone<TRouter>>,
+    ) => {
+      return <UploadDropzone {...props} />;
+    },
+    Uploader: (props: React.ComponentProps<typeof Uploader<TRouter>>) => {
+      return <Uploader {...props} />;
+    },
+  };
+}

--- a/packages/react/src/component.tsx
+++ b/packages/react/src/component.tsx
@@ -288,7 +288,7 @@ export const Uploader = <TRouter extends void | FileRouter = void>(props: {
   );
 };
 
-export function generateReactComponents<TRouter extends FileRouter>() {
+export function generateComponents<TRouter extends FileRouter>() {
   return {
     UploadButton: (
       props: React.ComponentProps<typeof UploadButton<TRouter>>,

--- a/packages/solid/src/component.tsx
+++ b/packages/solid/src/component.tsx
@@ -280,16 +280,18 @@ const Spinner = () => {
   );
 };
 
-export function generateSolidComponents<TRouter extends FileRouter>() {
+export function generateSolidComponents<TRouter extends FileRouter>(
+  url?: string,
+) {
   return {
     UploadButton: (props: ComponentProps<typeof UploadButton<TRouter>>) => {
-      return <UploadButton {...props} />;
+      return <UploadButton {...props} url={props.url ?? url} />;
     },
     UploadDropzone: (props: ComponentProps<typeof UploadDropzone<TRouter>>) => {
-      return <UploadDropzone {...props} />;
+      return <UploadDropzone {...props} url={props.url ?? url} />;
     },
     Uploader: (props: ComponentProps<typeof Uploader<TRouter>>) => {
-      return <Uploader {...props} />;
+      return <Uploader {...props} url={props.url ?? url} />;
     },
   };
 }

--- a/packages/solid/src/component.tsx
+++ b/packages/solid/src/component.tsx
@@ -280,9 +280,7 @@ const Spinner = () => {
   );
 };
 
-export function generateSolidComponents<TRouter extends FileRouter>(
-  url?: string,
-) {
+export function generateComponents<TRouter extends FileRouter>(url?: string) {
   return {
     UploadButton: (props: ComponentProps<typeof UploadButton<TRouter>>) => {
       return <UploadButton {...props} url={props.url ?? url} />;

--- a/packages/solid/src/component.tsx
+++ b/packages/solid/src/component.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react-hooks/rules-of-hooks */
+import type { ComponentProps } from "solid-js";
 import { createSignal } from "solid-js";
 import type { OnDropHandler } from "solidjs-dropzone";
 import { createDropzone } from "solidjs-dropzone";
@@ -274,7 +275,21 @@ const Spinner = () => {
       <path
         fill="currentColor"
         d="M256 32C256 14.33 270.3 0 288 0C429.4 0 544 114.6 544 256C544 302.6 531.5 346.4 509.7 384C500.9 399.3 481.3 404.6 465.1 395.7C450.7 386.9 445.5 367.3 454.3 351.1C470.6 323.8 480 291 480 255.1C480 149.1 394 63.1 288 63.1C270.3 63.1 256 49.67 256 31.1V32z"
-      ></path>
+      />
     </svg>
   );
 };
+
+export function generateSolidComponents<TRouter extends FileRouter>() {
+  return {
+    UploadButton: (props: ComponentProps<typeof UploadButton<TRouter>>) => {
+      return <UploadButton {...props} />;
+    },
+    UploadDropzone: (props: ComponentProps<typeof UploadDropzone<TRouter>>) => {
+      return <UploadDropzone {...props} />;
+    },
+    Uploader: (props: ComponentProps<typeof Uploader<TRouter>>) => {
+      return <Uploader {...props} />;
+    },
+  };
+}


### PR DESCRIPTION
Instead of having to pass the generic everytime, you can now create type safed  components using the `generateReactComponents` method.

```ts
import { generateComponents } from "@uploadthing/react";

import type { OurFileRouter } from "~/server/uploadthing";

export const { UploadButton, UploadDropzone, Uploader } =
  generateComponents<OurFileRouter>();
```

This can later be used like:

```tsx
  <UploadButton
          endpoint="withoutMdwr"
          onClientUploadComplete={(res) => {
            // Do something with the response
            console.log("Files: ", res);
            alert("Upload Completed");
          }}
          onUploadError={(error: Error) => {
            alert(`ERROR! ${error.message}`);
          }}
        />
```