### PR TITLE
fix: improper MIME type mapping of precise MIME types

### DIFF
--- a/.changeset/curvy-crabs-teach.md
+++ b/.changeset/curvy-crabs-teach.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+fix(uploadthing): fixed incorrect mapping of precise MIME types

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -110,8 +110,9 @@ export const DANGEROUS__uploadFiles = async <TRouter extends FileRouter>(
       throw new UploadThingError({
         code: "NOT_FOUND",
         message: "No file found for presigned URL",
-        cause: `Expected file with name ${presigned.name
-          } but got '${opts.files.join(",")}'`,
+        cause: `Expected file with name ${
+          presigned.name
+        } but got '${opts.files.join(",")}'`,
       });
     }
     const { url, fields } = presigned.presignedUrl;

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -110,9 +110,8 @@ export const DANGEROUS__uploadFiles = async <TRouter extends FileRouter>(
       throw new UploadThingError({
         code: "NOT_FOUND",
         message: "No file found for presigned URL",
-        cause: `Expected file with name ${
-          presigned.name
-        } but got '${opts.files.join(",")}'`,
+        cause: `Expected file with name ${presigned.name
+          } but got '${opts.files.join(",")}'`,
       });
     }
     const { url, fields } = presigned.presignedUrl;
@@ -197,6 +196,7 @@ export const generateMimeTypes = (fileTypes: string[]) => {
   const accepted = fileTypes.map((type) => {
     if (type === "blob") return "blob";
     if (type === "pdf") return "application/pdf";
+    if (type.includes("/")) return type;
     else return `${type}/*`;
   });
 


### PR DESCRIPTION
Closes #212

The issue is that `generateMimeTypes` function always append `*` to the type
![image](https://github.com/pingdotgg/uploadthing/assets/55754540/880a822b-bcd9-456d-8aae-7190b9835239)

It leads to error when using, for instance, `audio/mpeg` being turned into `audio/mpeg/*` which is invalid mime type

I added check for `/` in original type to differentiate precise MIME types from generic ones like `video`, `image`, `audio` 