### PR TITLE
feat(react): Dropzone modes

### DIFF
--- a/.changeset/polite-lions-peel.md
+++ b/.changeset/polite-lions-peel.md
@@ -1,0 +1,5 @@
+---
+"@uploadthing/react": minor
+---
+
+feat(react): modes for different dropzone behaviour

--- a/docs/src/pages/api-reference/react.mdx
+++ b/docs/src/pages/api-reference/react.mdx
@@ -67,15 +67,17 @@ export const OurUploadDropzone = () => (
 
 ### Configuration
 
-| Prop                   | Type     | Required                | Notes           | Description                                                                         |
-| :--------------------- | :------- | :---------------------- | :-------------- | :---------------------------------------------------------------------------------- |
-| `<FileRouter>`         | generic  | Yes                     |                 | The type from the FileRouter you defined in your backend                            |
-| endpoint               | string   | Yes                     |                 | The name of the [route](./server#FileRouter) you want this button to upload to      |
-| input                  | string   | If set on the fileroute | Added in `v5.0` | Object matching the input schema that was set for this endpoint in your File Router |
-| onClientUploadComplete | function | No                      |                 | `{fileKey: string, fileUrl: string}[]` callback function when upload is completed   |
-| onUploadError          | function | No                      |                 | callback function when upload fails                                                 |
-| onUploadProgress       | function | No                      | Added in `v5.1` | callback function for upload progress                                               |
-| onUploadBegin          | function | No                      | Added in `v5.4` | callback function for upload begin                                                  |
+| Prop                   | Type               | Required                | Notes           | Description                                                                             |
+| :--------------------- | :----------------- | :---------------------- | :-------------- | :-------------------------------------------------------------------------------------- |
+| `<FileRouter>`         | generic            | Yes                     |                 | The type from the FileRouter you defined in your backend                                |
+| endpoint               | string             | Yes                     |                 | The name of the [route](./server#FileRouter) you want this button to upload to          |
+| input                  | string             | If set on the fileroute | Added in `v5.0` | Object matching the input schema that was set for this endpoint in your File Router     |
+| onClientUploadComplete | function           | No                      |                 | `{fileKey: string, fileUrl: string}[]` callback function when upload is completed       |
+| onUploadError          | function           | No                      |                 | callback function when upload fails                                                     |
+| onUploadProgress       | function           | No                      | Added in `v5.1` | callback function for upload progress                                                   |
+| onUploadBegin          | function           | No                      | Added in `v5.4` | callback function for upload begin                                                      |
+| config                 | object             | No                      | Added in `v5.5` | object to pass additional configuration for dropzone                                    |
+| config.mode            | 'auto' \| 'manual' | No                      | Added in `v5.5` | mode of dropzone. 'manual' is default one. 'auto' triggers upload right after selection |
 
 ## generateReactHelpers
 

--- a/examples/appdir/src/app/page.tsx
+++ b/examples/appdir/src/app/page.tsx
@@ -65,6 +65,9 @@ export default function Home() {
             alert(`ERROR! ${error.message}`);
           }}
           className="ut-label:text-lg ut-label:text-cyan-900 ut-allowed-content:text-base ut-button:bg-orange-500"
+          config={{
+            mode: "manual",
+          }}
           // Uncomment this to see custom appearance in action
           // appearance={{
           //   container:

--- a/examples/appdir/src/app/page.tsx
+++ b/examples/appdir/src/app/page.tsx
@@ -66,7 +66,7 @@ export default function Home() {
           }}
           className="ut-label:text-lg ut-label:text-cyan-900 ut-allowed-content:text-base ut-button:bg-orange-500"
           config={{
-            mode: "manual",
+            mode: "manual", // change to 'auto' to upload files immediately on selection.
           }}
           // Uncomment this to see custom appearance in action
           // appearance={{

--- a/packages/react/src/components/dropzone.tsx
+++ b/packages/react/src/components/dropzone.tsx
@@ -45,14 +45,9 @@ export type UploadDropzoneProps<TRouter extends FileRouter> =
       button?: ContentField<DropzoneStyleFieldCallbackArgs>;
     };
     className?: string;
-    config?:
-      | {
-          mode?: "auto" | "manual";
-        }
-      | {
-          mode?: "threshold";
-          threshold?: number;
-        };
+    config?: {
+      mode?: "auto" | "manual";
+    };
   };
 
 export function UploadDropzone<TRouter extends FileRouter>(
@@ -103,9 +98,7 @@ export function UploadDropzone<TRouter extends FileRouter>(
     },
   );
 
-  const { fileTypes, maxFileCount } = generatePermittedFileTypes(
-    permittedFileInfo?.config,
-  );
+  const { fileTypes } = generatePermittedFileTypes(permittedFileInfo?.config);
 
   const onDrop = useCallback(
     (acceptedFiles: FileWithPath[]) => {
@@ -117,19 +110,8 @@ export function UploadDropzone<TRouter extends FileRouter>(
         void startUpload(acceptedFiles, input);
         return;
       }
-
-      // If mode is threshold, start upload if threshold is reached
-      if ($props.config?.mode === "threshold") {
-        // if threshold is not provided in config, using maximum file count as fallback
-        const threshold = $props.config.threshold ?? maxFileCount;
-
-        if (acceptedFiles.length >= threshold) {
-          const input = "input" in $props ? $props.input : undefined;
-          void startUpload(acceptedFiles, input);
-        }
-      }
     },
-    [$props, startUpload, maxFileCount],
+    [$props, startUpload],
   );
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({

--- a/packages/react/src/components/dropzone.tsx
+++ b/packages/react/src/components/dropzone.tsx
@@ -46,13 +46,13 @@ export type UploadDropzoneProps<TRouter extends FileRouter> =
     };
     className?: string;
     config?:
-    | {
-      mode?: "auto" | "manual";
-    }
-    | {
-      mode?: "threshold";
-      threshold?: number;
-    };
+      | {
+          mode?: "auto" | "manual";
+        }
+      | {
+          mode?: "threshold";
+          threshold?: number;
+        };
   };
 
 export function UploadDropzone<TRouter extends FileRouter>(

--- a/packages/react/src/components/shared.tsx
+++ b/packages/react/src/components/shared.tsx
@@ -10,7 +10,6 @@ export const generatePermittedFileTypes = (config?: ExpandedRouteConfig) => {
   return {
     fileTypes,
     multiple: maxFileCount.some((v) => v && v > 1),
-    maxFileCount: Math.max(...maxFileCount),
   };
 };
 

--- a/packages/react/src/components/shared.tsx
+++ b/packages/react/src/components/shared.tsx
@@ -7,7 +7,11 @@ export const generatePermittedFileTypes = (config?: ExpandedRouteConfig) => {
     ? Object.values(config).map((v) => v.maxFileCount)
     : [];
 
-  return { fileTypes, multiple: maxFileCount.some((v) => v && v > 1) };
+  return {
+    fileTypes,
+    multiple: maxFileCount.some((v) => v && v > 1),
+    maxFileCount: Math.max(...maxFileCount),
+  };
 };
 
 export const capitalizeStart = (str: string) => {


### PR DESCRIPTION
Three modes are available:
- manual
- auto
- threshold

`manual` - default behaviour. Upload have to be triggered manually
`auto` - will start upload right after drop
`threshold` - will start upload once if number of dropped files is equal or greater than threshold value. Threshold can be passed either explicitly through config, or maximum number of files will be used. Maximum number of files is equal to largest maximum number among specified types. Though maybe we should use different value

Addresses #273 
