### PR TITLE
chore(lint): enable method signature style

### DIFF
--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -44,13 +44,13 @@ export interface ResponseEsque {
    * that's not as type-safe as unknown. We use unknown because we're
    * more type-safe. You do want more type safety, right? 😉
    */
-  json<T = unknown>(): Promise<T>;
-  text(): Promise<string>;
-  blob(): Promise<Blob>;
+  json: <T = unknown>() => Promise<T>;
+  text: () => Promise<string>;
+  blob: () => Promise<Blob>;
 
   headers: Headers;
 
-  clone(): ResponseEsque;
+  clone: () => ResponseEsque;
 }
 
 export type MaybeUrl = string | URL;

--- a/tooling/eslint-config/base.js
+++ b/tooling/eslint-config/base.js
@@ -23,6 +23,7 @@ const config = {
   rules: {
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/consistent-type-definitions": "off",
+    "@typescript-eslint/method-signature-style": ["error", "property"],
     "turbo/no-undeclared-env-vars": "off",
     "@typescript-eslint/no-unused-vars": [
       "error",


### PR DESCRIPTION
https://www.totaltypescript.com/method-shorthand-syntax-considered-harmful