### PR TITLE
docs: destructure `req` in middleware

### DIFF
--- a/docs/src/pages/solid.mdx
+++ b/docs/src/pages/solid.mdx
@@ -88,7 +88,7 @@ export const uploadRouter = {
       maxFileSize: "1MB",
     },
   })
-    .middleware((req) => {
+    .middleware(({ req }) => {
       const h = req.headers.get("someProperty");
 
       if (!h) throw new Error("someProperty is required");

--- a/docs/src/pages/solid.mdx
+++ b/docs/src/pages/solid.mdx
@@ -88,8 +88,8 @@ export const uploadRouter = {
       maxFileSize: "1MB",
     },
   })
-    .middleware(({ req }) => {
-      const h = req.headers.get("someProperty");
+    .middleware((opts) => {
+      const h = opts.req.headers.get("someProperty");
 
       if (!h) throw new Error("someProperty is required");
 


### PR DESCRIPTION
Not super familiar with SolidStart but as-is this gives a type error.