### PR TITLE
feat: add version lock to ensure `uploadthing/client` and `uploadthing/server`uses same version

### DIFF
--- a/.changeset/eighty-laws-begin.md
+++ b/.changeset/eighty-laws-begin.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": minor
+---
+
+add version lock to ensure `uploadthing/client` and `uploadthing/server`uses same version

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -7,6 +7,7 @@ import {
   withExponentialBackoff,
 } from "@uploadthing/shared";
 
+import { UPLOADTHING_VERSION } from "./constants";
 import { resolveMaybeUrlArg } from "./internal/get-full-api-url";
 import type {
   MPUResponse,
@@ -114,6 +115,7 @@ export const DANGEROUS__uploadFiles = async <
       headers: {
         "Content-Type": "application/json",
         "x-uploadthing-package": opts.package,
+        "x-uploadthing-version": UPLOADTHING_VERSION,
       },
     },
   ).then(async (res) => {

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -184,6 +184,16 @@ export const buildRequestHandler = <
     const utFrontendPackage =
       req.headers.get("x-uploadthing-package") ?? "unknown";
 
+    const clientVersion = req.headers.get("x-uploadthing-version");
+    if (clientVersion !== UPLOADTHING_VERSION) {
+      logger.error("Client version mismatch");
+      return new UploadThingError({
+        code: "BAD_REQUEST",
+        message: "Client version mismatch",
+        cause: `Server version: ${UPLOADTHING_VERSION}, Client version: ${clientVersion}`,
+      });
+    }
+
     // Validate inputs
     if (!slug) {
       logger.error("No slug provided in params:", params);

--- a/packages/uploadthing/src/internal/ut-reporter.ts
+++ b/packages/uploadthing/src/internal/ut-reporter.ts
@@ -1,5 +1,6 @@
 import type { FetchEsque } from "@uploadthing/shared";
 import { UploadThingError } from "@uploadthing/shared";
+import { UPLOADTHING_VERSION } from "uploadthing/constants";
 
 import { maybeParseResponseXML } from "./s3-error-parser";
 import type { ActionType, UTEvents } from "./types";
@@ -49,6 +50,7 @@ export const createUTReporter = (cfg: {
       headers: {
         "Content-Type": "application/json",
         "x-uploadthing-package": cfg.package,
+        "x-uploadthing-version": UPLOADTHING_VERSION,
       },
     });
 

--- a/packages/uploadthing/src/internal/ut-reporter.ts
+++ b/packages/uploadthing/src/internal/ut-reporter.ts
@@ -1,7 +1,7 @@
 import type { FetchEsque } from "@uploadthing/shared";
 import { UploadThingError } from "@uploadthing/shared";
-import { UPLOADTHING_VERSION } from "uploadthing/constants";
 
+import { UPLOADTHING_VERSION } from "../constants";
 import { maybeParseResponseXML } from "./s3-error-parser";
 import type { ActionType, UTEvents } from "./types";
 


### PR DESCRIPTION
technically wouldn't need to be exact match, but why not?

### TODO
- [ ] maybe add version check (non-exact) between `@uploadthing/react` and `uploadthing/client` ? 