### PR TITLE
fix: incorrect app file name

### DIFF
--- a/docs/src/pages/nextjs/appdir.mdx
+++ b/docs/src/pages/nextjs/appdir.mdx
@@ -91,7 +91,7 @@ export const { UploadButton, UploadDropzone, Uploader } =
 The `@uploadthing/react` package includes an "UploadButton" component that you
 can simply drop into your app, and start uploading files immediately.
 
-```tsx copy filename="app/example-uploader.tsx"
+```tsx copy filename="app/example-uploader/page.tsx"
 "use client";
 
 // You need to import our styles for the button to look right. Best to import in the root /layout.tsx but this is fine


### PR DESCRIPTION
The file name for a page in the app router is incorrect as it requires the path in the website followed by "/page.tsx" whereas this is missing that:
![image](https://github.com/pingdotgg/uploadthing/assets/55663195/d77d6e0b-a10d-4126-912c-a7cc27da992e)
