### PR TITLE
fix: report failed PSPS uploads as failed to infra

### DIFF
--- a/.changeset/popular-apples-walk.md
+++ b/.changeset/popular-apples-walk.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+fix: report failed PSP uplaods as failed to UploadThing

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -331,22 +331,20 @@ async function uploadPresignedPost(
   Object.entries(presigned.fields).forEach(([k, v]) => formData.append(k, v));
   formData.append("file", file); // File data **MUST GO LAST**
 
-  const response: XMLHttpRequest = await new Promise<XMLHttpRequest>(
-    (resolve, reject) => {
-      const xhr = new XMLHttpRequest();
-      xhr.open("POST", presigned.url);
-      xhr.setRequestHeader("Accept", "application/xml");
-      xhr.upload.onprogress = (p) => {
-        opts.onUploadProgress?.({
-          file: file.name,
-          progress: (p.loaded / p.total) * 100,
-        });
-      };
-      xhr.onload = (e) => resolve(e.target as XMLHttpRequest);
-      xhr.onerror = (e) => reject(e);
-      xhr.send(formData);
-    },
-  ).catch(async (error) => {
+  const response = await new Promise<XMLHttpRequest>((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("POST", presigned.url);
+    xhr.setRequestHeader("Accept", "application/xml");
+    xhr.upload.onprogress = (p) => {
+      opts.onUploadProgress?.({
+        file: file.name,
+        progress: (p.loaded / p.total) * 100,
+      });
+    };
+    xhr.onload = (e) => resolve(e.target as XMLHttpRequest);
+    xhr.onerror = (e) => reject(e);
+    xhr.send(formData);
+  }).catch(async (error) => {
     await opts.reportEventToUT("failure", {
       fileKey: presigned.key,
       uploadId: null,

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -331,9 +331,8 @@ async function uploadPresignedPost(
   Object.entries(presigned.fields).forEach(([k, v]) => formData.append(k, v));
   formData.append("file", file); // File data **MUST GO LAST**
 
-  let response: XMLHttpRequest;
-  try {
-    response = await new Promise<XMLHttpRequest>((resolve, reject) => {
+  const response: XMLHttpRequest = await new Promise<XMLHttpRequest>(
+    (resolve, reject) => {
       const xhr = new XMLHttpRequest();
       xhr.open("POST", presigned.url);
       xhr.setRequestHeader("Accept", "application/xml");
@@ -346,8 +345,8 @@ async function uploadPresignedPost(
       xhr.onload = (e) => resolve(e.target as XMLHttpRequest);
       xhr.onerror = (e) => reject(e);
       xhr.send(formData);
-    });
-  } catch (error) {
+    },
+  ).catch(async (error) => {
     await opts.reportEventToUT("failure", {
       fileKey: presigned.key,
       uploadId: null,
@@ -355,7 +354,7 @@ async function uploadPresignedPost(
       s3Error: (error as Error).toString(),
     });
     throw "unreachable"; // failure event will throw for us
-  }
+  });
 
   if (response.status > 299 || response.status < 200) {
     await opts.reportEventToUT("failure", {

--- a/packages/uploadthing/src/internal/types.ts
+++ b/packages/uploadthing/src/internal/types.ts
@@ -178,7 +178,7 @@ export type UTEvents = {
   };
   failure: {
     fileKey: string;
-    uploadId: string;
+    uploadId: string | null;
     s3Error?: string;
     fileName: string;
   };


### PR DESCRIPTION
failed uploads using PSP were not reported to infra so they would still count towards quota for the user's app even though they didn't occupy space in s3