### PR TITLE
docs(examples): log cause in examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug-report-pkgs.yml
+++ b/.github/ISSUE_TEMPLATE/1.bug-report-pkgs.yml
@@ -8,6 +8,23 @@ body:
       value: |
         Thanks for taking the time to file a bug report! Please fill out this form as completely as possible.
         Note that the more precise you are, the quicker we will be able to investigate the bug.
+
+        When filing a bug report, we would much appreciate it if you could provide any additional error information by creating an error formatter that logs out the `error.cause`:
+
+        ```ts
+        const f = createUploadthing({
+          /**
+           * Log out more information about the error, but don't return it to the client
+           * @see https://docs.uploadthing.com/errors#error-formatting
+           */
+          errorFormatter: (err) => {
+            console.log("Error uploading file", err.message);
+            console.log("  - Above error caused by:", err.cause);
+
+            return { message: err.message };
+          },
+        });
+        ```
   - type: textarea
     attributes:
       label: Provide environment information

--- a/examples/backend-adapters/server/src/router.ts
+++ b/examples/backend-adapters/server/src/router.ts
@@ -1,7 +1,22 @@
 import { createUploadthing, type FileRouter } from "uploadthing/server";
 
-const f = createUploadthing();
+const f = createUploadthing({
+  /**
+   * Log out more information about the error, but don't return it to the client
+   * @see https://docs.uploadthing.com/errors#error-formatting
+   */
+  errorFormatter: (err) => {
+    console.log("Error uploading file", err.message);
+    console.log("  - Above error caused by:", err.cause);
 
+    return { message: err.message };
+  },
+});
+
+/**
+ * This is your Uploadthing file router. For more information:
+ * @see https://docs.uploadthing.com/api-reference/server#file-routes
+ */
 export const uploadRouter = {
   videoAndImage: f({
     image: {

--- a/examples/minimal-appdir/src/server/uploadthing.ts
+++ b/examples/minimal-appdir/src/server/uploadthing.ts
@@ -1,12 +1,23 @@
 import { createUploadthing } from "uploadthing/next";
 import type { FileRouter } from "uploadthing/next";
 
-const f = createUploadthing();
+const f = createUploadthing({
+  /**
+   * Log out more information about the error, but don't return it to the client
+   * @see https://docs.uploadthing.com/errors#error-formatting
+   */
+  errorFormatter: (err) => {
+    console.log("Error uploading file", err.message);
+    console.log("  - Above error caused by:", err.cause);
+
+    return { message: err.message };
+  },
+});
+
 /**
  * This is your Uploadthing file router. For more information:
  * @see https://docs.uploadthing.com/api-reference/server#file-routes
  */
-
 export const uploadRouter = {
   videoAndImage: f({
     image: {

--- a/examples/minimal-astro-react/src/server/uploadthing.ts
+++ b/examples/minimal-astro-react/src/server/uploadthing.ts
@@ -1,8 +1,23 @@
 import { createUploadthing } from "uploadthing/server";
 import type { FileRouter } from "uploadthing/server";
 
-const f = createUploadthing();
+const f = createUploadthing({
+  /**
+   * Log out more information about the error, but don't return it to the client
+   * @see https://docs.uploadthing.com/errors#error-formatting
+   */
+  errorFormatter: (err) => {
+    console.log("Error uploading file", err.message);
+    console.log("  - Above error caused by:", err.cause);
 
+    return { message: err.message };
+  },
+});
+
+/**
+ * This is your Uploadthing file router. For more information:
+ * @see https://docs.uploadthing.com/api-reference/server#file-routes
+ */
 export const uploadRouter = {
   videoAndImage: f({
     image: {

--- a/examples/minimal-pagedir/src/server/uploadthing.ts
+++ b/examples/minimal-pagedir/src/server/uploadthing.ts
@@ -1,12 +1,23 @@
 import { createUploadthing } from "uploadthing/next-legacy";
 import type { FileRouter } from "uploadthing/next-legacy";
 
-const f = createUploadthing();
+const f = createUploadthing({
+  /**
+   * Log out more information about the error, but don't return it to the client
+   * @see https://docs.uploadthing.com/errors#error-formatting
+   */
+  errorFormatter: (err) => {
+    console.log("Error uploading file", err.message);
+    console.log("  - Above error caused by:", err.cause);
+
+    return { message: err.message };
+  },
+});
+
 /**
  * This is your Uploadthing file router. For more information:
  * @see https://docs.uploadthing.com/api-reference/server#file-routes
  */
-
 export const uploadRouter = {
   videoAndImage: f({
     image: {

--- a/examples/minimal-solidstart/src/server/uploadthing.ts
+++ b/examples/minimal-solidstart/src/server/uploadthing.ts
@@ -1,13 +1,23 @@
 import { createUploadthing } from "uploadthing/server";
 import type { FileRouter } from "uploadthing/server";
 
-const f = createUploadthing();
+const f = createUploadthing({
+  /**
+   * Log out more information about the error, but don't return it to the client
+   * @see https://docs.uploadthing.com/errors#error-formatting
+   */
+  errorFormatter: (err) => {
+    console.log("Error uploading file", err.message);
+    console.log("  - Above error caused by:", err.cause);
+
+    return { message: err.message };
+  },
+});
 
 /**
  * This is your Uploadthing file router. For more information:
  * @see https://docs.uploadthing.com/api-reference/server#file-routes
  */
-
 export const uploadRouter = {
   videoAndImage: f({
     image: {

--- a/examples/with-clerk-appdir/src/server/uploadthing.ts
+++ b/examples/with-clerk-appdir/src/server/uploadthing.ts
@@ -3,12 +3,23 @@ import { auth } from "@clerk/nextjs";
 import { createUploadthing } from "uploadthing/next";
 import type { FileRouter } from "uploadthing/next";
 
-const f = createUploadthing();
+const f = createUploadthing({
+  /**
+   * Log out more information about the error, but don't return it to the client
+   * @see https://docs.uploadthing.com/errors#error-formatting
+   */
+  errorFormatter: (err) => {
+    console.log("Error uploading file", err.message);
+    console.log("  - Above error caused by:", err.cause);
+
+    return { message: err.message };
+  },
+});
+
 /**
  * This is your Uploadthing file router. For more information:
  * @see https://docs.uploadthing.com/api-reference/server#file-routes
  */
-
 export const uploadRouter = {
   videoAndImage: f({
     image: {

--- a/examples/with-clerk-pagesdir/src/server/uploadthing.ts
+++ b/examples/with-clerk-pagesdir/src/server/uploadthing.ts
@@ -3,12 +3,23 @@ import { getAuth } from "@clerk/nextjs/server";
 import { createUploadthing } from "uploadthing/next";
 import type { FileRouter } from "uploadthing/next";
 
-const f = createUploadthing();
+const f = createUploadthing({
+  /**
+   * Log out more information about the error, but don't return it to the client
+   * @see https://docs.uploadthing.com/errors#error-formatting
+   */
+  errorFormatter: (err) => {
+    console.log("Error uploading file", err.message);
+    console.log("  - Above error caused by:", err.cause);
+
+    return { message: err.message };
+  },
+});
+
 /**
  * This is your Uploadthing file router. For more information:
  * @see https://docs.uploadthing.com/api-reference/server#file-routes
  */
-
 export const uploadRouter = {
   videoAndImage: f({
     image: {

--- a/examples/with-drizzle-appdir/src/server/uploadthing.ts
+++ b/examples/with-drizzle-appdir/src/server/uploadthing.ts
@@ -6,7 +6,19 @@ import type { FileRouter } from "uploadthing/next";
 import { db } from "~/server/db";
 import { files } from "./db/schema";
 
-const f = createUploadthing();
+const f = createUploadthing({
+  /**
+   * Log out more information about the error, but don't return it to the client
+   * @see https://docs.uploadthing.com/errors#error-formatting
+   */
+  errorFormatter: (err) => {
+    console.log("Error uploading file", err.message);
+    console.log("  - Above error caused by:", err.cause);
+
+    return { message: err.message };
+  },
+});
+
 /**
  * This is your Uploadthing file router. For more information:
  * @see https://docs.uploadthing.com/api-reference/server#file-routes

--- a/examples/with-drizzle-pagesdir/src/server/uploadthing.ts
+++ b/examples/with-drizzle-pagesdir/src/server/uploadthing.ts
@@ -4,7 +4,19 @@ import type { FileRouter } from "uploadthing/next";
 import { db } from "~/server/db";
 import { files } from "./db/schema";
 
-const f = createUploadthing();
+const f = createUploadthing({
+  /**
+   * Log out more information about the error, but don't return it to the client
+   * @see https://docs.uploadthing.com/errors#error-formatting
+   */
+  errorFormatter: (err) => {
+    console.log("Error uploading file", err.message);
+    console.log("  - Above error caused by:", err.cause);
+
+    return { message: err.message };
+  },
+});
+
 /**
  * This is your Uploadthing file router. For more information:
  * @see https://docs.uploadthing.com/api-reference/server#file-routes

--- a/examples/with-react-image-crop/src/server/uploadthing.ts
+++ b/examples/with-react-image-crop/src/server/uploadthing.ts
@@ -1,12 +1,23 @@
 import { createUploadthing } from "uploadthing/next";
 import type { FileRouter } from "uploadthing/next";
 
-const f = createUploadthing();
+const f = createUploadthing({
+  /**
+   * Log out more information about the error, but don't return it to the client
+   * @see https://docs.uploadthing.com/errors#error-formatting
+   */
+  errorFormatter: (err) => {
+    console.log("Error uploading file", err.message);
+    console.log("  - Above error caused by:", err.cause);
+
+    return { message: err.message };
+  },
+});
+
 /**
  * This is your Uploadthing file router. For more information:
  * @see https://docs.uploadthing.com/api-reference/server#file-routes
  */
-
 export const uploadRouter = {
   proileImage: f({
     image: {

--- a/examples/with-tailwindcss/src/server/uploadthing.ts
+++ b/examples/with-tailwindcss/src/server/uploadthing.ts
@@ -1,12 +1,23 @@
 import { createUploadthing } from "uploadthing/next";
 import type { FileRouter } from "uploadthing/next";
 
-const f = createUploadthing();
+const f = createUploadthing({
+  /**
+   * Log out more information about the error, but don't return it to the client
+   * @see https://docs.uploadthing.com/errors#error-formatting
+   */
+  errorFormatter: (err) => {
+    console.log("Error uploading file", err.message);
+    console.log("  - Above error caused by:", err.cause);
+
+    return { message: err.message };
+  },
+});
+
 /**
  * This is your Uploadthing file router. For more information:
  * @see https://docs.uploadthing.com/api-reference/server#file-routes
  */
-
 export const uploadRouter = {
   videoAndImage: f({
     image: {


### PR DESCRIPTION
Includes logging the error.cause in the examples, should hopefuly assist when requesting debug logs when digging into issues