### PR TITLE
feat: logger for serverside stuff

### DIFF
--- a/.changeset/gorgeous-icons-dress.md
+++ b/.changeset/gorgeous-icons-dress.md
@@ -1,0 +1,6 @@
+---
+"uploadthing": minor
+"@uploadthing/shared": minor
+---
+
+feat: add `logLevel` option to enable more verbose logging

--- a/examples/minimal-appdir/src/app/api/uploadthing/route.ts
+++ b/examples/minimal-appdir/src/app/api/uploadthing/route.ts
@@ -7,4 +7,7 @@ import { uploadRouter } from "~/server/uploadthing";
 
 export const { GET, POST } = createNextRouteHandler({
   router: uploadRouter,
+  config: {
+    logLevel: "debug",
+  },
 });

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -45,7 +45,7 @@ function messageFromUnknown(cause: unknown, fallback?: string) {
 export class UploadThingError<
   TShape extends Json = { message: string },
 > extends Error {
-  public readonly cause?: Error;
+  public readonly cause?: unknown;
   public readonly code: ErrorCode;
   public readonly data?: TShape;
 
@@ -70,7 +70,7 @@ export class UploadThingError<
     } else if (typeof opts.cause === "string") {
       this.cause = new Error(opts.cause);
     } else {
-      this.cause = undefined;
+      this.cause = opts.cause;
     }
   }
 

--- a/packages/uploadthing/package.json
+++ b/packages/uploadthing/package.json
@@ -93,7 +93,8 @@
   },
   "dependencies": {
     "@uploadthing/mime-types": "^0.2.2",
-    "@uploadthing/shared": "^6.0.3"
+    "@uploadthing/shared": "^6.0.3",
+    "consola": "^3.2.3"
   },
   "devDependencies": {
     "@types/express": "^4.17.17",
@@ -119,6 +120,9 @@
     "root": true,
     "extends": [
       "@uploadthing/eslint-config/base"
-    ]
+    ],
+    "rules": {
+      "no-console": "error"
+    }
   }
 }

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -1,3 +1,6 @@
+// Don't want to ship our logger to the client, keep size down
+/* eslint-disable no-console */
+
 import {
   safeParseJSON,
   UploadThingError,

--- a/packages/uploadthing/src/express.ts
+++ b/packages/uploadthing/src/express.ts
@@ -15,6 +15,7 @@ import {
   buildRequestHandler,
 } from "./internal/handler";
 import { incompatibleNodeGuard } from "./internal/incompat-node-guard";
+import { initLogger } from "./internal/logger";
 import { getPostBody } from "./internal/node-http/getBody";
 import type { FileRouter } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
@@ -33,8 +34,11 @@ export const createUploadthing = <TErrorShape extends Json>(
 export const createUploadthingExpressHandler = <TRouter extends FileRouter>(
   opts: RouterWithConfig<TRouter>,
 ): ExpressRouter => {
+  initLogger(opts.config?.logLevel);
   incompatibleNodeGuard();
+
   const requestHandler = buildRequestHandler<TRouter>(opts);
+  const getBuildPerms = buildPermissionsInfoHandler<TRouter>(opts);
   const router = ExpressRouter();
 
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
@@ -88,8 +92,6 @@ export const createUploadthingExpressHandler = <TRouter extends FileRouter>(
     res.setHeader("x-uploadthing-version", UPLOADTHING_VERSION);
     res.send(JSON.stringify(response.body));
   });
-
-  const getBuildPerms = buildPermissionsInfoHandler<TRouter>(opts);
 
   router.get("/", (_req, res) => {
     res.status(200);

--- a/packages/uploadthing/src/fastify.ts
+++ b/packages/uploadthing/src/fastify.ts
@@ -16,6 +16,7 @@ import {
   buildRequestHandler,
 } from "./internal/handler";
 import { incompatibleNodeGuard } from "./internal/incompat-node-guard";
+import { initLogger } from "./internal/logger";
 import type { FileRouter } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
@@ -35,8 +36,11 @@ export const fastifyUploadthingPlugin = <TRouter extends FileRouter>(
   opts: RouterWithConfig<TRouter>,
   done: (err?: Error) => void,
 ) => {
+  initLogger(opts.config?.logLevel);
   incompatibleNodeGuard();
+
   const requestHandler = buildRequestHandler<TRouter>(opts);
+  const getBuildPerms = buildPermissionsInfoHandler<TRouter>(opts);
 
   const POST: RouteHandlerMethod = async (req, res) => {
     const proto = (req.headers["x-forwarded-proto"] as string) ?? "http";
@@ -78,8 +82,6 @@ export const fastifyUploadthingPlugin = <TRouter extends FileRouter>(
       })
       .send(response.body);
   };
-
-  const getBuildPerms = buildPermissionsInfoHandler<TRouter>(opts);
 
   const GET: RouteHandlerMethod = async (req, res) => {
     void res

--- a/packages/uploadthing/src/h3.ts
+++ b/packages/uploadthing/src/h3.ts
@@ -19,6 +19,8 @@ import {
   buildRequestHandler,
 } from "./internal/handler";
 import type { RouterWithConfig } from "./internal/handler";
+import { incompatibleNodeGuard } from "./internal/incompat-node-guard";
+import { initLogger } from "./internal/logger";
 import type { FileRouter } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
@@ -36,6 +38,9 @@ export const createUploadthing = <TErrorShape extends Json>(
 export const createH3EventHandler = <TRouter extends FileRouter>(
   opts: RouterWithConfig<TRouter>,
 ) => {
+  initLogger(opts.config?.logLevel);
+  incompatibleNodeGuard();
+
   const requestHandler = buildRequestHandler(opts);
   const getBuildPerms = buildPermissionsInfoHandler<TRouter>(opts);
 

--- a/packages/uploadthing/src/internal/dev-hook.ts
+++ b/packages/uploadthing/src/internal/dev-hook.ts
@@ -6,6 +6,7 @@ import {
 import type { FileData } from "@uploadthing/shared";
 
 import { UPLOADTHING_VERSION } from "../constants";
+import { logger } from "./logger";
 
 const isValidResponse = (response: Response) => {
   if (!response.ok) return false;
@@ -34,7 +35,7 @@ export const conditionalDevServer = async (opts: {
       if (!callbackUrl.startsWith("http"))
         callbackUrl = "http://" + callbackUrl;
 
-      console.log("[UT] SIMULATING FILE UPLOAD WEBHOOK CALLBACK", callbackUrl);
+      logger.info("SIMULATING FILE UPLOAD WEBHOOK CALLBACK", callbackUrl);
 
       const response = await fetch(callbackUrl, {
         method: "POST",
@@ -53,13 +54,13 @@ export const conditionalDevServer = async (opts: {
         },
       });
       if (isValidResponse(response)) {
-        console.log(
-          "[UT] Successfully simulated callback for file",
+        logger.success(
+          "Successfully simulated callback for file",
           opts.fileKey,
         );
       } else {
-        console.error(
-          "[UT] Failed to simulate callback for file. Is your webhook configured correctly?",
+        logger.error(
+          "Failed to simulate callback for file. Is your webhook configured correctly?",
           opts.fileKey,
         );
       }
@@ -69,7 +70,7 @@ export const conditionalDevServer = async (opts: {
 
   if (fileData !== undefined) return fileData;
 
-  console.error(`[UT] Failed to simulate callback for file ${opts.fileKey}`);
+  logger.error(`Failed to simulate callback for file ${opts.fileKey}`);
   throw new UploadThingError({
     code: "UPLOAD_FAILED",
     message: "File took too long to upload",

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -20,6 +20,7 @@ import type {
 import { UPLOADTHING_VERSION } from "../constants";
 import { conditionalDevServer } from "./dev-hook";
 import { getFullApiUrl } from "./get-full-api-url";
+import type { LogLevel } from "./logger";
 import { logger } from "./logger";
 import { getParseFn } from "./parser";
 import { VALID_ACTION_TYPES } from "./types";
@@ -85,6 +86,7 @@ const fileCountLimitHit = (
 export type RouterWithConfig<TRouter extends FileRouter> = {
   router: TRouter;
   config?: {
+    logLevel?: LogLevel;
     callbackUrl?: string;
     uploadthingId?: string;
     uploadthingSecret?: string;

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -261,7 +261,7 @@ export const buildRequestHandler = <TRouter extends FileRouter>(
       // This would either be someone spamming or the AWS webhook
       const msg = `Expected ${VALID_ACTION_TYPES.map((x) => `"${x}"`)
         .join(", ")
-        .replace(/,(?!.*,)/, " or")} but got "${"a"}"`;
+        .replace(/,(?!.*,)/, " or")} but got "${actionType}"`;
       logger.error("Invalid action type.", msg);
       return new UploadThingError({
         code: "BAD_REQUEST",

--- a/packages/uploadthing/src/internal/incompat-node-guard.ts
+++ b/packages/uploadthing/src/internal/incompat-node-guard.ts
@@ -28,7 +28,7 @@ export function incompatibleNodeGuard() {
   if (major > 18) return;
   if (major === 18 && minor >= 13) return;
 
-  logger.error(
+  logger.fatal(
     `YOU ARE USING A LEGACY (${major}.${minor}) NODE VERSION WHICH ISN'T OFFICIALLY SUPPORTED. PLEASE UPGRADE TO NODE ^18.13.`,
   );
   process.exit(1); // Kill the process if it isn't going to work correctly anyway

--- a/packages/uploadthing/src/internal/incompat-node-guard.ts
+++ b/packages/uploadthing/src/internal/incompat-node-guard.ts
@@ -1,3 +1,5 @@
+import { logger } from "./logger";
+
 export function incompatibleNodeGuard() {
   if (typeof process === "undefined") return;
 
@@ -26,8 +28,8 @@ export function incompatibleNodeGuard() {
   if (major > 18) return;
   if (major === 18 && minor >= 13) return;
 
-  console.error(
-    `[UT]: YOU ARE USING A LEGACY (${major}.${minor}) NODE VERSION WHICH ISN'T OFFICIALLY SUPPORTED. PLEASE UPGRADE TO NODE ^18.13.`,
+  logger.error(
+    `YOU ARE USING A LEGACY (${major}.${minor}) NODE VERSION WHICH ISN'T OFFICIALLY SUPPORTED. PLEASE UPGRADE TO NODE ^18.13.`,
   );
   process.exit(1); // Kill the process if it isn't going to work correctly anyway
 }

--- a/packages/uploadthing/src/internal/logger.ts
+++ b/packages/uploadthing/src/internal/logger.ts
@@ -12,18 +12,18 @@ const colorize = (str: string, level: LogType) => {
   switch (level) {
     case "error":
     case "fatal":
-      return `\x1b[31m${str}\x1b[0m`;
+      return `\x1b[41m\x1b[97m${str}\x1b[0m`; // Red background with white text
     case "warn":
-      return `\x1b[33m${str}\x1b[0m`;
+      return `\x1b[43m\x1b[30m${str}\x1b[0m`; // Yellow background with black text
     case "info":
     case "log":
-      return `\x1b[34m${str}\x1b[0m`;
+      return `\x1b[44m\x1b[97m${str}\x1b[0m`; // Blue background with white text
     case "debug":
-      return `\x1b[35m${str}\x1b[0m`;
+      return `\x1b[45m\x1b[97m${str}\x1b[0m`; // Magenta background with white text
     case "trace":
-      return `\x1b[36m${str}\x1b[0m`;
+      return `\x1b[46m\x1b[30m${str}\x1b[0m`; // Cyan background with black text
     case "success":
-      return `\x1b[32m${str}\x1b[0m`;
+      return `\x1b[42m\x1b[30m${str}\x1b[0m`; // Green background with black text
     default:
       return str;
   }
@@ -107,7 +107,7 @@ export const logger = createConsola({
 });
 
 export const initLogger = (level: LogLevel | undefined) => {
-  logger.wrapConsole();
+  // logger.wrapConsole();
   logger.level = LogLevels[level ?? "info"];
   logger.info("Set log level", { level: logger.level });
 };

--- a/packages/uploadthing/src/internal/logger.ts
+++ b/packages/uploadthing/src/internal/logger.ts
@@ -102,7 +102,8 @@ export const logger = createConsola({
   },
 });
 
-export const setLogLevel = (level: LogLevel = "info") => {
-  logger.level = LogLevels[level];
+export const initLogger = (level: LogLevel | undefined) => {
+  logger.wrapConsole();
+  logger.level = LogLevels[level ?? "info"];
   logger.info("Set log level", { level: logger.level });
 };

--- a/packages/uploadthing/src/internal/logger.ts
+++ b/packages/uploadthing/src/internal/logger.ts
@@ -28,9 +28,11 @@ const colorize = (str: string, level: LogType) => {
 };
 
 const icons: { [t in LogType]?: string } = {
+  fatal: "⨯",
   error: "⨯",
   warn: "⚠️",
   info: "ℹ",
+  log: "ℹ",
   debug: "⚙",
   trace: "→",
   success: "✓",

--- a/packages/uploadthing/src/internal/logger.ts
+++ b/packages/uploadthing/src/internal/logger.ts
@@ -1,0 +1,108 @@
+import { inspect } from "node:util";
+import type { LogObject, LogType } from "consola/core";
+import { createConsola, LogLevels } from "consola/core";
+
+import { isObject } from "@uploadthing/shared";
+
+export type LogLevel = "error" | "warn" | "info" | "debug" | "trace";
+
+const colorize = (str: string, level: LogType) => {
+  // TODO: Maybe check is shell supports colors
+
+  switch (level) {
+    case "error":
+      return `\x1b[31m${str}\x1b[0m`;
+    case "warn":
+      return `\x1b[33m${str}\x1b[0m`;
+    case "info":
+      return `\x1b[34m${str}\x1b[0m`;
+    case "debug":
+      return `\x1b[35m${str}\x1b[0m`;
+    case "trace":
+      return `\x1b[36m${str}\x1b[0m`;
+    case "success":
+      return `\x1b[32m${str}\x1b[0m`;
+    default:
+      return str;
+  }
+};
+
+const icons: { [t in LogType]?: string } = {
+  error: "⨯",
+  warn: "⚠️",
+  info: "ℹ",
+  debug: "⚙",
+  trace: "→",
+  success: "✓",
+};
+
+function formatStack(stack: string) {
+  return (
+    "  " +
+    stack
+      .split("\n")
+      .splice(1)
+      .map((l) =>
+        l
+          .trim()
+          .replace("file://", "")
+          .replace(process.cwd() + "/", ""),
+      )
+      .join("\n  ")
+  );
+}
+
+function formatArgs(args: any[]) {
+  const fmtArgs = args.map((arg) => {
+    if (isObject(arg) && typeof arg.stack === "string") {
+      return (arg.message as string) + "\n" + formatStack(arg.stack);
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return arg;
+  });
+
+  return fmtArgs.map((arg) => {
+    if (typeof arg === "string") {
+      return arg;
+    }
+    try {
+      // prefer inspect over JSON.stringify because it handles circular references, prints classes etc
+      return inspect(arg, { depth: 4 });
+    } catch {
+      // fallback to JSON.stringify if inspect fails e.g. if runtime doesn't have util module
+      return JSON.stringify(arg, null, 4);
+    }
+  });
+}
+
+export const logger = createConsola({
+  reporters: [
+    {
+      log: (logObj: LogObject) => {
+        const { type, tag, date, args } = logObj;
+        const icon = icons[type as LogLevel];
+
+        const logPrefix = colorize(
+          ` ${icon} ${tag} ${date.toLocaleTimeString()} `,
+          type as LogLevel,
+        );
+        const lines = formatArgs(args)
+          .join(" ") // concat all arguments to one space-separated string (like console does)
+          .split("\n") // split all the newlines (e.g. from logged JSON.stringified objects)
+          .map((l) => logPrefix + " " + l) // prepend the log prefix to each line
+          .join("\n"); // join all the lines back together
+
+        // eslint-disable-next-line no-console
+        console.log(lines);
+      },
+    },
+  ],
+  defaults: {
+    tag: "UPLOADTHING",
+  },
+});
+
+export const setLogLevel = (level: LogLevel = "info") => {
+  logger.level = LogLevels[level];
+  logger.info("Set log level", { level: logger.level });
+};

--- a/packages/uploadthing/src/internal/logger.ts
+++ b/packages/uploadthing/src/internal/logger.ts
@@ -11,10 +11,12 @@ const colorize = (str: string, level: LogType) => {
 
   switch (level) {
     case "error":
+    case "fatal":
       return `\x1b[31m${str}\x1b[0m`;
     case "warn":
       return `\x1b[33m${str}\x1b[0m`;
     case "info":
+    case "log":
       return `\x1b[34m${str}\x1b[0m`;
     case "debug":
       return `\x1b[35m${str}\x1b[0m`;

--- a/packages/uploadthing/src/internal/logger.ts
+++ b/packages/uploadthing/src/internal/logger.ts
@@ -19,9 +19,9 @@ const colorize = (str: string, level: LogType) => {
     case "log":
       return `\x1b[44m\x1b[30m${str}\x1b[0m`;
     case "debug":
-      return `\x1b[45m\x1b[30m${str}\x1b[0m`;
+      return `\x1b[47m\x1b[30m${str}\x1b[0m`;
     case "trace":
-      return `\x1b[46m\x1b[30m${str}\x1b[0m`;
+      return `\x1b[47m\x1b[30m${str}\x1b[0m`;
     case "success":
       return `\x1b[42m\x1b[30m${str}\x1b[0m`;
     default:

--- a/packages/uploadthing/src/internal/logger.ts
+++ b/packages/uploadthing/src/internal/logger.ts
@@ -12,18 +12,18 @@ const colorize = (str: string, level: LogType) => {
   switch (level) {
     case "error":
     case "fatal":
-      return `\x1b[41m\x1b[97m${str}\x1b[0m`; // Red background with white text
+      return `\x1b[41m\x1b[30m${str}\x1b[0m`;
     case "warn":
-      return `\x1b[43m\x1b[30m${str}\x1b[0m`; // Yellow background with black text
+      return `\x1b[43m\x1b[30m${str}\x1b[0m`;
     case "info":
     case "log":
-      return `\x1b[44m\x1b[97m${str}\x1b[0m`; // Blue background with white text
+      return `\x1b[44m\x1b[30m${str}\x1b[0m`;
     case "debug":
-      return `\x1b[45m\x1b[97m${str}\x1b[0m`; // Magenta background with white text
+      return `\x1b[45m\x1b[30m${str}\x1b[0m`;
     case "trace":
-      return `\x1b[46m\x1b[30m${str}\x1b[0m`; // Cyan background with black text
+      return `\x1b[46m\x1b[30m${str}\x1b[0m`;
     case "success":
-      return `\x1b[42m\x1b[30m${str}\x1b[0m`; // Green background with black text
+      return `\x1b[42m\x1b[30m${str}\x1b[0m`;
     default:
       return str;
   }

--- a/packages/uploadthing/src/next-legacy.ts
+++ b/packages/uploadthing/src/next-legacy.ts
@@ -13,6 +13,7 @@ import {
 } from "./internal/handler";
 import type { RouterWithConfig } from "./internal/handler";
 import { incompatibleNodeGuard } from "./internal/incompat-node-guard";
+import { initLogger } from "./internal/logger";
 import type { FileRouter } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
@@ -30,9 +31,10 @@ export const createUploadthing = <TErrorShape extends Json>(
 export const createNextPageApiHandler = <TRouter extends FileRouter>(
   opts: RouterWithConfig<TRouter>,
 ) => {
+  initLogger(opts.config?.logLevel);
   incompatibleNodeGuard();
-  const requestHandler = buildRequestHandler<TRouter>(opts);
 
+  const requestHandler = buildRequestHandler<TRouter>(opts);
   const getBuildPerms = buildPermissionsInfoHandler<TRouter>(opts);
 
   return async (req: NextApiRequest, res: NextApiResponse) => {

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -8,6 +8,7 @@ import { generateUploadThingURL, UploadThingError } from "@uploadthing/shared";
 
 import { UPLOADTHING_VERSION } from "../constants";
 import { incompatibleNodeGuard } from "../internal/incompat-node-guard";
+import { logger } from "../internal/logger";
 import type { FileEsque, UploadFileResponse } from "./utils";
 import {
   getApiKeyOrThrow,
@@ -62,7 +63,7 @@ export class UTApi {
 
     const json = await res.json<T | { error: string }>();
     if (!res.ok || "error" in json) {
-      console.error("[UT] Error:", json);
+      logger.error("Error:", json);
       throw new UploadThingError({
         code: "INTERNAL_SERVER_ERROR",
         message:

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -8,7 +8,8 @@ import { generateUploadThingURL, UploadThingError } from "@uploadthing/shared";
 
 import { UPLOADTHING_VERSION } from "../constants";
 import { incompatibleNodeGuard } from "../internal/incompat-node-guard";
-import { logger } from "../internal/logger";
+import type { LogLevel } from "../internal/logger";
+import { initLogger, logger } from "../internal/logger";
 import type { FileEsque, UploadFileResponse } from "./utils";
 import {
   getApiKeyOrThrow,
@@ -27,6 +28,10 @@ export interface UTApiOptions {
    * @default process.env.UPLOADTHING_SECRET
    */
   apiKey?: string;
+  /**
+   * @default "info"
+   */
+  logLevel?: LogLevel;
 }
 
 export class UTApi {
@@ -43,6 +48,8 @@ export class UTApi {
       "x-uploadthing-version": UPLOADTHING_VERSION,
     };
 
+    initLogger(opts?.logLevel);
+
     // Assert some stuff
     guardServerOnly();
     getApiKeyOrThrow(this.apiKey);
@@ -54,12 +61,19 @@ export class UTApi {
     body: Record<string, unknown>,
     fallbackErrorMessage: string,
   ) {
-    const res = await this.fetch(generateUploadThingURL(pathname), {
+    const url = generateUploadThingURL(pathname);
+    logger.debug("Requesting UploadThing:", {
+      url,
+      body,
+      headers: this.defaultHeaders,
+    });
+    const res = await this.fetch(url, {
       method: "POST",
       cache: "no-store",
       headers: this.defaultHeaders,
       body: JSON.stringify(body),
     });
+    logger.debug("UploadThing responsed with status:", res.status);
 
     const json = await res.json<T | { error: string }>();
     if (!res.ok || "error" in json) {
@@ -73,12 +87,12 @@ export class UTApi {
       });
     }
 
+    logger.debug("UploadThing response:", json);
     return json;
   }
 
   /**
-   * @param {FileEsque | FileEsque[]} files The file(s) to upload
-   * @param {Json} metadata JSON-parseable metadata to attach to the uploaded file(s)
+   * Upload files to UploadThing storage.
    *
    * @example
    * await uploadFiles(new File(["foo"], "foo.txt"));
@@ -99,6 +113,7 @@ export class UTApi {
     guardServerOnly();
 
     const filesToUpload: FileEsque[] = Array.isArray(files) ? files : [files];
+    logger.debug("Uploading files:", filesToUpload);
 
     const uploads = await uploadFilesInternal(
       {
@@ -113,6 +128,7 @@ export class UTApi {
     );
 
     const uploadFileResponse = Array.isArray(files) ? uploads : uploads[0];
+    logger.debug("Finished uploading:", uploadFileResponse);
 
     return uploadFileResponse as T extends FileEsque[]
       ? UploadFileResponse[]
@@ -152,6 +168,7 @@ export class UTApi {
         const filename = url.pathname.split("/").pop() ?? "unknown-filename";
 
         // Download the file on the user's server to avoid egress charges
+        logger.debug("Downloading file:", url);
         const fileResponse = await fetch(url);
         if (!fileResponse.ok) {
           throw new UploadThingError({
@@ -160,10 +177,14 @@ export class UTApi {
             cause: fileResponse,
           });
         }
+        logger.debug("Finished downloading file. Reading blob...");
         const blob = await fileResponse.blob();
+        logger.debug("Finished reading blob.");
         return Object.assign(blob, { name: filename });
       }),
     );
+
+    logger.debug("All files downloaded, uploading...");
 
     const uploads = await uploadFilesInternal(
       {
@@ -179,6 +200,7 @@ export class UTApi {
 
     const uploadFileResponse = Array.isArray(urls) ? uploads : uploads[0];
 
+    logger.debug("Finished uploading:", uploadFileResponse);
     return uploadFileResponse as T extends MaybeUrl[]
       ? UploadFileResponse[]
       : UploadFileResponse;

--- a/packages/uploadthing/src/sdk/utils.ts
+++ b/packages/uploadthing/src/sdk/utils.ts
@@ -8,6 +8,7 @@ import {
 } from "@uploadthing/shared";
 
 import { UPLOADTHING_VERSION } from "../constants";
+import { logger } from "../internal/logger";
 import { uploadPart } from "../internal/multi-part";
 import type { UTEvents } from "../server";
 
@@ -66,6 +67,7 @@ export const uploadFilesInternal = async (
     type: file.type,
     size: file.size,
   }));
+  logger.debug("Getting presigned URLs for files", fileData);
   const res = await opts.fetch(generateUploadThingURL("/api/uploadFiles"), {
     method: "POST",
     headers: opts.utRequestHeaders,
@@ -79,6 +81,7 @@ export const uploadFilesInternal = async (
 
   if (!res.ok) {
     const error = await UploadThingError.fromResponse(res);
+    logger.debug("Failed getting presigned URLs:", error);
     throw error;
   }
 
@@ -100,8 +103,12 @@ export const uploadFilesInternal = async (
 
   if ("error" in json) {
     const error = await UploadThingError.fromResponse(clonedRes);
+    logger.debug("Failed getting presigned URLs:", error);
     throw error;
   }
+
+  logger.debug("Got presigned URLs:", json.data);
+  logger.debug("Starting uploads...");
 
   // Upload each file to S3 in chunks using multi-part uploads
   const uploads = await Promise.allSettled(
@@ -109,12 +116,27 @@ export const uploadFilesInternal = async (
       const { presignedUrls, key, fileUrl, uploadId, chunkSize } = json.data[i];
 
       if (!presignedUrls || !Array.isArray(presignedUrls)) {
+        logger.error(
+          "Failed to generate presigned URL for file:",
+          file,
+          json.data[i],
+        );
         throw new UploadThingError({
           code: "URL_GENERATION_FAILED",
           message: "Failed to generate presigned URL",
           cause: JSON.stringify(json.data[i]),
         });
       }
+
+      logger.debug(
+        "Uploading file",
+        file.name,
+        "with",
+        presignedUrls.length,
+        "chunks of size",
+        chunkSize,
+        "bytes each",
+      );
 
       const etags = await Promise.all(
         presignedUrls.map(async (url, index) => {
@@ -134,20 +156,34 @@ export const uploadFilesInternal = async (
             utRequestHeaders: opts.utRequestHeaders,
           });
 
+          logger.debug("Part", index + 1, "uploaded successfully:", etag);
+
           return { tag: etag, partNumber: index + 1 };
         }),
       );
 
+      logger.debug(
+        "File",
+        file.name,
+        "uploaded successfully. Notifying UploadThing to complete multipart upload.",
+      );
+
       // Complete multipart upload
-      await opts.fetch(generateUploadThingURL("/api/completeMultipart"), {
-        method: "POST",
-        body: JSON.stringify({
-          fileKey: key,
-          uploadId,
-          etags,
-        } satisfies UTEvents["multipart-complete"]),
-        headers: opts.utRequestHeaders,
-      });
+      const completionRes = await opts.fetch(
+        generateUploadThingURL("/api/completeMultipart"),
+        {
+          method: "POST",
+          body: JSON.stringify({
+            fileKey: key,
+            uploadId,
+            etags,
+          } satisfies UTEvents["multipart-complete"]),
+          headers: opts.utRequestHeaders,
+        },
+      );
+
+      logger.debug("UploadThing responsed with status:", completionRes.status);
+      logger.debug("Polling for file data...");
 
       // Poll for file to be available
       await pollForFileData({
@@ -155,6 +191,8 @@ export const uploadFilesInternal = async (
         apiKey: opts.utRequestHeaders["x-uploadthing-api-key"],
         sdkVersion: UPLOADTHING_VERSION,
       });
+
+      logger.debug("Polling complete.");
 
       return {
         key,
@@ -164,6 +202,8 @@ export const uploadFilesInternal = async (
       };
     }),
   );
+
+  logger.debug("All uploads complete, aggregating results...");
 
   return uploads.map((upload) => {
     if (upload.status === "fulfilled") {

--- a/packages/uploadthing/src/server.ts
+++ b/packages/uploadthing/src/server.ts
@@ -9,6 +9,7 @@ import {
   buildRequestHandler,
 } from "./internal/handler";
 import { incompatibleNodeGuard } from "./internal/incompat-node-guard";
+import { initLogger } from "./internal/logger";
 import type { FileRouter } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
@@ -27,8 +28,11 @@ export const createUploadthing = <TErrorShape extends Json>(
 export const createServerHandler = <TRouter extends FileRouter>(
   opts: RouterWithConfig<TRouter>,
 ) => {
+  initLogger(opts.config?.logLevel);
   incompatibleNodeGuard();
+
   const requestHandler = buildRequestHandler<TRouter>(opts);
+  const getBuildPerms = buildPermissionsInfoHandler<TRouter>(opts);
 
   const POST = async (request: Request | { request: Request }) => {
     const req = request instanceof Request ? request : request.request;
@@ -59,8 +63,6 @@ export const createServerHandler = <TRouter extends FileRouter>(
       },
     });
   };
-
-  const getBuildPerms = buildPermissionsInfoHandler<TRouter>(opts);
 
   const GET = (request: Request | { request: Request }) => {
     const _req = request instanceof Request ? request : request.request;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -956,6 +956,9 @@ importers:
       '@uploadthing/shared':
         specifier: ^6.0.3
         version: link:../shared
+      consola:
+        specifier: ^3.2.3
+        version: 3.2.3
     devDependencies:
       '@types/express':
         specifier: ^4.17.17


### PR DESCRIPTION
Adds consola logger, adds a config option to enable more verbose logging, e.g.:

```ts
export const { GET, POST } = createNextRouteHandler({
  router: uploadRouter,
  config: {
    logLevel: "debug",
  },
});
```

### TODO

- [ ] discuss / decide what levels we want, now i just do `.error`, `.info` and `.debug` as i feel fit
- [x] add more debug logs

### Example output:

![CleanShot 2024-01-11 at 14 59 27@2x](https://github.com/pingdotgg/uploadthing/assets/51714798/b075272c-1db9-4c3b-9ac2-2af4765b6b6d)

### Example output with `logLevel: "debug"` set:

![CleanShot 2024-01-11 at 17 14 15@2x](https://github.com/pingdotgg/uploadthing/assets/51714798/40b8f9b7-f4e3-4682-890c-ffdb378601a8)

