### PR TITLE
[Fix] Update to buildRequestHandler secret

### DIFF
--- a/.changeset/swift-bottles-dream.md
+++ b/.changeset/swift-bottles-dream.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+[Fix] Update to buildRequestHandler secret

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -154,7 +154,14 @@ export const buildRequestHandler = <
     res?: TRuntime extends "pages" ? NextApiResponse : undefined;
   }) => {
     const { router, config } = opts;
-    const upSecret = config?.uploadthingId ?? process.env.UPLOADTHING_SECRET;
+    const preferredOrEnvSecret =
+      config?.uploadthingSecret ?? process.env.UPLOADTHING_SECRET;
+
+    if (!preferredOrEnvSecret) {
+      throw new Error(
+        "Please set your preferred secret in the router's config or set UPLOADTHING_SECRET in your env file"
+      );
+    }
 
     const { uploadthingHook, slug, req, res, actionType } = input;
     if (!slug) throw new Error("we need a slug");
@@ -212,7 +219,7 @@ export const buildRequestHandler = <
           }),
           headers: {
             "Content-Type": "application/json",
-            "x-uploadthing-api-key": upSecret ?? "",
+            "x-uploadthing-api-key": preferredOrEnvSecret,
             "x-uploadthing-version": UPLOADTHING_VERSION,
           },
         }

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -156,15 +156,16 @@ export const buildRequestHandler = <
     const { router, config } = opts;
     const preferredOrEnvSecret =
       config?.uploadthingSecret ?? process.env.UPLOADTHING_SECRET;
+    const { uploadthingHook, slug, req, res, actionType } = input;
+
+    if (!slug) throw new Error("we need a slug");
 
     if (!preferredOrEnvSecret) {
       throw new Error(
-        "Please set your preferred secret in the router's config or set UPLOADTHING_SECRET in your env file"
+        `Please set your preferred secret in ${slug} router's config or set UPLOADTHING_SECRET in your env file`
       );
     }
 
-    const { uploadthingHook, slug, req, res, actionType } = input;
-    if (!slug) throw new Error("we need a slug");
     const uploadable = router[slug];
 
     if (!uploadable) {


### PR DESCRIPTION
## Change Log
- Updated `buildRequestHandler` 
  - Now uses `config.uploadthingSecret` instead of `config.uploadthingId`
  - Throws an error if secret does not exist
  - Renamed `upSecret` to `preferredOrEnvSecret`