### PR TITLE
fix: smarter URL detection

### DIFF
--- a/docs/src/pages/api-reference/next.mdx
+++ b/docs/src/pages/api-reference/next.mdx
@@ -23,10 +23,11 @@ programmatically set your UploadThing credentials. If you do not specify a
 `config` we will use the `UPLOADTHING_SECRET` and `UPLOADTHING_APP_ID`
 environment variables.
 
-|        Key        |  Type  | Required | Notes |             Description              |
-| :---------------: | :----: | :------: | :---: | :----------------------------------: |
-|   uploadthingId   | string |    No    |       | The App ID for your uploadthing app  |
-| uploadthingSecret | string |    No    |       | The API key for your uploadthing app |
+|        Key        |  Type  | Required | Notes |                             Description                             |
+| :---------------: | :----: | :------: | :---: | :-----------------------------------------------------------------: |
+|   uploadthingId   | string |    No    |       |                 The App ID for your uploadthing app                 |
+| uploadthingSecret | string |    No    |       |                The API key for your uploadthing app                 |
+|    callbackUrl    | string |    No    |       | Custom callback URL to use instead of `<BASE_URL>/api/uploadthing`. |
 
 <Callout type="info">
   **Note:** This same configuration object is also available for the

--- a/docs/src/pages/faq.mdx
+++ b/docs/src/pages/faq.mdx
@@ -78,3 +78,6 @@ setups. In this case, set either
 - [`config.callbackUrl`](/api-reference/next#config-object) when you're creating
   the server entrypoints
 - `UPLOADTHING_URL` environment variable to the correct URL.
+
+You will get a warning in the console if we detect a localhost URL is being used
+as the callback URL in production.

--- a/docs/src/pages/faq.mdx
+++ b/docs/src/pages/faq.mdx
@@ -73,11 +73,10 @@ to expose your application to the internet. Start the application with the
 #### Your app is running behind a reverse proxy such as Nginx.
 
 The automatic URL inference unfortunately breaks for certain reverse proxy
-setups. In this case, set either
-
-- [`config.callbackUrl`](/api-reference/next#config-object) when you're creating
-  the server entrypoints
-- `UPLOADTHING_URL` environment variable to the correct URL.
+setups. In this case, set either the
+[`config.callbackUrl`](/api-reference/next#config-object) when you're creating
+the server entrypoints or the `UPLOADTHING_URL` environment variable to the
+public URL of your application.
 
 You will get a warning in the console if we detect a localhost URL is being used
 as the callback URL in production.

--- a/docs/src/pages/faq.mdx
+++ b/docs/src/pages/faq.mdx
@@ -50,3 +50,31 @@ import type { OurFileRouter } from "~/app/api/uploadthing/core";
 As you can see, it's quite cumbersome having to provide the generics yourself,
 especially since the `endpoint` prop must be specified twice due to lack of
 partial inference in TypeScript.
+
+### My callback runs in development but not in production
+
+In order for UploadThing to work, our external server have to be able to reach
+your application in order to trigger the callbacks you have set up in your file
+router. This is not possible if your application is running on localhost.
+
+When you're running in development, UploadThing will simulate this callback for
+you so that you can test your application. However, for production we require
+your application to be reachable over the internet. The URL we'll attempt to hit
+is automatically inferred based on the request. There are mainly two reasons why
+your app would not be reachable by the callback:
+
+#### You're testing a production build locally.
+
+In this case, you can use a tool like [ngrok](https://ngrok.com/) or
+[Cloudflare Tunnels](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/get-started/create-remote-tunnel/)
+to expose your application to the internet. Start the application with the
+`UPLOADTHING_URL` variable set to the tunneled URL.
+
+#### Your app is running behind a reverse proxy such as Nginx.
+
+The automatic URL inference unfortunately breaks for certain reverse proxy
+setups. In this case, set either
+
+- [`config.callbackUrl`](/api-reference/next#config-object) when you're creating
+  the server entrypoints
+- `UPLOADTHING_URL` environment variable to the correct URL.

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -4,6 +4,7 @@ import {
   withExponentialBackoff,
 } from "@uploadthing/shared";
 
+import { getFullApiUrl } from "./internal/get-full-api-url";
 import type { UploadThingResponse } from "./internal/handler";
 import { uploadPartWithProgress } from "./internal/multi-part";
 import type {
@@ -282,38 +283,4 @@ export const generateClientDropzoneAccept = (fileTypes: string[]) => {
   return Object.fromEntries(mimeTypes.map((type) => [type, []]));
 };
 
-// Returns a full URL to the dev's uploadthing endpoint
-export function getFullApiUrl(maybeUrl?: string): URL {
-  const base = (() => {
-    if (typeof window !== "undefined") {
-      return window.location.origin;
-    }
-
-    // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
-    if (typeof process !== "undefined" && process?.env?.VERCEL_URL) {
-      return `https://${process.env.VERCEL_URL}`;
-    }
-
-    // @ts-expect-error - import meta is not defined in node
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    if (import.meta.env?.VERCEL_URL) {
-      // @ts-expect-error - import meta is not defined in node
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      return `https://${import.meta.env.VERCEL_URL}`;
-    }
-
-    return "http://localhost:3000";
-  })();
-
-  try {
-    const url = new URL(maybeUrl ?? "/api/uploadthing", base);
-    if (url.pathname === "/") {
-      url.pathname = "/api/uploadthing";
-    }
-    return url;
-  } catch (err) {
-    throw new Error(
-      `Failed to parse '${maybeUrl}' as a URL. Make sure it's a valid URL or path`,
-    );
-  }
-}
+export { getFullApiUrl };

--- a/packages/uploadthing/src/internal/get-full-api-url.ts
+++ b/packages/uploadthing/src/internal/get-full-api-url.ts
@@ -1,0 +1,40 @@
+/*
+ * Returns a full URL to the dev's uploadthing endpoint
+ * Can take either an origin, or a pathname, or a full URL
+ * and will return the "closest" url matching the default
+ * `<VERCEL_URL || localhost>/api/uploadthing`
+ */
+export function getFullApiUrl(maybeUrl?: string): URL {
+  const base = (() => {
+    if (typeof window !== "undefined") {
+      return window.location.origin;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/prefer-optional-chain
+    if (typeof process !== "undefined" && process?.env?.VERCEL_URL) {
+      return `https://${process.env.VERCEL_URL}`;
+    }
+
+    // @ts-expect-error - import meta is not defined in node
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    if (import.meta.env?.VERCEL_URL) {
+      // @ts-expect-error - import meta is not defined in node
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      return `https://${import.meta.env.VERCEL_URL}`;
+    }
+
+    return "http://localhost:3000";
+  })();
+
+  try {
+    const url = new URL(maybeUrl ?? "/api/uploadthing", base);
+    if (url.pathname === "/") {
+      url.pathname = "/api/uploadthing";
+    }
+    return url;
+  } catch (err) {
+    throw new Error(
+      `Failed to parse '${maybeUrl}' as a URL. Make sure it's a valid URL or path`,
+    );
+  }
+}

--- a/packages/uploadthing/test/get-full-url.test.ts
+++ b/packages/uploadthing/test/get-full-url.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { getFullApiUrl } from "../src/client";
+import { getFullApiUrl } from "../src/internal/get-full-api-url";
 
 describe("getFullApiUrl", () => {
   it("should return the provided url if it is already absolute", () => {


### PR DESCRIPTION
un-deprecated `config.callbackUrl` as it could be useful for some edge cases when we can't autodetect the URL.

makes the parsing of both `process.env.UPLOADTHING_URL` and `config.callbackUrl` smarter to handle relative, host and full URL strings.
