### PR TITLE
chore(ci): don't run PR linter on both pr and pr target

### DIFF
--- a/.github/workflows/pr-titles.yaml
+++ b/.github/workflows/pr-titles.yaml
@@ -6,11 +6,6 @@ on:
       - opened
       - edited
       - synchronize
-  pull_request:
-    types:
-      - opened
-      - edited
-      - synchronize
 
 permissions:
   pull-requests: read


### PR DESCRIPTION
Don't need to run on both types: 
<img width="587" alt="CleanShot 2023-08-14 at 21 22 53@2x" src="https://github.com/pingdotgg/uploadthing/assets/51714798/995b8bed-f59a-48ae-be66-74b0b6505474">
