### PR TITLE
fix: Improve dropzone styles to be less confusing

### DIFF
--- a/.changeset/brave-schools-visit.md
+++ b/.changeset/brave-schools-visit.md
@@ -1,0 +1,5 @@
+---
+"@uploadthing/react": patch
+---
+
+fix: make dropzone less confusing

--- a/packages/react/src/components/dropzone.tsx
+++ b/packages/react/src/components/dropzone.tsx
@@ -281,12 +281,12 @@ export function UploadDropzone<
 
       <button
         className={twMerge(
-          "relative mt-4 flex h-10 w-36 cursor-pointer items-center justify-center overflow-hidden rounded-md text-white after:transition-[width] after:duration-500 focus-within:ring-2 focus-within:ring-blue-600 focus-within:ring-offset-2",
+          "relative mt-4 flex h-10 w-36 cursor-pointer items-center justify-center overflow-hidden rounded-md text-white after:transition-[width] after:duration-500 focus-within:ring-2 focus-within:ring-blue-600 focus-within:ring-offset-2 text-base border-none",
           state === "readying" && "cursor-not-allowed bg-blue-400",
           state === "uploading" &&
             `bg-blue-400 after:absolute after:left-0 after:h-full after:bg-blue-600 after:content-[''] ${progressWidths[uploadProgress]}`,
           state === "ready" && "bg-blue-600",
-          "disabled:cursor-not-allowed disabled:bg-blue-400",
+          "disabled:pointer-events-none",
           styleFieldToClassName($props.appearance?.button, styleFieldArg),
         )}
         style={styleFieldToCssObject($props.appearance?.button, styleFieldArg)}


### PR DESCRIPTION
Previously, the button was displayed as disabled when there were no files. This change makes it appear like a normal button, and passes click through to the input. Also removes weird border. 


Before:

![image](https://github.com/pingdotgg/uploadthing/assets/11494384/6cbe6760-32ec-441b-bd6b-e2270d25e9d4)


After:

![image](https://github.com/pingdotgg/uploadthing/assets/11494384/04afc496-baba-4238-af64-23078797668a)
