### PR TITLE
Fix nonexistent location in docs

### DIFF
--- a/docs/src/pages/nextjs/appdir.mdx
+++ b/docs/src/pages/nextjs/appdir.mdx
@@ -77,7 +77,7 @@ individually from `@uploadthing/react`.
 ```ts copy filename="src/utils/uploadthing.ts"
 import { generateComponents } from "@uploadthing/react";
 
-import type { OurFileRouter } from "~/server/uploadthing";
+import type { OurFileRouter } from "~/app/api/uploadthing/core";
 
 export const { UploadButton, UploadDropzone, Uploader } =
   generateComponents<OurFileRouter>();


### PR DESCRIPTION
[According to /app dir docs ](https://docs.uploadthing.com/nextjs/appdir#creating-your-first-fileroute) we should create the router and export the type at app/api/uploadthing/core.ts.
[Later, it mentions that the type should be imported from server/uploadthing.ts](https://docs.uploadthing.com/nextjs/appdir#creating-the-uploadthing-components-optional)