### PR TITLE
[fix] clear files on onClientUploadComplete in UploadDropzone

### DIFF
--- a/packages/react/src/component.tsx
+++ b/packages/react/src/component.tsx
@@ -145,7 +145,10 @@ export const UploadDropzone = <
   const { startUpload, isUploading, permittedFileInfo } =
     useUploadThing<string>({
       endpoint: props.endpoint as string,
-      onClientUploadComplete: props.onClientUploadComplete,
+      onClientUploadComplete: () => {
+        if (props.onClientUploadComplete) props.onClientUploadComplete();
+        setFiles([]);
+      },
       onUploadError: props.onUploadError,
     });
 


### PR DESCRIPTION
After a successful upload using the dropzone it doesn't clear the files and the upload button is still showing. 