### PR TITLE
fix: ensure that uploadProgress fires 0 when upload starts

### DIFF
--- a/packages/react/src/useUploadThing.ts
+++ b/packages/react/src/useUploadThing.ts
@@ -59,6 +59,7 @@ export const INTERNAL_uploadthingHookGen = <TRouter extends FileRouter>() => {
     const startUpload = useEvent(async (...args: FuncInput) => {
       const [files, input] = args;
       setUploading(true);
+      opts?.onUploadProgress?.(0);
       try {
         const res = await DANGEROUS__uploadFiles({
           files,

--- a/packages/solid/src/useUploadThing.ts
+++ b/packages/solid/src/useUploadThing.ts
@@ -48,6 +48,7 @@ export const INTERNAL_uploadthingHookGen = <TRouter extends FileRouter>() => {
     const startUpload = async (...args: FuncInput) => {
       const [files, input] = args;
       setUploading(true);
+      opts?.onUploadProgress?.(0)
       try {
         const res = await DANGEROUS__uploadFiles({
           files,

--- a/packages/solid/src/useUploadThing.ts
+++ b/packages/solid/src/useUploadThing.ts
@@ -48,7 +48,7 @@ export const INTERNAL_uploadthingHookGen = <TRouter extends FileRouter>() => {
     const startUpload = async (...args: FuncInput) => {
       const [files, input] = args;
       setUploading(true);
-      opts?.onUploadProgress?.(0)
+      opts?.onUploadProgress?.(0);
       try {
         const res = await DANGEROUS__uploadFiles({
           files,

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -204,14 +204,12 @@ export const DANGEROUS__uploadFiles = async <TRouter extends FileRouter>(
         }),
       },
       (progressEvent) =>
-        opts.onUploadProgress &&
-        opts.onUploadProgress({
+        opts.onUploadProgress?.({
           file: file.name,
           progress: (progressEvent.loaded / progressEvent.total) * 100,
         }),
       () => {
-        opts.onUploadBegin &&
-          opts.onUploadBegin({
+          opts.onUploadBegin?.({
             file: file.name,
           });
       },

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -209,9 +209,9 @@ export const DANGEROUS__uploadFiles = async <TRouter extends FileRouter>(
           progress: (progressEvent.loaded / progressEvent.total) * 100,
         }),
       () => {
-          opts.onUploadBegin?.({
-            file: file.name,
-          });
+        opts.onUploadBegin?.({
+          file: file.name,
+        });
       },
     );
 


### PR DESCRIPTION
Pretty straight forward, fires a 0 progress callback the same time we initially set uploading state to true
