### PR TITLE
Bring back export of getFullApiUrl

### DIFF
--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -312,3 +312,5 @@ export const generateClientDropzoneAccept = (fileTypes: string[]) => {
 };
 
 export { resolveMaybeUrlArg };
+export { getFullApiUrl } from "./internal/get-full-api-url";
+


### PR DESCRIPTION
So that older 6.x packages can be used with 6.3+