### PR TITLE
chore!: remove deprecated `utapi` object in favor of initializing with constructor

### DIFF
--- a/.changeset/neat-buses-flow.md
+++ b/.changeset/neat-buses-flow.md
@@ -1,0 +1,17 @@
+---
+"uploadthing": major
+---
+
+feat!: change sdk function arguments to be an option object instead of
+positional arguments
+
+the signature of `UTApi.uploadFiles` and `UTApi.uploadFilesFromUrl` has 
+changed to be easier to add new options in the future.
+
+```diff
+- uploadFiles(files, metadata, contentDisposition)
++ uploadFiles(files, { metadata, contentDisposition })
+
+- uploadFilesFromUrl(urls, metadata, contentDisposition)
++ uploadFilesFromUrl(urls, { metadata, contentDisposition })
+```

--- a/.changeset/real-peas-compare.md
+++ b/.changeset/real-peas-compare.md
@@ -5,13 +5,15 @@
 chore!: remove deprecated `utapi` object in preference of using constructor
 
 the default UTApi was exported as `utapi` from `uploadthing/server`. this was
-deprecated in a previous release in favor of using the constructor directly.
+deprecated in `v5.7` in favor of using the constructor directly.
 
 ```diff
 - import { utapi } from 'uploadthing/server'
 + import { UTApi } from 'uploadthing/server'
 + const utapi = new UTApi(opts)
 ```
+
+> For full API spec of `UTAPI` see [the the server API reference](https://docs.uploadthing.com/api-reference/server#utapi).
 
 This update removes the deprecated `utapi` export.
 

--- a/.changeset/real-peas-compare.md
+++ b/.changeset/real-peas-compare.md
@@ -10,7 +10,8 @@ deprecated in `v5.7` in favor of using the constructor directly.
 ```diff
 - import { utapi } from 'uploadthing/server'
 + import { UTApi } from 'uploadthing/server'
-+ const utapi = new UTApi(opts)
++
++ export const utapi = new UTApi(opts)
 ```
 
 > For full API spec of `UTAPI` see [the the server API reference](https://docs.uploadthing.com/api-reference/server#utapi).

--- a/.changeset/real-peas-compare.md
+++ b/.changeset/real-peas-compare.md
@@ -1,0 +1,21 @@
+---
+"uploadthing": major
+---
+
+chore!: remove deprecated `utapi` object in preference of using constructor
+
+the default UTApi was exported as `utapi` from `uploadthing/server`. this was
+deprecated in a previous release in favor of using the constructor directly.
+
+```diff
+- import { utapi } from 'uploadthing/server'
++ import { UTApi } from 'uploadthing/server'
++ const utapi = new UTApi(opts)
+```
+
+This update removes the deprecated `utapi` export.
+
+In conjunction with this, we have moved certain guards to be in the constructor
+instead of in individual methods. This means that the constructor will throw
+if there is no `apiKey` passed as object or `UPLOADTHING_SECRET` in env, instead
+of this error being delayed until the method call.

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -86,7 +86,8 @@ export type RouterWithConfig<TRouter extends FileRouter> = {
   router: TRouter;
   config?: {
     /**
-     * @deprecated this option is deprecated and will be removed in a future version
+     * @deprecated since v6.0.0
+     * this option is deprecated and will be removed in a future version, you can safely remove it from your config
      */
     callbackUrl?: string;
     uploadthingId?: string;

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -44,7 +44,7 @@ export class UTApi {
 
     // Assert some stuff
     guardServerOnly();
-    getApiKeyOrThrow();
+    getApiKeyOrThrow(this.apiKey);
     incompatibleNodeGuard();
   }
 

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -90,7 +90,7 @@ export class UTApi {
    */
   async uploadFiles<T extends FileEsque | FileEsque[]>(
     files: T,
-    opts: {
+    opts?: {
       metadata?: Json;
       contentDisposition?: ContentDisposition;
     },
@@ -102,8 +102,8 @@ export class UTApi {
     const uploads = await uploadFilesInternal(
       {
         files: filesToUpload,
-        metadata: opts.metadata ?? {},
-        contentDisposition: opts.contentDisposition ?? "inline",
+        metadata: opts?.metadata ?? {},
+        contentDisposition: opts?.contentDisposition ?? "inline",
       },
       {
         fetch: this.fetch,
@@ -133,7 +133,7 @@ export class UTApi {
    */
   async uploadFilesFromUrl<T extends MaybeUrl | MaybeUrl[]>(
     urls: T,
-    opts: {
+    opts?: {
       metadata: Json;
       contentDisposition: ContentDisposition;
     },
@@ -143,7 +143,7 @@ export class UTApi {
     const fileUrls: MaybeUrl[] = Array.isArray(urls) ? urls : [urls];
 
     const formData = new FormData();
-    formData.append("metadata", JSON.stringify(opts.metadata ?? {}));
+    formData.append("metadata", JSON.stringify(opts?.metadata ?? {}));
 
     const filesToUpload = await Promise.all(
       fileUrls.map(async (url) => {
@@ -167,8 +167,8 @@ export class UTApi {
     const uploads = await uploadFilesInternal(
       {
         files: filesToUpload,
-        metadata: opts.metadata ?? {},
-        contentDisposition: opts.contentDisposition ?? "inline",
+        metadata: opts?.metadata ?? {},
+        contentDisposition: opts?.contentDisposition ?? "inline",
       },
       {
         fetch: this.fetch,

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -295,14 +295,3 @@ export class UTApi {
     );
   }
 }
-
-/**
- * @deprecated
- *
- * Import `UTApi` and instantiate it yourself:
- * ```ts
- * import { UTApi } from "@uploadthing/server";
- * const utapi = new UTApi({ ... });
- * ```
- */
-export const utapi = new UTApi();

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -41,6 +41,11 @@ export class UTApi {
       "x-uploadthing-api-key": this.apiKey!,
       "x-uploadthing-version": UPLOADTHING_VERSION,
     };
+
+    // Assert some stuff
+    guardServerOnly();
+    getApiKeyOrThrow();
+    incompatibleNodeGuard();
   }
 
   private async requestUploadThing<T extends Record<string, unknown>>(
@@ -48,13 +53,6 @@ export class UTApi {
     body: Record<string, unknown>,
     fallbackErrorMessage: string,
   ) {
-    // Force API key to be set before requesting.
-    // Ideally we'd just throw in the constructor but since we need to export
-    // a `utapi` object we can't throw in the constructor because it would
-    // be a breaking change.
-    // FIXME: In next major
-    getApiKeyOrThrow();
-
     const res = await this.fetch(generateUploadThingURL(pathname), {
       method: "POST",
       cache: "no-store",
@@ -92,20 +90,20 @@ export class UTApi {
    */
   async uploadFiles<T extends FileEsque | FileEsque[]>(
     files: T,
-    // FIXME: config option in v6 instead of positional args
-    metadata: Json = {},
-    contentDisposition: ContentDisposition = "inline",
+    opts: {
+      metadata?: Json;
+      contentDisposition?: ContentDisposition;
+    },
   ) {
     guardServerOnly();
-    incompatibleNodeGuard();
 
     const filesToUpload: FileEsque[] = Array.isArray(files) ? files : [files];
 
     const uploads = await uploadFilesInternal(
       {
         files: filesToUpload,
-        metadata,
-        contentDisposition,
+        metadata: opts.metadata ?? {},
+        contentDisposition: opts.contentDisposition ?? "inline",
       },
       {
         fetch: this.fetch,
@@ -135,16 +133,17 @@ export class UTApi {
    */
   async uploadFilesFromUrl<T extends MaybeUrl | MaybeUrl[]>(
     urls: T,
-    // FIXME: config option in v6 instead of positional args
-    metadata: Json = {},
-    contentDisposition: ContentDisposition = "inline",
+    opts: {
+      metadata: Json;
+      contentDisposition: ContentDisposition;
+    },
   ) {
     guardServerOnly();
 
     const fileUrls: MaybeUrl[] = Array.isArray(urls) ? urls : [urls];
 
     const formData = new FormData();
-    formData.append("metadata", JSON.stringify(metadata));
+    formData.append("metadata", JSON.stringify(opts.metadata ?? {}));
 
     const filesToUpload = await Promise.all(
       fileUrls.map(async (url) => {
@@ -168,8 +167,8 @@ export class UTApi {
     const uploads = await uploadFilesInternal(
       {
         files: filesToUpload,
-        metadata,
-        contentDisposition,
+        metadata: opts.metadata ?? {},
+        contentDisposition: opts.contentDisposition ?? "inline",
       },
       {
         fetch: this.fetch,
@@ -220,7 +219,6 @@ export class UTApi {
    */
   async getFileUrls(fileKeys: string[] | string) {
     guardServerOnly();
-    incompatibleNodeGuard();
 
     if (!Array.isArray(fileKeys)) fileKeys = [fileKeys];
 
@@ -244,7 +242,6 @@ export class UTApi {
    */
   async listFiles() {
     guardServerOnly();
-    incompatibleNodeGuard();
 
     // TODO: Implement filtering and pagination
     const json = await this.requestUploadThing<{
@@ -270,7 +267,6 @@ export class UTApi {
         }[],
   ) {
     guardServerOnly();
-    incompatibleNodeGuard();
 
     if (!Array.isArray(updates)) updates = [updates];
 
@@ -283,7 +279,6 @@ export class UTApi {
 
   async getUsageInfo() {
     guardServerOnly();
-    incompatibleNodeGuard();
 
     return this.requestUploadThing<{
       totalBytes: number;

--- a/packages/uploadthing/src/sdk/sdk.test.ts
+++ b/packages/uploadthing/src/sdk/sdk.test.ts
@@ -3,7 +3,7 @@ import { describe, expectTypeOf, test } from "vitest";
 import { UTApi } from ".";
 import type { UploadError } from "./utils";
 
-const utapi = new UTApi();
+const utapi = new UTApi({ apiKey: "foo" });
 
 async function ignoreErrors<T>(fn: () => T | Promise<T>) {
   try {

--- a/packages/uploadthing/src/sdk/sdk.test.ts
+++ b/packages/uploadthing/src/sdk/sdk.test.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, test } from "vitest";
+import { describe, expect, expectTypeOf, test } from "vitest";
 
 import { UTApi } from ".";
 import type { UploadError } from "./utils";
@@ -58,5 +58,20 @@ describe("uploadFilesFromUrl", () => {
         | { data: null; error: UploadError }
       >(result);
     });
+  });
+});
+
+describe("constructor throws if no apiKey or secret is set", () => {
+  test("no secret or apikey", () => {
+    expect(() => new UTApi()).toThrowErrorMatchingInlineSnapshot(
+      '"Missing `UPLOADTHING_SECRET` env variable."',
+    );
+  });
+  test("env is set", () => {
+    process.env.UPLOADTHING_SECRET = "foo";
+    expect(() => new UTApi()).not.toThrow();
+  });
+  test("apikey option is passed", () => {
+    expect(() => new UTApi({ apiKey: "foobar" })).not.toThrow();
   });
 });

--- a/packages/uploadthing/src/server.ts
+++ b/packages/uploadthing/src/server.ts
@@ -16,7 +16,7 @@ import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
 
 export * from "./internal/types";
-export { utapi, UTApi } from "./sdk";
+export { UTApi } from "./sdk";
 
 export const createUploadthing = <TErrorShape extends Json>(
   opts?: CreateBuilderOptions<TErrorShape>,


### PR DESCRIPTION
remove deprecated `utapi` object in favor of initializing with constructor