### PR TITLE
feat: Upload status type added

### DIFF
--- a/.changeset/thirty-zebras-know.md
+++ b/.changeset/thirty-zebras-know.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+feat: Upload status type added

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -248,7 +248,11 @@ export class UTApi {
 
     // TODO: Implement filtering and pagination
     const json = await this.requestUploadThing<{
-      files: { key: string; id: string; status: "Deletion Pending" | "Failed" | "Uploaded" | "Uploading" }[];
+      files: {
+        key: string;
+        id: string;
+        status: "Deletion Pending" | "Failed" | "Uploaded" | "Uploading";
+      }[];
     }>("/api/listFiles", {}, "An unknown error occured while listing files.");
 
     return json.files;

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -248,7 +248,7 @@ export class UTApi {
 
     // TODO: Implement filtering and pagination
     const json = await this.requestUploadThing<{
-      files: { key: string; id: string }[];
+      files: { key: string; id: string; status: string }[];
     }>("/api/listFiles", {}, "An unknown error occured while listing files.");
 
     return json.files;

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -248,7 +248,7 @@ export class UTApi {
 
     // TODO: Implement filtering and pagination
     const json = await this.requestUploadThing<{
-      files: { key: string; id: string; status: string }[];
+      files: { key: string; id: string; status: "Deletion Pending" | "Failed" | "Uploaded" | "Uploading" }[];
     }>("/api/listFiles", {}, "An unknown error occured while listing files.");
 
     return json.files;


### PR DESCRIPTION
`listFiles` now includes the status like shown in the Dashboard. (https://github.com/pingdotgg/uploadthing/issues/429) I added the type for this. As I don't know all possible status options it's a string for now. Maybe make it a union with all possible options?