### PR TITLE
feat: add `UTFile` utility

### DIFF
--- a/.changeset/witty-weeks-hear.md
+++ b/.changeset/witty-weeks-hear.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": minor
+---
+
+feat: add `UTFile` utility to simplify usage of Blobs with properties

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -1,5 +1,6 @@
 import { process } from "std-env";
 
+import { lookup } from "@uploadthing/mime-types";
 import type {
   ACL,
   ContentDisposition,
@@ -20,6 +21,33 @@ import {
   parseTimeToSeconds,
   uploadFilesInternal,
 } from "./utils";
+
+interface UTFilePropertyBag extends BlobPropertyBag {
+  lastModified?: number;
+  customId?: string;
+}
+
+/**
+ * Extension of the Blob class that simplifies setting the `name` and `customId` properties,
+ * similar to the built-in File class from Node > 20.
+ */
+export class UTFile extends Blob {
+  name: string;
+  lastModified: number;
+  customId?: string;
+
+  constructor(parts: BlobPart[], name: string, options?: UTFilePropertyBag) {
+    const optionsWithDefaults = {
+      ...options,
+      type: options?.type ?? (lookup(name) || undefined),
+      lastModified: options?.lastModified ?? Date.now(),
+    };
+    super(parts, optionsWithDefaults);
+    this.name = name;
+    this.customId = optionsWithDefaults.customId;
+    this.lastModified = optionsWithDefaults.lastModified;
+  }
+}
 
 export interface UTApiOptions {
   /**

--- a/packages/uploadthing/src/server.ts
+++ b/packages/uploadthing/src/server.ts
@@ -15,7 +15,7 @@ import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
 
 export type * from "./internal/types";
-export { UTApi } from "./sdk";
+export { UTApi, UTFile } from "./sdk";
 export { UploadThingError };
 
 type MiddlewareArgs = { req: Request; res: undefined; event: undefined };


### PR DESCRIPTION
Simplifies when creating File's from Blobs etc wihtout having to use Object.assign() and being warned about readonly shit...