### PR TITLE
fix(sdk): prevent `uploadFilesInternal` from consuming response body twice on bad response

### DIFF
--- a/.changeset/bright-pugs-watch.md
+++ b/.changeset/bright-pugs-watch.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+fix(sdk): prevent `uploadFilesInternal` from consuming response body twice on bad response

--- a/packages/uploadthing/src/sdk/utils.ts
+++ b/packages/uploadthing/src/sdk/utils.ts
@@ -54,7 +54,7 @@ export const uploadFilesInternal = async (
   if (!res.ok) {
     throw UploadThingError.fromResponse(res);
   }
-  
+
   const clonedRes = res.clone(); // so that `UploadThingError.fromResponse()` can consume the body again
   const json = (await res.json()) as
     | {
@@ -66,7 +66,7 @@ export const uploadFilesInternal = async (
         }[];
       }
     | { error: string };
-  
+
   if ("error" in json) {
     throw UploadThingError.fromResponse(clonedRes);
   }

--- a/packages/uploadthing/src/sdk/utils.ts
+++ b/packages/uploadthing/src/sdk/utils.ts
@@ -51,6 +51,10 @@ export const uploadFilesInternal = async (
     }),
   });
 
+  if (!res.ok) {
+    throw UploadThingError.fromResponse(res);
+  }
+  
   const json = (await res.json()) as
     | {
         data: {
@@ -61,9 +65,9 @@ export const uploadFilesInternal = async (
         }[];
       }
     | { error: string };
-
-  if (!res.ok || "error" in json) {
-    throw UploadThingError.fromResponse(res);
+  
+  if ("error" in json) {
+    throw UploadThingError.toObject(json);
   }
 
   // Upload each file to S3

--- a/packages/uploadthing/src/sdk/utils.ts
+++ b/packages/uploadthing/src/sdk/utils.ts
@@ -55,6 +55,7 @@ export const uploadFilesInternal = async (
     throw UploadThingError.fromResponse(res);
   }
   
+  const clonedRes = res.clone(); // so that `UploadThingError.fromResponse()` can consume the body again
   const json = (await res.json()) as
     | {
         data: {
@@ -67,7 +68,7 @@ export const uploadFilesInternal = async (
     | { error: string };
   
   if ("error" in json) {
-    throw UploadThingError.toObject(json);
+    throw UploadThingError.fromResponse(clonedRes);
   }
 
   // Upload each file to S3


### PR DESCRIPTION
on a bad upload response (within `uploadFilesInternal`), the function calls `UploadThingError.fromResponse()` after having consumed the response body -- leading to a `TypeError` for attempting to consume the response body twice.