### PR TITLE
chore: add missing changeset from server upload PR.

### DIFF
--- a/.changeset/tender-bags-complain.md
+++ b/.changeset/tender-bags-complain.md
@@ -1,0 +1,5 @@
+---
+"@uploadthing/shared": minor
+---
+
+feat: add serialization functions for UploadthingError


### PR DESCRIPTION
add missing changeset from server upload PR.

need the `UploadthingError.toObject` method to be published