### PR TITLE
Removed base layer from stylesheet and added missing `ut-` prefix

### DIFF
--- a/packages/react/src/component.tsx
+++ b/packages/react/src/component.tsx
@@ -157,7 +157,7 @@ export function UploadButton<TRouter extends FileRouter>(
       </label>
       <div className="ut-h-[1.25rem]">
         {fileTypes && (
-          <p className="ut-text-xs ut-leading-5 ut-text-gray-600">
+          <p className="ut-m-0 ut-text-xs ut-leading-5 ut-text-gray-600">
             {allowedContentTextLabelGenerator(permittedFileInfo?.config)}
           </p>
         )}
@@ -210,7 +210,7 @@ export function UploadDropzone<TRouter extends FileRouter>(
         isDragActive ? "ut-bg-blue-600/10" : "",
       )}
     >
-      <div className="text-center" {...getRootProps()}>
+      <div className="ut-text-center" {...getRootProps()}>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
@@ -242,7 +242,7 @@ export function UploadDropzone<TRouter extends FileRouter>(
           </label>
         </div>
         <div className="ut-h-[1.25rem]">
-          <p className="ut-text-xs ut-leading-5 ut-text-gray-600">
+          <p className="ut-m-0 ut-text-xs ut-leading-5 ut-text-gray-600">
             {allowedContentTextLabelGenerator(permittedFileInfo?.config)}
           </p>
         </div>
@@ -281,15 +281,15 @@ export function Uploader<TRouter extends FileRouter>(
 ) {
   return (
     <>
-      <div className="flex flex-col items-center justify-center gap-4">
-        <span className="text-center text-4xl font-bold">
+      <div className="ut-flex ut-flex-col ut-items-center ut-justify-center ut-gap-4">
+        <span className="ut-text-center ut-text-4xl ut-font-bold">
           {`Upload a file using a button:`}
         </span>
         {/* @ts-expect-error - this is validated above */}
         <UploadButton<TRouter> {...props} />
       </div>
-      <div className="flex flex-col items-center justify-center gap-4">
-        <span className="text-center text-4xl font-bold">
+      <div className="ut-flex ut-flex-col ut-items-center ut-justify-center ut-gap-4">
+        <span className="ut-text-center ut-text-4xl ut-font-bold">
           {`...or using a dropzone:`}
         </span>
         {/* @ts-expect-error - this is validated above */}

--- a/packages/react/styles.css
+++ b/packages/react/styles.css
@@ -1,3 +1,2 @@
-@tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/packages/solid/src/component.tsx
+++ b/packages/solid/src/component.tsx
@@ -135,7 +135,7 @@ export function UploadButton<TRouter extends FileRouter>(
       </label>
       <div class="ut-h-[1.25rem]">
         {fileInfo().fileTypes ? (
-          <p class="ut-text-xs ut-leading-5 ut-text-gray-600">
+          <p class="ut-m-0 ut-text-xs ut-leading-5 ut-text-gray-600">
             {allowedContentTextLabelGenerator(
               uploadedThing.permittedFileInfo()?.config,
             )}
@@ -185,7 +185,7 @@ export const UploadDropzone = <TRouter extends FileRouter>(
         isDragActive ? "ut-bg-blue-600/10" : "",
       )}
     >
-      <div class="text-center" {...getRootProps()}>
+      <div class="ut-text-center" {...getRootProps()}>
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
@@ -209,7 +209,7 @@ export const UploadDropzone = <TRouter extends FileRouter>(
           <p class="ut-pl-1">{`or drag and drop`}</p>
         </div>
         <div class="ut-h-[1.25rem]">
-          <p class="ut-text-xs ut-leading-5 ut-text-gray-600">
+          <p class="ut-m-0 ut-text-xs ut-leading-5 ut-text-gray-600">
             {allowedContentTextLabelGenerator(
               uploadedThing.permittedFileInfo()?.config,
             )}
@@ -260,15 +260,15 @@ export const Uploader = <TRouter extends FileRouter>(
     });
   return (
     <>
-      <div class="flex flex-col items-center justify-center gap-4">
-        <span class="text-center text-4xl font-bold">
+      <div class="ut-flex ut-flex-col ut-items-center ut-justify-center ut-gap-4">
+        <span class="ut-text-center ut-text-4xl ut-font-bold">
           {`Upload a file using a button:`}
         </span>
         {/* @ts-expect-error - we know this is valid from the check above */}
         <UploadButton<TRouter> {...$props} uploadedThing={uploadedThing} />
       </div>
-      <div class="flex flex-col items-center justify-center gap-4">
-        <span class="text-center text-4xl font-bold">
+      <div class="ut-flex ut-flex-col ut-items-center ut-justify-center ut-gap-4">
+        <span class="ut-text-center ut-text-4xl ut-font-bold">
           {`...or using a dropzone:`}
         </span>
         {/* @ts-expect-error - we know this is valid from the check above */}

--- a/packages/solid/styles.css
+++ b/packages/solid/styles.css
@@ -1,3 +1,2 @@
-@tailwind base;
 @tailwind components;
 @tailwind utilities;


### PR DESCRIPTION
- It emits global level styles that may affect whole application. It may create conflicts with app's styling (like it does with shadcn/ui #87 )
- Noticed that some internal classes were not using ut prefix
- Applied additional class to `p` tags in components to remove default margins to preserve default styling of components