### PR TITLE
fix(shared): Swap order of cases in getUploadthingUrl()

### DIFF
--- a/.changeset/quick-carpets-refuse.md
+++ b/.changeset/quick-carpets-refuse.md
@@ -1,0 +1,8 @@
+---
+"@uploadthing/shared": patch
+"@uploadthing/react": patch
+"@uploadthing/solid": patch
+"uploadthing": patch
+---
+
+fix(shared): Swap order of cases in `getUploadthingUrl()`

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -161,19 +161,22 @@ export async function pollForFileData(
 
 export function getUploadthingUrl() {
   /**
-   * Use VERCEL_URL as the default callbackUrl if it's set
-   * they don't set the protocol, so we need to add it
-   * User can override this with the UPLOADTHING_URL env var,
-   * if they do, they should include the protocol
-   *
    * The pathname must be /api/uploadthing
    * since we call that via webhook, so the user
    * should not override that. Just the protocol and host
+   *
+   * User can override the callback url with the UPLOADTHING_URL env var,
+   * if they do, they should include the protocol
+   */
+  const uturl = process.env.UPLOADTHING_URL;
+  if (uturl) return `${uturl}/api/uploadthing`;
+
+  /**
+   * If the VERCEL_URL is set, we will fall back to that next.
+   * They don't set the protocol, however, so we need to add it
    */
   const vcurl = process.env.VERCEL_URL;
   if (vcurl) return `https://${vcurl}/api/uploadthing`; // SSR should use vercel url
-  const uturl = process.env.UPLOADTHING_URL;
-  if (uturl) return `${uturl}/api/uploadthing`;
 
   return `http://localhost:${process.env.PORT ?? 3000}/api/uploadthing`; // dev SSR should use localhost
 }


### PR DESCRIPTION
We should default to the `UPLOADTHING_URL` if it is set, always.
