### PR TITLE
chore: swap dev and build scripts to favor only packages/*

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
     "pnpm": ">=8.6.0"
   },
   "scripts": {
-    "build": "turbo run build",
-    "build:pkgs": "turbo run build --filter \"./packages/*\"",
+    "build:all": "turbo run build",
+    "build": "turbo run build --filter \"./packages/*\"",
     "clean": "turbo run clean && git clean -xdf node_modules",
-    "dev": "turbo run dev",
-    "dev:pkgs": "turbo run dev --filter \"./packages/*\"",
+    "dev:all": "turbo run dev",
+    "dev": "turbo run dev --filter \"./packages/*\"",
     "lint": "turbo run lint && manypkg check",
     "format:check": "prettier --check .",
     "format": "prettier --write . --list-different",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -98,7 +98,8 @@
     "tsup": "6.7.0",
     "tsup-preset-solid": "0.1.8",
     "typescript": "^5.1.6",
-    "uploadthing": "5.3.3"
+    "uploadthing": "5.3.3",
+    "wait-on": "^7.0.1"
   },
   "peerDependencies": {
     "solid-js": "^1.5.3",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -82,6 +82,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "rm -rf dist && tsup --config ./tsup.config.js",
+    "dev": "wait-on ../uploadthing/dist/server.mjs && tsup --watch --config ./tsup.config.js",
     "lint": "eslint \"**/*.{ts,tsx}\"",
     "typecheck": "tsc --noEmit"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -470,6 +470,9 @@ importers:
       uploadthing:
         specifier: 5.3.3
         version: link:../uploadthing
+      wait-on:
+        specifier: ^7.0.1
+        version: 7.0.1
 
   packages/uploadthing:
     dependencies:


### PR DESCRIPTION
Just me that feels like running dev/build should just run dev in packages/* ?

