### PR TITLE
fix(docs): errors page withInput example

### DIFF
--- a/docs/src/pages/errors.mdx
+++ b/docs/src/pages/errors.mdx
@@ -36,7 +36,7 @@ const f = createUploadthing({
 });
 
 export const uploadRouter = {
-  withInput: f.input(z.object({ foo: z.string() })),
+  withInput: f(["image"]).input(z.object({ foo: z.string() })),
   //  ...
 } satisfies FileRouter;
 ```


### PR DESCRIPTION
fix errors page withInput example to use correct .input syntax