### PR TITLE
fix: @uploadthing/react peer deps

### DIFF
--- a/.changeset/warm-balloons-decide.md
+++ b/.changeset/warm-balloons-decide.md
@@ -1,0 +1,5 @@
+---
+"@uploadthing/react": patch
+---
+
+fix: @uploadthing/react peer deps

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -50,7 +50,7 @@
     "tailwind-merge": "^1.13.2"
   },
   "peerDependencies": {
-    "next": "14.0.1",
+    "next": "*",
     "react": "^17.0.2 || ^18.0.0",
     "uploadthing": "^6.0.0"
   },


### PR DESCRIPTION
Technically >=13 is required for SSR plugin, but if you don't use that, older versions are allowed.

closes #490 