### PR TITLE
chore: rm redundant log

### DIFF
--- a/.changeset/bright-weeks-wash.md
+++ b/.changeset/bright-weeks-wash.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+chore: rm redundant log

--- a/packages/uploadthing/src/internal/logger.ts
+++ b/packages/uploadthing/src/internal/logger.ts
@@ -109,5 +109,4 @@ export const logger = createConsola({
 export const initLogger = (level: LogLevel | undefined) => {
   // logger.wrapConsole();
   logger.level = LogLevels[level ?? "info"];
-  logger.info("Set log level", { level: logger.level });
 };


### PR DESCRIPTION
unnecessary