### PR TITLE
fix: Add optional to import.meta.env call

### DIFF
--- a/.changeset/cold-masks-call.md
+++ b/.changeset/cold-masks-call.md
@@ -1,0 +1,5 @@
+---
+"@uploadthing/shared": patch
+---
+
+fix: Add optional to import.meta.env call for better Remix support

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -112,7 +112,6 @@ export function generateUploadThingURL(path: `/${string}`) {
   } else {
     // @ts-expect-error - import.meta is dumb
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
-    // prevent error if import.meta.env does not exist
     host = import.meta.env?.CUSTOM_INFRA_URL ?? host;
   }
   return `${host}${path}`;

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -112,7 +112,8 @@ export function generateUploadThingURL(path: `/${string}`) {
   } else {
     // @ts-expect-error - import.meta is dumb
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment
-    host = import.meta.env.CUSTOM_INFRA_URL ?? host;
+    // prevent error if import.meta.env does not exist
+    host = import.meta.env?.CUSTOM_INFRA_URL ?? host;
   }
   return `${host}${path}`;
 }


### PR DESCRIPTION
Hi, when using Remix this file fails because import.meta.env does not exist. Proposing a change to prevent function from failing and use the host value in these cases.

Thanks