### PR TITLE
fix: wrap `response.json()` in a try-catch block

### DIFF
--- a/.changeset/slow-coins-begin.md
+++ b/.changeset/slow-coins-begin.md
@@ -1,0 +1,5 @@
+---
+"@uploadthing/shared": patch
+---
+
+fix: wrap response.json in try-catch block

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -74,7 +74,20 @@ export class UploadThingError<
   }
 
   public static async fromResponse(response: Response) {
-    const json = (await response.json()) as Json;
+    let json: Json | null = null;
+    try {
+      json = (await response.json()) as Json;
+    } catch (err) {
+      console.error(
+        "[FATAL] Failed to parse response body as JSON, got",
+        await response.text(),
+      );
+      return new UploadThingError({
+        message: `Failed to parse response body: ${(err as Error).message}`,
+        code: getErrorTypeFromStatusCode(response.status),
+        cause: response,
+      });
+    }
     let message: string | undefined = undefined;
     if (json !== null && typeof json === "object" && !Array.isArray(json)) {
       if (typeof json.message === "string") {


### PR DESCRIPTION
Related: https://github.com/pingdotgg/uploadthing/issues/385#issuecomment-1742303132