### PR TITLE
fix: export UTFiles from server entrypoint

### DIFF
--- a/.changeset/silent-ravens-raise.md
+++ b/.changeset/silent-ravens-raise.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+export UTFiles from server entrypoint

--- a/packages/uploadthing/src/server.ts
+++ b/packages/uploadthing/src/server.ts
@@ -15,6 +15,7 @@ import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
 
 export type * from "./internal/types";
+export { UTFiles } from "./internal/types";
 export { UTApi, UTFile } from "./sdk";
 export { UploadThingError };
 


### PR DESCRIPTION
missed this entrypoint, currently only exported as a type from the `export type *` but need the runtime symbol too.

Ref #613