### PR TITLE
fix: wrap execution of middleware in try-catch

### DIFF
--- a/.changeset/spicy-candles-agree.md
+++ b/.changeset/spicy-candles-agree.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+fix: errors thrown in middleware causes entire request to throw

--- a/docs/src/pages/_meta.json
+++ b/docs/src/pages/_meta.json
@@ -8,6 +8,7 @@
     "theme": { "toc": false }
   },
   "api-reference": "API Reference",
+  "errors": "Error Handling",
 
   "roadmap": {
     "title": "Roadmap",

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -253,7 +253,6 @@ export const buildRequestHandler = <
           input: parsedInput,
         });
       } catch (error) {
-        console.error(error);
         return new UploadThingError({
           code: "BAD_REQUEST",
           message: "An error occured in the upload middleware",

--- a/packages/uploadthing/src/internal/next/approuter.ts
+++ b/packages/uploadthing/src/internal/next/approuter.ts
@@ -21,7 +21,6 @@ export const createNextRouteHandler = <TRouter extends FileRouter>(
       const formattedError = errorFormatter(
         response,
       ) as inferErrorShape<TRouter>;
-      console.log("formattedError", formattedError);
       return new Response(JSON.stringify(formattedError), {
         status: getStatusCodeFromError(response),
         headers: {


### PR DESCRIPTION
Regression of the `errorFormatter`. The middleware function can throw and will cause the entire API function to throw since we're now relying on the `requestHandler` to return the error instead of throwing it. I wish there was a way for TypeScript to know if your function can throw or not and show it on the type level :/

Closes #218