### PR TITLE
fix(upload): URI encode filenames in content-disposition header

### DIFF
--- a/.changeset/good-news-travel.md
+++ b/.changeset/good-news-travel.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+fix(upload): URI encode filenames in content-disposition header to handle non-standard characters

--- a/packages/uploadthing/src/internal/multi-part.ts
+++ b/packages/uploadthing/src/internal/multi-part.ts
@@ -28,8 +28,8 @@ export async function uploadPart(
       "Content-Type": opts.contentType,
       "Content-Disposition": [
         opts.contentDisposition,
-        `filename="${opts.fileName}"`,
-        `filename*=UTF-8''${opts.fileName}`,
+        `filename="${encodeURI(opts.fileName)}"`,
+        `filename*=UTF-8''${encodeURI(opts.fileName)}`,
       ].join("; "),
     },
   });
@@ -101,8 +101,8 @@ export async function uploadPartWithProgress(
       "Content-Disposition",
       [
         opts.contentDisposition,
-        `filename="${opts.fileName}"`,
-        `filename*=UTF-8''${opts.fileName}`,
+        `filename="${encodeURI(opts.fileName)}"`,
+        `filename*=UTF-8''${encodeURI(opts.fileName)}`,
       ].join("; "),
     );
 


### PR DESCRIPTION
Closes #494, #505
