### PR TITLE
fix: clone res before attempting json parse in `uploadFiles`

### DIFF
--- a/.changeset/quick-seahorses-care.md
+++ b/.changeset/quick-seahorses-care.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+clone res before attempting to parse json so that we can fallback to .text()

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -74,13 +74,14 @@ export class UploadThingError<
   }
 
   public static async fromResponse(response: Response) {
+    const clonedResponse = response.clone();
     let json: Json | null = null;
     try {
       json = (await response.json()) as Json;
     } catch (err) {
       console.error(
         "[FATAL] Failed to parse response body as JSON, got",
-        await response.text(),
+        await clonedResponse.text(),
       );
       return new UploadThingError({
         message: `Failed to parse response body: ${(err as Error).message}`,

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -137,7 +137,8 @@ export const DANGEROUS__uploadFiles = async <TRouter extends FileRouter>(
       throw error;
     }
 
-    // attempt to parse response
+    // attempt to parse response, clone in case .json fails and we need to read the response again
+    const clonedRes = res.clone();
     try {
       return res.json();
     } catch (e) {
@@ -145,7 +146,7 @@ export const DANGEROUS__uploadFiles = async <TRouter extends FileRouter>(
       console.error(e);
       throw new UploadThingError({
         code: "BAD_REQUEST",
-        message: `Failed to parse response as JSON. Got: ${await res.text()}`,
+        message: `Failed to parse response as JSON. Got: ${await clonedRes.text()}`,
         cause: e,
       });
     }


### PR DESCRIPTION
Ref: https://github.com/pingdotgg/uploadthing/issues/385#issuecomment-1747119451

![272625936-e29e647f-3633-4b51-b6f5-6dc68808a0a9](https://github.com/pingdotgg/uploadthing/assets/51714798/9248412a-b2b3-4f71-8d30-4ef18dde1c3f)

That safeJSONParse couldn't come any sooner 😅 
