### PR TITLE
Removed @ts-expect-error for middleware in upload-builder.ts

### DIFF
--- a/packages/uploadthing/src/types.ts
+++ b/packages/uploadthing/src/types.ts
@@ -39,25 +39,26 @@ type ResolverOptions<TParams extends AnyParams> = {
   file: UploadedFile;
 };
 
-export type ReqMiddlewareFn<TOutput extends Record<string, unknown>> = (
-  req: Request
-) => MaybePromise<TOutput>;
-export type NextReqMiddlewareFn<TOutput extends Record<string, unknown>> = (
-  req: NextRequest
-) => MaybePromise<TOutput>;
-export type NextApiMiddlewareFn<TOutput extends Record<string, unknown>> = (
-  req: NextApiRequest,
-  res: NextApiResponse
-) => MaybePromise<TOutput>;
+export type ReqMiddlewareFn<TOutput extends Record<string, unknown>> =
+  MiddlewareFn<TOutput, "web">;
+export type NextReqMiddlewareFn<TOutput extends Record<string, unknown>> =
+  MiddlewareFn<TOutput, "app">;
+export type NextApiMiddlewareFn<TOutput extends Record<string, unknown>> =
+  MiddlewareFn<TOutput, "pages">;
+
+type Args<TRuntime> = TRuntime extends "web"
+  ? { req: Request; res: never }
+  : TRuntime extends "app"
+  ? { req: NextRequest; res: never }
+  : { req: NextApiRequest; res: NextApiResponse };
 
 type MiddlewareFn<
   TOutput extends Record<string, unknown>,
   TRuntime extends string
-> = TRuntime extends "web"
-  ? ReqMiddlewareFn<TOutput>
-  : TRuntime extends "app"
-  ? NextReqMiddlewareFn<TOutput>
-  : NextApiMiddlewareFn<TOutput>;
+> = (
+  req: Args<TRuntime>["req"],
+  res: Args<TRuntime>["res"]
+) => MaybePromise<TOutput>;
 
 type ResolverFn<TParams extends AnyParams> = (
   opts: ResolverOptions<TParams>

--- a/packages/uploadthing/src/types.ts
+++ b/packages/uploadthing/src/types.ts
@@ -39,14 +39,7 @@ type ResolverOptions<TParams extends AnyParams> = {
   file: UploadedFile;
 };
 
-export type ReqMiddlewareFn<TOutput extends Record<string, unknown>> =
-  MiddlewareFn<TOutput, "web">;
-export type NextReqMiddlewareFn<TOutput extends Record<string, unknown>> =
-  MiddlewareFn<TOutput, "app">;
-export type NextApiMiddlewareFn<TOutput extends Record<string, unknown>> =
-  MiddlewareFn<TOutput, "pages">;
-
-type Args<TRuntime> = TRuntime extends "web"
+type MiddlewareFnArgs<TRuntime> = TRuntime extends "web"
   ? { req: Request; res: never }
   : TRuntime extends "app"
   ? { req: NextRequest; res: never }
@@ -55,10 +48,19 @@ type Args<TRuntime> = TRuntime extends "web"
 type MiddlewareFn<
   TOutput extends Record<string, unknown>,
   TRuntime extends string
-> = (
-  req: Args<TRuntime>["req"],
-  res: Args<TRuntime>["res"]
-) => MaybePromise<TOutput>;
+> = MiddlewareFnArgs<TRuntime>["res"] extends never
+  ? (req: MiddlewareFnArgs<TRuntime>["req"]) => MaybePromise<TOutput>
+  : (
+      req: MiddlewareFnArgs<TRuntime>["req"],
+      res: MiddlewareFnArgs<TRuntime>["res"]
+    ) => MaybePromise<TOutput>;
+
+export type ReqMiddlewareFn<TOutput extends Record<string, unknown>> =
+  MiddlewareFn<TOutput, "web">;
+export type NextReqMiddlewareFn<TOutput extends Record<string, unknown>> =
+  MiddlewareFn<TOutput, "app">;
+export type NextApiMiddlewareFn<TOutput extends Record<string, unknown>> =
+  MiddlewareFn<TOutput, "pages">;
 
 type ResolverFn<TParams extends AnyParams> = (
   opts: ResolverOptions<TParams>

--- a/packages/uploadthing/src/upload-builder.test.ts
+++ b/packages/uploadthing/src/upload-builder.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-/* eslint-disable @typescript-eslint/ban-types */
+
 import type { NextApiRequest, NextApiResponse } from "next";
 import { genUploader } from "../client";
 import type { FileRouter } from "./types";
@@ -16,7 +16,7 @@ const badReqMock = {
   },
 } as unknown as Request;
 
-it("typeerrors for invalid input", async () => {
+it("typeerrors for invalid input", () => {
   const f = createBuilder();
 
   // @ts-expect-error - invalid file type
@@ -26,12 +26,12 @@ it("typeerrors for invalid input", async () => {
   f.maxSize("1gb");
 
   // @ts-expect-error - should return an object
-  f.middleware(async () => {
+  f.middleware(() => {
     return null;
   });
 
   // @ts-expect-error - res does not exist (`pages` flag not set)
-  f.middleware(async (req, res) => {
+  f.middleware((req, res) => {
     return {};
   });
 
@@ -56,29 +56,42 @@ it("uses defaults for not-chained", async () => {
   expectTypeOf(metadata).toMatchTypeOf<{}>();
 });
 
-it("passes `Request` by default", async () => {
+it("passes `Request` by default", () => {
   const f = createBuilder();
 
-  f.middleware(async (req) => {
+  f.middleware((req) => {
     expectTypeOf(req).toMatchTypeOf<Request>();
 
     return {};
   });
 });
 
-it("passes `NextRequest` for /app", async () => {
+it("allows async middleware", () => {
+  const f = createBuilder();
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  f.middleware(async (req) => {
+    expectTypeOf(req).toMatchTypeOf<Request>();
+
+    return { foo: "bar" } as const;
+  }).onUploadComplete((opts) => {
+    expectTypeOf(opts.metadata).toMatchTypeOf<{ foo: "bar" }>();
+  });
+});
+
+it("passes `NextRequest` for /app", () => {
   const f = createBuilder<"app">();
 
-  f.middleware(async (req) => {
+  f.middleware((req) => {
     expectTypeOf(req).toMatchTypeOf<NextRequest>();
     return { nextUrl: req.nextUrl };
   });
 });
 
-it("passes `res` for /pages", async () => {
+it("passes `res` for /pages", () => {
   const f = createBuilder<"pages">();
 
-  f.middleware(async (req, res) => {
+  f.middleware((req, res) => {
     expectTypeOf(req).toMatchTypeOf<NextApiRequest>();
     expectTypeOf(res).toMatchTypeOf<NextApiResponse>();
 
@@ -92,7 +105,7 @@ it("smoke", async () => {
   const uploadable = f
     .fileTypes(["image", "video"])
     .maxSize("1GB")
-    .middleware(async (req) => {
+    .middleware((req) => {
       const header1 = req.headers.get("header1");
 
       return { header1, userId: "123" as const };

--- a/packages/uploadthing/src/upload-builder.ts
+++ b/packages/uploadthing/src/upload-builder.ts
@@ -15,7 +15,6 @@ export function createBuilder<TRuntime extends AnyRuntime = "web">(
   const _def: UploadBuilderDef<TRuntime> = {
     fileTypes: ["image"],
     maxSize: "1MB",
-    // @ts-expect-error - huh?
     middleware: () => ({}),
     ...initDef,
   };


### PR DESCRIPTION
Use a single function instead of interpreting from multiple signatures and use arguments from the `Args` type so it's still customizable.

It's also possible to use the code below, but it would give an error to the user if they wrote this `.middleware((req) => {...})` so they would need to write `.middleware((req, _res) => {...})` if they didn't need the response when using `next-legacy`.

```typescript
type MiddlewareFn<
  TOutput extends Record<string, unknown>,
  TRuntime extends string
> = Args<TRuntime>["res"] extends never
  ? (req: Args<TRuntime>["req"]) => MaybePromise<TOutput>
  : (
      req: Args<TRuntime>["req"],
      res: Args<TRuntime>["res"]
    ) => MaybePromise<TOutput>;
```

But the one plus would be it doesn't allow the `.middleware((req, _res) => {...})` when using `next` or `server`, while in the one committed `_res` is of type `never` so it's not really usable.