### PR TITLE
[docs] added missing type import in next.js page dir server snippet

### DIFF
--- a/docs/src/pages/nextjs/pagedir.mdx
+++ b/docs/src/pages/nextjs/pagedir.mdx
@@ -33,6 +33,7 @@ All files uploaded to uploadthing are associated with a FileRoute. Think of a Fi
 
 ```ts copy
 /** server/uploadthing.ts */
+import type { NextApiRequest, NextApiResponse } from 'next';
 import { createUploadthing, type FileRouter } from "uploadthing/next-legacy";
 
 const f = createUploadthing();


### PR DESCRIPTION
The server code snippet for the Next.js page dir docs is missing type imports