### PR TITLE
fix(react-UploadDropzone): clear files onClientUploadComplete

### DIFF
--- a/.changeset/few-snakes-itch.md
+++ b/.changeset/few-snakes-itch.md
@@ -1,0 +1,5 @@
+---
+"@uploadthing/react": patch
+---
+
+fix(react-UploadDropzone): clear files onClientUploadComplete for dropzone and upload button

--- a/packages/react/src/component.tsx
+++ b/packages/react/src/component.tsx
@@ -145,7 +145,12 @@ export const UploadDropzone = <
   const { startUpload, isUploading, permittedFileInfo } =
     useUploadThing<string>({
       endpoint: props.endpoint as string,
-      onClientUploadComplete: props.onClientUploadComplete,
+      onClientUploadComplete: (res) => {
+        setFiles([]);
+        if (props.onClientUploadComplete) {
+          props.onClientUploadComplete(res);
+        }
+      },
       onUploadError: props.onUploadError,
     });
 


### PR DESCRIPTION
# Pull Request

## Linked GH Issues

Fixes #140

## Summary of Change

Clears `files` state onUploadComplete for react-dropzone
