### PR TITLE
docs: add github link

### DIFF
--- a/docs/src/theme.config.js
+++ b/docs/src/theme.config.js
@@ -116,6 +116,9 @@ const config = {
     defaultTheme: "light",
   },
   primaryHue: 348,
+  project: {
+    link: "https://github.com/pingdotgg/uploadthing",
+  },
   useNextSeoProps() {
     return {
       additionalLinkTags: [


### PR DESCRIPTION
Add a GitHub icon button in top right that links to this repo. Using Nextra theme config.

![Screenshot 2023-05-13 at 21 16 50](https://github.com/pingdotgg/uploadthing/assets/9057554/7d4f9dec-0dcd-48bb-b448-9a41c7677fc2)
