### PR TITLE
Export useUploadThing hook

### DIFF
--- a/packages/react/hooks.ts
+++ b/packages/react/hooks.ts
@@ -1,1 +1,1 @@
-export { generateReactHelpers } from "./src/useUploadThing";
+export { generateReactHelpers, useUploadThing } from "./src/useUploadThing";


### PR DESCRIPTION
To be able to create our "own" `UploadButton` or `UploadDropzone` component, the hook `useUploadThing` is needed.