### PR TITLE
fix: progress bar and spinner

### DIFF
--- a/.changeset/small-students-sit.md
+++ b/.changeset/small-students-sit.md
@@ -1,0 +1,6 @@
+---
+"@uploadthing/react": patch
+"@uploadthing/solid": patch
+---
+
+fix bug where progress bar styles was not included in the compiled stylesheet

--- a/packages/react/src/components/button.tsx
+++ b/packages/react/src/components/button.tsx
@@ -6,7 +6,6 @@ import {
   contentFieldToContent,
   generateMimeTypes,
   generatePermittedFileTypes,
-  progressWidths,
   styleFieldToClassName,
   styleFieldToCssObject,
 } from "uploadthing/client";
@@ -15,7 +14,7 @@ import type { ErrorMessage, FileRouter } from "uploadthing/server";
 
 import type { UploadthingComponentProps } from "../types";
 import { INTERNAL_uploadthingHookGen } from "../useUploadThing";
-import { Spinner } from "./shared";
+import { progressWidths, Spinner } from "./shared";
 
 type ButtonStyleFieldCallbackArgs = {
   __runtime: "react";
@@ -150,7 +149,7 @@ export function UploadButton<TRouter extends FileRouter>(
           "relative flex h-10 w-36 cursor-pointer items-center justify-center overflow-hidden rounded-md text-white after:transition-[width] after:duration-500",
           state === "readying" && "cursor-not-allowed bg-blue-400",
           state === "uploading" &&
-            `bg-blue-400 after:absolute after:left-0 after:h-full after:bg-blue-600 ${progressWidths[uploadProgress]}`,
+            `bg-blue-400 after:absolute after:left-0 after:h-full after:bg-blue-600 after:content-[''] ${progressWidths[uploadProgress]}`,
           state === "ready" && "bg-blue-600",
           styleFieldToClassName($props.appearance?.button, styleFieldArg),
         )}

--- a/packages/react/src/components/dropzone.tsx
+++ b/packages/react/src/components/dropzone.tsx
@@ -7,7 +7,6 @@ import {
   contentFieldToContent,
   generateClientDropzoneAccept,
   generatePermittedFileTypes,
-  progressWidths,
   styleFieldToClassName,
   styleFieldToCssObject,
 } from "uploadthing/client";
@@ -18,7 +17,7 @@ import type { UploadthingComponentProps } from "../types";
 import type { FileWithPath } from "../use-dropzone";
 import { useDropzone } from "../use-dropzone";
 import { INTERNAL_uploadthingHookGen } from "../useUploadThing";
-import { Spinner } from "./shared";
+import { progressWidths, Spinner } from "./shared";
 
 type DropzoneStyleFieldCallbackArgs = {
   __runtime: "react";

--- a/packages/react/src/components/shared.tsx
+++ b/packages/react/src/components/shared.tsx
@@ -1,7 +1,7 @@
 export function Spinner() {
   return (
     <svg
-      className="block h-5 w-5 animate-spin align-middle text-white"
+      className="z-10 block h-5 w-5 animate-spin align-middle text-white"
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 576 512"
@@ -13,3 +13,17 @@ export function Spinner() {
     </svg>
   );
 }
+
+export const progressWidths: Record<number, string> = {
+  0: "after:w-0",
+  10: "after:w-[10%]",
+  20: "after:w-[20%]",
+  30: "after:w-[30%]",
+  40: "after:w-[40%]",
+  50: "after:w-[50%]",
+  60: "after:w-[60%]",
+  70: "after:w-[70%]",
+  80: "after:w-[80%]",
+  90: "after:w-[90%]",
+  100: "after:w-[100%]",
+};

--- a/packages/solid/src/components/button.tsx
+++ b/packages/solid/src/components/button.tsx
@@ -6,7 +6,6 @@ import {
   contentFieldToContent,
   generateMimeTypes,
   generatePermittedFileTypes,
-  progressWidths,
   styleFieldToClassName,
   styleFieldToCssObject,
 } from "uploadthing/client";
@@ -15,7 +14,7 @@ import type { ErrorMessage, FileRouter } from "uploadthing/server";
 
 import type { UploadthingComponentProps } from "../types";
 import { INTERNAL_uploadthingHookGen } from "../useUploadThing";
-import { Spinner } from "./shared";
+import { progressWidths, Spinner } from "./shared";
 
 type ButtonStyleFieldCallbackArgs = {
   __runtime: "solid";

--- a/packages/solid/src/components/dropzone.tsx
+++ b/packages/solid/src/components/dropzone.tsx
@@ -9,7 +9,6 @@ import {
   contentFieldToContent,
   generateClientDropzoneAccept,
   generatePermittedFileTypes,
-  progressWidths,
   styleFieldToClassName,
   styleFieldToCssObject,
 } from "uploadthing/client";
@@ -18,7 +17,7 @@ import type { ErrorMessage, FileRouter } from "uploadthing/server";
 
 import type { UploadthingComponentProps } from "../types";
 import { INTERNAL_uploadthingHookGen } from "../useUploadThing";
-import { Spinner } from "./shared";
+import { progressWidths, Spinner } from "./shared";
 
 type DropzoneStyleFieldCallbackArgs = {
   __runtime: "solid";

--- a/packages/solid/src/components/shared.tsx
+++ b/packages/solid/src/components/shared.tsx
@@ -1,7 +1,7 @@
 export function Spinner() {
   return (
     <svg
-      class="block h-5 w-5 animate-spin align-middle text-white"
+      class="z-10 block h-5 w-5 animate-spin align-middle text-white"
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 576 512"
@@ -13,3 +13,17 @@ export function Spinner() {
     </svg>
   );
 }
+
+export const progressWidths: Record<number, string> = {
+  0: "after:w-0",
+  10: "after:w-[10%]",
+  20: "after:w-[20%]",
+  30: "after:w-[30%]",
+  40: "after:w-[40%]",
+  50: "after:w-[50%]",
+  60: "after:w-[60%]",
+  70: "after:w-[70%]",
+  80: "after:w-[80%]",
+  90: "after:w-[90%]",
+  100: "after:w-[100%]",
+};

--- a/packages/uploadthing/src/internal/component-theming.ts
+++ b/packages/uploadthing/src/internal/component-theming.ts
@@ -53,20 +53,6 @@ export const allowedContentTextLabelGenerator = (
   return capitalizeStart(INTERNAL_doFormatting(config));
 };
 
-export const progressWidths: Record<number, string> = {
-  0: "after:w-0",
-  10: "after:w-[10%]",
-  20: "after:w-[20%]",
-  30: "after:w-[30%]",
-  40: "after:w-[40%]",
-  50: "after:w-[50%]",
-  60: "after:w-[60%]",
-  70: "after:w-[70%]",
-  80: "after:w-[80%]",
-  90: "after:w-[90%]",
-  100: "after:w-[100%]",
-};
-
 type AnyRuntime = "react" | "solid";
 type MinCallbackArg = { __runtime: AnyRuntime };
 type inferRuntime<T extends MinCallbackArg> = T["__runtime"] extends "react"


### PR DESCRIPTION
Fixes two issues:
1. Classes `after:w-[%]` were not generated because they were part of another package not included in tailwind.config. I decided to move progressWidths instead of changing tailwind.config
2. Spinner had been covered by progress bar