### PR TITLE
fix(changeset): add changeset for react and solid packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,12 @@
     { "repo": "pingdotgg/uploadthing" }
   ],
   "commit": false,
-  "fixed": [["uploadthing", "@uploadthing/react", "@uploadthing/solid"]],
+  "fixed": [[
+    "uploadthing", 
+    "@uploadthing/react",
+    "@uploadthing/solid",
+    "@uploadthing/shared"
+  ]],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,12 +5,6 @@
     { "repo": "pingdotgg/uploadthing" }
   ],
   "commit": false,
-  "fixed": [[
-    "uploadthing", 
-    "@uploadthing/react",
-    "@uploadthing/solid",
-    "@uploadthing/shared"
-  ]],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",

--- a/.changeset/metal-parents-bow.md
+++ b/.changeset/metal-parents-bow.md
@@ -1,0 +1,7 @@
+---
+"@uploadthing/react": patch
+"@uploadthing/solid": patch
+"uploadthing": patch
+---
+
+chore(deps): update dependency '@uploadthing/shared'


### PR DESCRIPTION
should fix the failing workflow

will force a release of the react and solid pacakges needed in order to fix the declaration bug that the current changeset indicates

![CleanShot 2023-06-29 at 22 24 18](https://github.com/pingdotgg/uploadthing/assets/51714798/fa2f94c8-f143-4a09-b03f-f6312504b9f3)

alternatively we can change the current changeset to manually bump these packages if we don't want them to always be locked to one another