### PR TITLE
bug: `useUploadThing` can not be used with `declaration: true`

### DIFF
--- a/examples/appdir/src/utils/uploadthing.ts
+++ b/examples/appdir/src/utils/uploadthing.ts
@@ -1,6 +1,12 @@
 import { generateComponents } from "@uploadthing/react";
+import { generateReactHelpers } from "@uploadthing/react/hooks";
 
 import type { OurFileRouter } from "~/server/uploadthing";
 
 export const { UploadButton, UploadDropzone, Uploader } =
   generateComponents<OurFileRouter>();
+
+// UploadFiles works
+export const { uploadFiles } = generateReactHelpers<OurFileRouter>();
+// useUploadThing doesn't work
+export const { useUploadThing } = generateReactHelpers<OurFileRouter>();

--- a/packages/react/src/useUploadThing.ts
+++ b/packages/react/src/useUploadThing.ts
@@ -9,7 +9,9 @@ import useFetch from "./utils/useFetch";
 
 type EndpointMetadata = {
   slug: string;
-  config: ExpandedRouteConfig;
+  // Not using the ExpandedRouteConfig type "fixes" the declaration issue, but we don't want to do that
+  // config: ExpandedRouteConfig;
+  config: any;
 }[];
 
 const useEndpointMetadata = (endpoint: string) => {


### PR DESCRIPTION
We get the beloved TS2742 error on the `useUploadThing` hook:

![image](https://github.com/pingdotgg/uploadthing/assets/51714798/e7712280-e504-4931-abb0-d563b0ce43c3)

I dug in a bit and concluded it's the `ExpandedRouteConfig` type that it doesn't like to resolve properly. Tried to fix it but couldn't. :/

Help wanted ❤️ 
