### PR TITLE
fix: pass same info to onClientUploadComplete as onUploadComplete

### DIFF
--- a/.changeset/violet-pumas-talk.md
+++ b/.changeset/violet-pumas-talk.md
@@ -1,5 +1,23 @@
 ---
 "uploadthing": patch
+"@uploadthing/react": patch
+"@uploadthing/solid": patch
 ---
 
-fix: pass same info to onClientUploadComplete as onUploadComplete
+fix: coherent file info in all methods
+
+all methods now receives a similarly shaped object as the serverside `onUploadComplete` callback:
+
+```ts
+export type UploadFileResponse = {
+  name: string;
+  size: number;
+  key: string;
+  url: string;
+};
+```
+
+Updated methods are:
+
+- `onClientUploadComplete` in hooks as well as components (The old `fileName`, `fileSize`, `fileUrl` and `fileKey` are retained but marked as deprecated for backwards compatibility, and will be removed in the next major.)
+- `utapi.uploadFiles` as well as `utapi.uploadFilesFromUrl`

--- a/.changeset/violet-pumas-talk.md
+++ b/.changeset/violet-pumas-talk.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+fix: pass same info to onClientUploadComplete as onUploadComplete

--- a/examples/appdir/src/app/page.tsx
+++ b/examples/appdir/src/app/page.tsx
@@ -31,7 +31,6 @@ export default function Home() {
           onClientUploadComplete={(res) => {
             // Do something with the response
             console.log("Files: ", res);
-            res?.[0]?.fileKey;
             alert("Upload Completed");
           }}
           onUploadError={(error: Error) => {

--- a/examples/appdir/src/app/page.tsx
+++ b/examples/appdir/src/app/page.tsx
@@ -31,6 +31,7 @@ export default function Home() {
           onClientUploadComplete={(res) => {
             // Do something with the response
             console.log("Files: ", res);
+            res?.[0]?.fileKey;
             alert("Upload Completed");
           }}
           onUploadError={(error: Error) => {

--- a/packages/react/src/component.tsx
+++ b/packages/react/src/component.tsx
@@ -6,7 +6,7 @@ import type {
   ExpandedRouteConfig,
   UploadThingError,
 } from "@uploadthing/shared";
-import type { UploadFileType } from "uploadthing/client";
+import type { UploadFileResponse } from "uploadthing/client";
 import {
   classNames,
   generateClientDropzoneAccept,
@@ -76,9 +76,7 @@ export type UploadthingComponentProps<TRouter extends FileRouter> = {
     endpoint: TEndpoint;
 
     onUploadProgress?: (progress: number) => void;
-    onClientUploadComplete?: (
-      res?: Awaited<ReturnType<UploadFileType<TRouter>>>,
-    ) => void;
+    onClientUploadComplete?: (res?: UploadFileResponse[]) => void;
     onUploadError?: (error: UploadThingError<inferErrorShape<TRouter>>) => void;
   } & (undefined extends inferEndpointInput<TRouter[TEndpoint]>
     ? {}

--- a/packages/react/src/useUploadThing.ts
+++ b/packages/react/src/useUploadThing.ts
@@ -2,6 +2,7 @@ import { useRef, useState } from "react";
 
 import type { ExpandedRouteConfig } from "@uploadthing/shared";
 import { UploadThingError } from "@uploadthing/shared";
+import type { UploadFileResponse } from "uploadthing/client";
 import { DANGEROUS__uploadFiles } from "uploadthing/client";
 import type {
   FileRouter,
@@ -23,9 +24,7 @@ const useEndpointMetadata = (endpoint: string) => {
 };
 
 export type UseUploadthingProps<TRouter extends FileRouter> = {
-  onClientUploadComplete?: (
-    res?: Awaited<ReturnType<typeof DANGEROUS__uploadFiles>>,
-  ) => void;
+  onClientUploadComplete?: (res?: UploadFileResponse[]) => void;
   onUploadProgress?: (p: number) => void;
   onUploadError?: (e: UploadThingError<inferErrorShape<TRouter>>) => void;
 };

--- a/packages/solid/src/component.tsx
+++ b/packages/solid/src/component.tsx
@@ -3,7 +3,7 @@ import type { OnDropHandler } from "solidjs-dropzone";
 import { createDropzone } from "solidjs-dropzone";
 
 import type { ExpandedRouteConfig } from "@uploadthing/shared";
-import type { UploadFileType } from "uploadthing/client";
+import type { UploadFileResponse } from "uploadthing/client";
 import {
   classNames,
   generateClientDropzoneAccept,
@@ -68,9 +68,7 @@ export type UploadthingComponentProps<TRouter extends FileRouter> = {
     endpoint: TEndpoint;
 
     onUploadProgress?: (progress: number) => void;
-    onClientUploadComplete?: (
-      res?: Awaited<ReturnType<UploadFileType<TRouter>>>,
-    ) => void;
+    onClientUploadComplete?: (res?: UploadFileResponse[]) => void;
     onUploadError?: (error: Error) => void;
     url?: string;
     multiple?: boolean;

--- a/packages/solid/src/useUploadThing.ts
+++ b/packages/solid/src/useUploadThing.ts
@@ -1,6 +1,7 @@
 import { createSignal } from "solid-js";
 
 import type { ExpandedRouteConfig } from "@uploadthing/shared";
+import type { UploadFileResponse } from "uploadthing/client";
 import { DANGEROUS__uploadFiles } from "uploadthing/client";
 import type { FileRouter, inferEndpointInput } from "uploadthing/server";
 
@@ -20,9 +21,7 @@ const createEndpointMetadata = (endpoint: string, url?: string) => {
 
 export type UseUploadthingProps = {
   onUploadProgress?: (p: number) => void;
-  onClientUploadComplete?: (
-    res?: Awaited<ReturnType<typeof DANGEROUS__uploadFiles>>,
-  ) => void;
+  onClientUploadComplete?: (res?: UploadFileResponse[]) => void;
   onUploadError?: (e: Error) => void;
   url?: string;
 };

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -171,18 +171,18 @@ export const DANGEROUS__uploadFiles = async <TRouter extends FileRouter>(
 
     // TODO: remove `file` prefix in next major version
     return {
-    // @deprecated - use `name` instead
-    fileName: file.name,
-    name: file.name,
-    // @deprecated - use `size` instead
-    fileSize: file.size,
-    size: file.size,
-    // @deprecated - use `key` instead
-    fileKey: presigned.key,
-    key: presigned.key,
-    // @deprecated - use `url` instead
-    fileUrl: genUrl,
-    url: genUrl,
+      // @deprecated - use `name` instead
+      fileName: file.name,
+      name: file.name,
+      // @deprecated - use `size` instead
+      fileSize: file.size,
+      size: file.size,
+      // @deprecated - use `key` instead
+      fileKey: presigned.key,
+      key: presigned.key,
+      // @deprecated - use `url` instead
+      fileUrl: genUrl,
+      url: genUrl,
     };
   });
 

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -169,6 +169,7 @@ export const DANGEROUS__uploadFiles = async <TRouter extends FileRouter>(
     // Poll for file data, this way we know that the client-side onUploadComplete callback will be called after the server-side version
     await pollForFileData(presigned.key);
 
+    // TODO: remove `file` prefix in next major version
     return {
       fileName: file.name,
       fileSize: file.size,

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -54,6 +54,33 @@ type UploadFilesOptions<TRouter extends FileRouter> = {
   };
 }[keyof TRouter];
 
+export type UploadFileResponse = {
+  /**
+   * @deprecated
+   * use `name` instead
+   */
+  fileName: string;
+  name: string;
+  /**
+   * @deprecated
+   * use `size` instead
+   */
+  fileSize: number;
+  size: number;
+  /**
+   * @deprecated
+   * use `key` instead
+   */
+  fileKey: string;
+  key: string;
+  /**
+   * @deprecated
+   * use `url` instead
+   */
+  fileUrl: string;
+  url: string;
+};
+
 export const DANGEROUS__uploadFiles = async <TRouter extends FileRouter>(
   opts: UploadFilesOptions<TRouter>,
   config?: {
@@ -170,29 +197,21 @@ export const DANGEROUS__uploadFiles = async <TRouter extends FileRouter>(
     await pollForFileData(presigned.key);
 
     // TODO: remove `file` prefix in next major version
-    return {
-      // @deprecated - use `name` instead
+    const ret: UploadFileResponse = {
       fileName: file.name,
       name: file.name,
-      // @deprecated - use `size` instead
       fileSize: file.size,
       size: file.size,
-      // @deprecated - use `key` instead
       fileKey: presigned.key,
       key: presigned.key,
-      // @deprecated - use `url` instead
       fileUrl: genUrl,
       url: genUrl,
     };
+    return ret;
   });
 
-  return Promise.all(fileUploadPromises) as Promise<
-    { fileUrl: string; fileKey: string }[]
-  >;
+  return Promise.all(fileUploadPromises);
 };
-
-export type UploadFileType<TRouter extends FileRouter> =
-  typeof DANGEROUS__uploadFiles<TRouter>;
 
 export const genUploader = <
   TRouter extends FileRouter,

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -170,6 +170,8 @@ export const DANGEROUS__uploadFiles = async <TRouter extends FileRouter>(
     await pollForFileData(presigned.key);
 
     return {
+      fileName: file.name,
+      fileSize: file.size,
       fileKey: presigned.key,
       fileUrl: genUrl,
     };

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -171,10 +171,18 @@ export const DANGEROUS__uploadFiles = async <TRouter extends FileRouter>(
 
     // TODO: remove `file` prefix in next major version
     return {
-      fileName: file.name,
-      fileSize: file.size,
-      fileKey: presigned.key,
-      fileUrl: genUrl,
+    // @deprecated - use `name` instead
+    fileName: file.name,
+    name: file.name,
+    // @deprecated - use `size` instead
+    fileSize: file.size,
+    size: file.size,
+    // @deprecated - use `key` instead
+    fileKey: presigned.key,
+    key: presigned.key,
+    // @deprecated - use `url` instead
+    fileUrl: genUrl,
+    url: genUrl,
     };
   });
 

--- a/packages/uploadthing/src/sdk/utils.ts
+++ b/packages/uploadthing/src/sdk/utils.ts
@@ -10,6 +10,8 @@ export type FileEsque = Blob & { name: string };
 export type UploadData = {
   key: string;
   url: string;
+  name: string;
+  size: number;
 };
 
 export type UploadError = {
@@ -105,6 +107,8 @@ export const uploadFilesInternal = async (
       return {
         key,
         url: fileUrl,
+        name: file.name,
+        size: file.size,
       };
     }),
   );


### PR DESCRIPTION
Addresses https://discord.com/channels/966627436387266600/1102510616326967306/1138143461908951111

Previously was only providing file key and url, now includes name and size as well 
to match with the input to `onUploadComplete()`

would be nice to have the objects be identical, however that would break back 
compat. 

`onUploadComplete()` uses this shape:

```
{
   url: string,
   key: string,
   name: string, 
   size: number
}
```

while `onClientUploadComplete()` uses:

```
{
   fileName: string,
   fileSize: number,
   fileKey: string,
   fileUrl: string
}
```
