### PR TITLE
chore(lint): add `no-restricted-imports`

### DIFF
--- a/packages/dropzone/package.json
+++ b/packages/dropzone/package.json
@@ -82,6 +82,17 @@
     "extends": [
       "@uploadthing/eslint-config/base"
     ],
+    "rules": {
+      "no-restricted-imports": [
+        "error",
+        {
+          "patterns": [
+            "@uploadthing/dropzone",
+            "@uploadthing/dropzone/*"
+          ]
+        }
+      ]
+    },
     "overrides": [
       {
         "files": [

--- a/packages/mime-types/package.json
+++ b/packages/mime-types/package.json
@@ -41,6 +41,17 @@
   },
   "eslintConfig": {
     "root": true,
+    "rules": {
+      "no-restricted-imports": [
+        "error",
+        {
+          "patterns": [
+            "@uploadthing/mime-types",
+            "@uploadthing/mime-types/*"
+          ]
+        }
+      ]
+    },
     "extends": [
       "@uploadthing/eslint-config/base"
     ]

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -91,6 +91,17 @@
   },
   "eslintConfig": {
     "root": true,
+    "rules": {
+      "no-restricted-imports": [
+        "error",
+        {
+          "patterns": [
+            "@uploadthing/react",
+            "@uploadthing/react/*"
+          ]
+        }
+      ]
+    },
     "extends": [
       "@uploadthing/eslint-config/base",
       "@uploadthing/eslint-config/react"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -50,6 +50,17 @@
   },
   "eslintConfig": {
     "root": true,
+    "rules": {
+      "no-restricted-imports": [
+        "error",
+        {
+          "patterns": [
+            "@uploadthing/shared",
+            "@uploadthing/shared/*"
+          ]
+        }
+      ]
+    },
     "extends": [
       "@uploadthing/eslint-config/base"
     ]

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -112,6 +112,17 @@
   ],
   "eslintConfig": {
     "root": true,
+    "rules": {
+      "no-restricted-imports": [
+        "error",
+        {
+          "patterns": [
+            "@uploadthing/solid",
+            "@uploadthing/solid/*"
+          ]
+        }
+      ]
+    },
     "extends": [
       "@uploadthing/eslint-config/base"
     ]

--- a/packages/uploadthing/package.json
+++ b/packages/uploadthing/package.json
@@ -186,6 +186,15 @@
           "name": "process",
           "message": "Use `import { process } from 'std-env` instead"
         }
+      ],
+      "no-restricted-imports": [
+        "error",
+        {
+          "patterns": [
+            "uploadthing",
+            "uploadthing/*"
+          ]
+        }
       ]
     }
   }


### PR DESCRIPTION
After doing #603, I've noticed vscode has started suggesting absolute auto-imports such as `import { UPLOADTHING_VERSION } from "uploadthing/constants"` which can cause issues at runtime since that's not an entrypoint in the built package. Adding a lint-rule to force relative imports within each package, so e.g. no file in `@uploadthing/shared` can import using `@uploadthing/shared` paths etc

### Example error

![CleanShot 2024-02-25 at 22 27 56@2x](https://github.com/pingdotgg/uploadthing/assets/51714798/548c8f06-d922-475b-b37f-9bb938f80c60)

### Example correct

![CleanShot 2024-02-25 at 22 28 15@2x](https://github.com/pingdotgg/uploadthing/assets/51714798/39f8b4e9-e436-448e-bf57-0508baa4a9a0)
