### PR TITLE
fix(pagedir): only json parse if body is a string

### DIFF
--- a/.changeset/funny-suns-run.md
+++ b/.changeset/funny-suns-run.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+fix: only run JSON.parse if body is a string

--- a/packages/uploadthing/src/next-legacy.ts
+++ b/packages/uploadthing/src/next-legacy.ts
@@ -38,14 +38,13 @@ export const createNextPageApiHandler = <TRouter extends FileRouter>(
       return;
     }
 
+    console.log("req.body", typeof req.body, req.body);
+
     const response = await requestHandler({
       req: Object.assign(req, {
         json: () =>
           Promise.resolve(
-            JSON.parse(
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-              req.body,
-            ),
+            typeof req.body === "string" ? JSON.parse(req.body) : req.body,
           ),
       }),
       res,

--- a/packages/uploadthing/src/next-legacy.ts
+++ b/packages/uploadthing/src/next-legacy.ts
@@ -38,8 +38,6 @@ export const createNextPageApiHandler = <TRouter extends FileRouter>(
       return;
     }
 
-    console.log("req.body", typeof req.body, req.body);
-
     const response = await requestHandler({
       req: Object.assign(req, {
         json: () =>


### PR DESCRIPTION
Closes #362

No idea when this would have been introduced though, as we have ran the body through JSON.parse for a loooong time, so I don't see why it would have broken in this update. 