### PR TITLE
fix: don't mess with headers

### DIFF
--- a/.changeset/real-bulldogs-protect.md
+++ b/.changeset/real-bulldogs-protect.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+fix invalid `NextApiResponse` object for pages middleware

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -133,11 +133,11 @@ export type RouterWithConfig<TRouter extends FileRouter> = {
   };
 };
 
-const getHeader = (headers: RequestLike["headers"], key: string) => {
-  if (headers instanceof Headers) {
-    return headers.get(key);
+const getHeader = (req: RequestLike, key: string) => {
+  if (req.headers instanceof Headers) {
+    return req.headers.get(key);
   }
-  return headers[key];
+  return req.headers[key];
 };
 
 export const buildRequestHandler = <
@@ -157,8 +157,7 @@ export const buildRequestHandler = <
 
     // Get inputs from query and params
     const params = new URL(req.url ?? "", getUploadthingUrl()).searchParams;
-    const uploadthingHook =
-      getHeader(req.headers, "uploadthing-hook") ?? undefined;
+    const uploadthingHook = getHeader(req, "uploadthing-hook") ?? undefined;
     const slug = params.get("slug") ?? undefined;
     const actionType = params.get("actionType") ?? undefined;
 

--- a/packages/uploadthing/src/internal/next/pagerouter.ts
+++ b/packages/uploadthing/src/internal/next/pagerouter.ts
@@ -26,17 +26,16 @@ export const createNextPageApiHandler = <TRouter extends FileRouter>(
       return;
     }
 
-    const standardRequest = {
-      ...req,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      json: () => Promise.resolve(JSON.parse(req.body)),
-      headers: {
-        get: (key: string) => req.headers[key],
-      } as Headers,
-    };
-
     const response = await requestHandler({
-      req: standardRequest,
+      req: Object.assign(req, {
+        json: () =>
+          Promise.resolve(
+            JSON.parse(
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+              req.body,
+            ),
+          ),
+      }),
       res,
     });
 

--- a/packages/uploadthing/src/internal/types.ts
+++ b/packages/uploadthing/src/internal/types.ts
@@ -1,3 +1,4 @@
+import type { IncomingHttpHeaders } from "node:http";
 import type { NextApiRequest, NextApiResponse } from "next";
 import type { NextRequest } from "next/server";
 
@@ -20,6 +21,15 @@ export type Simplify<TType> = { [TKey in keyof TType]: TType[TKey] } & {};
 
 export type MaybePromise<TType> = TType | Promise<TType>;
 
+export type WithRequired<T, K extends keyof T> = T & Required<Pick<T, K>>;
+export type Overwrite<T, U> = Omit<T, keyof U> & U;
+
+export type RequestLike = Overwrite<
+  WithRequired<Partial<Request>, "json">,
+  {
+    headers: Headers | IncomingHttpHeaders;
+  }
+>;
 //
 // Package
 type ResolverOptions<TParams extends AnyParams> = {


### PR DESCRIPTION
Not sure how we haven't had any issue posted about this yet.

We're lying to the type saying `headers` is of type `NextApiRequest["headers"]`, but sending in `headers: (key) => headers[key]` to the handler.

This also fixes some workarounds people have had to make with Clerk: https://discord.com/channels/966627436387266600/1102510616326967306/1131989764950724808. Now, `getAuth(req)` **just** works since the `req` is actually a proper `NextApiRequest` like we say it is

(See a test repo here: https://github.com/juliusmarminge/clerk-uploadthing-pages)