### PR TITLE
fix: changeset bumping to major

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,6 +9,9 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  },
   "ignore": [
     "@example/appdir",
     "@example/pagedir",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "react": "^17.0.2 || ^18.0.0",
     "react-dropzone": "^14.2.3",
-    "uploadthing": "4.0.0"
+    "uploadthing": "^4.0.0"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.3",


### PR DESCRIPTION
Fixes the issue where changeset bumps peer dependents to major version when the package it depends on is leaving the range:

Before:

<img width="869" alt="CleanShot 2023-05-31 at 09 11 22@2x" src="https://github.com/pingdotgg/uploadthing/assets/51714798/700b75f5-1594-4472-9784-266d26849844">

After:

<img width="876" alt="CleanShot 2023-05-31 at 09 11 29@2x" src="https://github.com/pingdotgg/uploadthing/assets/51714798/9f633fe8-bcfe-4372-b341-a356c459db66">

