### PR TITLE
fix: `uploadFiles` wrong runtime return type

### DIFF
--- a/.changeset/little-dogs-exercise.md
+++ b/.changeset/little-dogs-exercise.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+fix: runtime return type of `utapi.uploadFiles`

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -1,5 +1,5 @@
 import type { Json } from "@uploadthing/shared";
-import { UploadThingError, generateUploadThingURL } from "@uploadthing/shared";
+import { generateUploadThingURL, UploadThingError } from "@uploadthing/shared";
 
 import { UPLOADTHING_VERSION } from "../constants";
 import type { FileEsque } from "./utils";
@@ -10,7 +10,7 @@ function guardServerOnly() {
     throw new UploadThingError({
       code: "INTERNAL_SERVER_ERROR",
       message: "The `utapi` can only be used on the server.",
-    })
+    });
   }
 }
 
@@ -19,13 +19,29 @@ function getApiKeyOrThrow() {
     throw new UploadThingError({
       code: "MISSING_ENV",
       message: "Missing `UPLOADTHING_SECRET` env variable.",
-    })
+    });
   }
   return process.env.UPLOADTHING_SECRET;
 }
 
-// File is just a Blob with a name property
-type UploadFileResponse = Awaited<ReturnType<typeof uploadFilesInternal>>[0];
+export type SuccessUpload = {
+  data: {
+    key: string;
+    url: string;
+  };
+  error: null;
+};
+
+export type SerializedUploadthingError<T extends Json = any> = {
+  code: string;
+  message: string;
+  data: T;
+};
+
+export type FailedUpload = {
+  data: null;
+  error: SerializedUploadthingError;
+};
 
 /**
  * @param {FileEsque | FileEsque[]} files The file(s) to upload
@@ -43,9 +59,7 @@ type UploadFileResponse = Awaited<ReturnType<typeof uploadFilesInternal>>[0];
 export const uploadFiles = async <T extends FileEsque | FileEsque[]>(
   files: T,
   metadata: Json = {},
-): Promise<
-  T extends FileEsque[] ? UploadFileResponse[] : UploadFileResponse
-> => {
+) => {
   guardServerOnly();
 
   const filesToUpload: FileEsque[] = Array.isArray(files) ? files : [files];
@@ -61,8 +75,9 @@ export const uploadFiles = async <T extends FileEsque | FileEsque[]>(
     },
   );
 
-  // @ts-expect-error - ehh? type is tested in sdk.test.ts
-  return uploads;
+  return uploads as T extends FileEsque[]
+    ? (SuccessUpload | FailedUpload)[]
+    : SuccessUpload | FailedUpload;
 };
 
 /**
@@ -82,7 +97,7 @@ type Url = string | URL;
 export const uploadFilesFromUrl = async <T extends Url | Url[]>(
   urls: T,
   metadata: Json = {},
-): Promise<T extends Url[] ? UploadFileResponse[] : UploadFileResponse> => {
+) => {
   guardServerOnly();
 
   const fileUrls: Url[] = Array.isArray(urls) ? urls : [urls];
@@ -102,7 +117,7 @@ export const uploadFilesFromUrl = async <T extends Url | Url[]>(
           code: "BAD_REQUEST",
           message: "Failed to download requested file.",
           cause: fileResponse,
-        })
+        });
       }
       const blob = await fileResponse.blob();
       return Object.assign(blob, { name: filename });
@@ -120,8 +135,9 @@ export const uploadFilesFromUrl = async <T extends Url | Url[]>(
     },
   );
 
-  // @ts-expect-error - ehh? type is tested in sdk.test.ts
-  return Array.isArray(urls) ? uploads : uploads[0];
+  return uploads as T extends Url[]
+    ? (SuccessUpload | FailedUpload)[]
+    : SuccessUpload | FailedUpload;
 };
 
 /**

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -24,7 +24,7 @@ function getApiKeyOrThrow() {
   return process.env.UPLOADTHING_SECRET;
 }
 
-type SuccessUpload = {
+type UploadSucess = {
   data: {
     key: string;
     url: string;
@@ -32,7 +32,7 @@ type SuccessUpload = {
   error: null;
 };
 
-type FailedUpload = {
+type UploadFailed = {
   data: null;
   error: {
     code: string;
@@ -41,7 +41,7 @@ type FailedUpload = {
   };
 };
 
-type UploadFileResponse = SuccessUpload | FailedUpload;
+type UploadFileResponse = UploadSucess | UploadFailed;
 
 /**
  * @param {FileEsque | FileEsque[]} files The file(s) to upload

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -44,9 +44,7 @@ type UploadFileResponse =
 export const uploadFiles = async <T extends FileEsque | FileEsque[]>(
   files: T,
   metadata: Json = {},
-): Promise<
-  T extends FileEsque[] ? UploadFileResponse[] : UploadFileResponse
-> => {
+) => {
   guardServerOnly();
 
   const filesToUpload: FileEsque[] = Array.isArray(files) ? files : [files];
@@ -62,8 +60,11 @@ export const uploadFiles = async <T extends FileEsque | FileEsque[]>(
     },
   );
 
-  // @ts-expect-error - Array.isArray doesn't typeguard
-  return Array.isArray(files) ? uploads : uploads[0];
+  const uploadFileResponse = Array.isArray(files) ? uploads : uploads[0];
+
+  return uploadFileResponse as T extends FileEsque[]
+    ? UploadFileResponse[]
+    : UploadFileResponse;
 };
 
 /**
@@ -83,7 +84,7 @@ type Url = string | URL;
 export const uploadFilesFromUrl = async <T extends Url | Url[]>(
   urls: T,
   metadata: Json = {},
-): Promise<T extends Url[] ? UploadFileResponse[] : UploadFileResponse> => {
+) => {
   guardServerOnly();
 
   const fileUrls: Url[] = Array.isArray(urls) ? urls : [urls];
@@ -121,8 +122,11 @@ export const uploadFilesFromUrl = async <T extends Url | Url[]>(
     },
   );
 
-  // @ts-expect-error - Array.isArray doesn't typeguard
-  return Array.isArray(urls) ? uploads : uploads[0];
+  const uploadFileResponse = Array.isArray(urls) ? uploads : uploads[0];
+
+  return uploadFileResponse as T extends Url[]
+    ? UploadFileResponse[]
+    : UploadFileResponse;
 };
 
 /**

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -24,7 +24,7 @@ function getApiKeyOrThrow() {
   return process.env.UPLOADTHING_SECRET;
 }
 
-export type SuccessUpload = {
+type SuccessUpload = {
   data: {
     key: string;
     url: string;
@@ -38,10 +38,12 @@ export type SerializedUploadthingError<T extends Json = any> = {
   data: T;
 };
 
-export type FailedUpload = {
+type FailedUpload = {
   data: null;
   error: SerializedUploadthingError;
 };
+
+type UploadFileResponse = SuccessUpload | FailedUpload;
 
 /**
  * @param {FileEsque | FileEsque[]} files The file(s) to upload
@@ -60,9 +62,7 @@ export const uploadFiles = async <T extends FileEsque | FileEsque[]>(
   files: T,
   metadata: Json = {},
 ): Promise<
-  T extends FileEsque[]
-    ? (SuccessUpload | FailedUpload)[]
-    : SuccessUpload | FailedUpload
+  T extends FileEsque[] ? UploadFileResponse[] : UploadFileResponse
 > => {
   guardServerOnly();
 
@@ -100,11 +100,7 @@ type Url = string | URL;
 export const uploadFilesFromUrl = async <T extends Url | Url[]>(
   urls: T,
   metadata: Json = {},
-): Promise<
-  T extends Url[]
-    ? (SuccessUpload | FailedUpload)[]
-    : SuccessUpload | FailedUpload
-> => {
+): Promise<T extends Url[] ? UploadFileResponse[] : UploadFileResponse> => {
   guardServerOnly();
 
   const fileUrls: Url[] = Array.isArray(urls) ? urls : [urls];

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -2,7 +2,7 @@ import type { Json } from "@uploadthing/shared";
 import { generateUploadThingURL, UploadThingError } from "@uploadthing/shared";
 
 import { UPLOADTHING_VERSION } from "../constants";
-import type { FileEsque } from "./utils";
+import type { FileEsque, UploadData, UploadError } from "./utils";
 import { uploadFilesInternal } from "./utils";
 
 function guardServerOnly() {
@@ -24,24 +24,9 @@ function getApiKeyOrThrow() {
   return process.env.UPLOADTHING_SECRET;
 }
 
-type UploadSucess = {
-  data: {
-    key: string;
-    url: string;
-  };
-  error: null;
-};
-
-type UploadFailed = {
-  data: null;
-  error: {
-    code: string;
-    message: string;
-    data: any;
-  };
-};
-
-type UploadFileResponse = UploadSucess | UploadFailed;
+type UploadFileResponse =
+  | { data: UploadData; error: null }
+  | { data: null; error: UploadError };
 
 /**
  * @param {FileEsque | FileEsque[]} files The file(s) to upload

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -59,7 +59,11 @@ export type FailedUpload = {
 export const uploadFiles = async <T extends FileEsque | FileEsque[]>(
   files: T,
   metadata: Json = {},
-) => {
+): Promise<
+  T extends FileEsque[]
+    ? (SuccessUpload | FailedUpload)[]
+    : SuccessUpload | FailedUpload
+> => {
   guardServerOnly();
 
   const filesToUpload: FileEsque[] = Array.isArray(files) ? files : [files];
@@ -75,9 +79,8 @@ export const uploadFiles = async <T extends FileEsque | FileEsque[]>(
     },
   );
 
-  return uploads as T extends FileEsque[]
-    ? (SuccessUpload | FailedUpload)[]
-    : SuccessUpload | FailedUpload;
+  // @ts-expect-error - Array.isArray doesn't typeguard
+  return Array.isArray(files) ? uploads : uploads[0];
 };
 
 /**
@@ -97,7 +100,11 @@ type Url = string | URL;
 export const uploadFilesFromUrl = async <T extends Url | Url[]>(
   urls: T,
   metadata: Json = {},
-) => {
+): Promise<
+  T extends Url[]
+    ? (SuccessUpload | FailedUpload)[]
+    : SuccessUpload | FailedUpload
+> => {
   guardServerOnly();
 
   const fileUrls: Url[] = Array.isArray(urls) ? urls : [urls];
@@ -135,9 +142,8 @@ export const uploadFilesFromUrl = async <T extends Url | Url[]>(
     },
   );
 
-  return uploads as T extends Url[]
-    ? (SuccessUpload | FailedUpload)[]
-    : SuccessUpload | FailedUpload;
+  // @ts-expect-error - Array.isArray doesn't typeguard
+  return Array.isArray(urls) ? uploads : uploads[0];
 };
 
 /**

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -32,15 +32,13 @@ type SuccessUpload = {
   error: null;
 };
 
-export type SerializedUploadthingError<T extends Json = any> = {
-  code: string;
-  message: string;
-  data: T;
-};
-
 type FailedUpload = {
   data: null;
-  error: SerializedUploadthingError;
+  error: {
+    code: string;
+    message: string;
+    data: any;
+  };
 };
 
 type UploadFileResponse = SuccessUpload | FailedUpload;

--- a/packages/uploadthing/src/sdk/sdk.test.ts
+++ b/packages/uploadthing/src/sdk/sdk.test.ts
@@ -1,12 +1,8 @@
 import { describe, expectTypeOf, test } from "vitest";
 
 import * as utapi from ".";
+import type { UploadError } from "./utils";
 
-type SerializedUploadthingError = {
-  code: string;
-  message: string;
-  data: any;
-};
 
 async function ignoreErrors<T>(fn: () => T | Promise<T>) {
   try {
@@ -23,7 +19,7 @@ describe("uploadFiles", () => {
       expectTypeOf<
         (
           | { data: { key: string; url: string }; error: null }
-          | { data: null; error: SerializedUploadthingError }
+          | { data: null; error: UploadError }
         )[]
       >(result);
     });
@@ -34,7 +30,7 @@ describe("uploadFiles", () => {
       const result = await utapi.uploadFiles({} as File);
       expectTypeOf<
         | { data: { key: string; url: string }; error: null }
-        | { data: null; error: SerializedUploadthingError }
+        | { data: null; error: UploadError }
       >(result);
     });
   });
@@ -47,7 +43,7 @@ describe("uploadFilesFromUrl", () => {
       expectTypeOf<
         (
           | { data: { key: string; url: string }; error: null }
-          | { data: null; error: SerializedUploadthingError }
+          | { data: null; error: UploadError }
         )[]
       >(result);
     });
@@ -58,7 +54,7 @@ describe("uploadFilesFromUrl", () => {
       const result = await utapi.uploadFilesFromUrl("foo");
       expectTypeOf<
         | { data: { key: string; url: string }; error: null }
-        | { data: null; error: SerializedUploadthingError }
+        | { data: null; error: UploadError }
       >(result);
     });
   });

--- a/packages/uploadthing/src/sdk/sdk.test.ts
+++ b/packages/uploadthing/src/sdk/sdk.test.ts
@@ -1,7 +1,12 @@
 import { describe, expectTypeOf, test } from "vitest";
 
-import type { SerializedUploadthingError } from ".";
 import * as utapi from ".";
+
+type SerializedUploadthingError = {
+  code: string;
+  message: string;
+  data: any;
+};
 
 async function ignoreErrors<T>(fn: () => T | Promise<T>) {
   try {

--- a/packages/uploadthing/src/sdk/sdk.test.ts
+++ b/packages/uploadthing/src/sdk/sdk.test.ts
@@ -1,12 +1,7 @@
 import { describe, expectTypeOf, test } from "vitest";
 
+import type { SerializedUploadthingError } from ".";
 import * as utapi from ".";
-
-type SerializedUploadthingError = {
-  code: string;
-  message: string;
-  data: any;
-};
 
 async function ignoreErrors<T>(fn: () => T | Promise<T>) {
   try {

--- a/packages/uploadthing/src/sdk/utils.ts
+++ b/packages/uploadthing/src/sdk/utils.ts
@@ -114,6 +114,7 @@ export const uploadFilesInternal = async (
       const data = upload.value satisfies UploadData;
       return { data, error: null };
     }
+    // We only throw UploadThingErrors, so this is safe
     const reason = upload.reason as UploadThingError;
     const error = UploadThingError.toObject(reason) satisfies UploadError;
     return { data: null, error };

--- a/packages/uploadthing/src/sdk/utils.ts
+++ b/packages/uploadthing/src/sdk/utils.ts
@@ -105,13 +105,14 @@ export const uploadFilesInternal = async (
       return {
         key,
         url: fileUrl,
-      } satisfies UploadData;
+      };
     }),
   );
 
   return uploads.map((upload) => {
     if (upload.status === "fulfilled") {
-      return { data: upload.value, error: null };
+      const data = upload.value satisfies UploadData;
+      return { data, error: null };
     }
 
     const error = UploadThingError.toObject(

--- a/packages/uploadthing/src/sdk/utils.ts
+++ b/packages/uploadthing/src/sdk/utils.ts
@@ -7,6 +7,17 @@ import {
 
 export type FileEsque = Blob & { name: string };
 
+export type UploadData = {
+  key: string;
+  url: string;
+};
+
+export type UploadError = {
+  code: string;
+  message: string;
+  data: any;
+};
+
 export const uploadFilesInternal = async (
   data: {
     files: FileEsque[];
@@ -94,7 +105,7 @@ export const uploadFilesInternal = async (
       return {
         key,
         url: fileUrl,
-      };
+      } satisfies UploadData;
     }),
   );
 
@@ -102,9 +113,10 @@ export const uploadFilesInternal = async (
     if (upload.status === "fulfilled") {
       return { data: upload.value, error: null };
     }
-    return {
-      data: null,
-      error: UploadThingError.toObject(upload.reason as UploadThingError),
-    };
+
+    const error = UploadThingError.toObject(
+      upload.reason as UploadThingError,
+    ) satisfies UploadError;
+    return { data: null, error };
   });
 };

--- a/packages/uploadthing/src/sdk/utils.ts
+++ b/packages/uploadthing/src/sdk/utils.ts
@@ -114,10 +114,8 @@ export const uploadFilesInternal = async (
       const data = upload.value satisfies UploadData;
       return { data, error: null };
     }
-
-    const error = UploadThingError.toObject(
-      upload.reason as UploadThingError,
-    ) satisfies UploadError;
+    const reason = upload.reason as UploadThingError;
+    const error = UploadThingError.toObject(reason) satisfies UploadError;
     return { data: null, error };
   });
 };


### PR DESCRIPTION
I suck at Git so I have now made 3 PRs just cause i couldn't push to the orignial branch in #243 🤣 

(This is still not typesafe (due to the the `as` cast) but it's a bit tidier than it was before and I added some internal checks to the `uploadFilesInternal` to ensure that returns the correct shape)

Closes #243