### PR TITLE
refactor: move internal stuff into shared

### DIFF
--- a/.changeset/hip-boxes-share.md
+++ b/.changeset/hip-boxes-share.md
@@ -1,0 +1,8 @@
+---
+"uploadthing": patch
+"@uploadthing/shared": patch
+"@uploadthing/react": patch
+"@uploadthing/solid": patch
+---
+
+refactor: move some internally exported functions to `@uploadthing/shared`

--- a/examples/minimal-appdir/src/server/uploadthing.ts
+++ b/examples/minimal-appdir/src/server/uploadthing.ts
@@ -3,6 +3,8 @@ import { randomUUID } from "crypto";
 import { createUploadthing, UTFiles } from "uploadthing/next";
 import type { FileRouter } from "uploadthing/next";
 
+import "uploadthing/types";
+
 const f = createUploadthing({
   /**
    * Log out more information about the error, but don't return it to the client

--- a/examples/minimal-appdir/src/server/uploadthing.ts
+++ b/examples/minimal-appdir/src/server/uploadthing.ts
@@ -3,8 +3,6 @@ import { randomUUID } from "crypto";
 import { createUploadthing, UTFiles } from "uploadthing/next";
 import type { FileRouter } from "uploadthing/next";
 
-import "uploadthing/types";
-
 const f = createUploadthing({
   /**
    * Log out more information about the error, but don't return it to the client

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -69,7 +69,7 @@
   "peerDependencies": {
     "next": "*",
     "react": "^17.0.2 || ^18.0.0",
-    "uploadthing": "^6.4.0"
+    "uploadthing": "^6.5.1"
   },
   "peerDependenciesMeta": {
     "next": {

--- a/packages/react/src/components/button.tsx
+++ b/packages/react/src/components/button.tsx
@@ -27,23 +27,36 @@ type ButtonStyleFieldCallbackArgs = {
   fileTypes: string[];
 };
 
+type ButtonAppearance = {
+  container?: StyleField<ButtonStyleFieldCallbackArgs>;
+  button?: StyleField<ButtonStyleFieldCallbackArgs>;
+  allowedContent?: StyleField<ButtonStyleFieldCallbackArgs>;
+  clearBtn?: StyleField<ButtonStyleFieldCallbackArgs>;
+};
+
+type ButtonContent = {
+  button?: ContentField<ButtonStyleFieldCallbackArgs>;
+  allowedContent?: ContentField<ButtonStyleFieldCallbackArgs>;
+  clearBtn?: ContentField<ButtonStyleFieldCallbackArgs>;
+};
+
 export type UploadButtonProps<
   TRouter extends FileRouter,
   TEndpoint extends keyof TRouter,
   TSkipPolling extends boolean = false,
 > = UploadthingComponentProps<TRouter, TEndpoint, TSkipPolling> & {
-  appearance?: {
-    container?: StyleField<ButtonStyleFieldCallbackArgs>;
-    button?: StyleField<ButtonStyleFieldCallbackArgs>;
-    allowedContent?: StyleField<ButtonStyleFieldCallbackArgs>;
-    clearBtn?: StyleField<ButtonStyleFieldCallbackArgs>;
-  };
-  content?: {
-    button?: ContentField<ButtonStyleFieldCallbackArgs>;
-    allowedContent?: ContentField<ButtonStyleFieldCallbackArgs>;
-    clearBtn?: ContentField<ButtonStyleFieldCallbackArgs>;
-  };
+  /**
+   * @see https://docs.uploadthing.com/theming#style-using-the-classname-prop
+   */
   className?: string;
+  /**
+   * @see https://docs.uploadthing.com/theming#style-using-the-appearance-prop
+   */
+  appearance?: ButtonAppearance;
+  /**
+   * @see https://docs.uploadthing.com/theming#content-customisation
+   */
+  content?: ButtonContent;
 };
 
 /**

--- a/packages/react/src/components/button.tsx
+++ b/packages/react/src/components/button.tsx
@@ -12,8 +12,12 @@ import {
   styleFieldToClassName,
   styleFieldToCssObject,
 } from "@uploadthing/shared";
-import type { ContentField, StyleField } from "@uploadthing/shared";
-import type { ErrorMessage, FileRouter } from "uploadthing/server";
+import type {
+  ContentField,
+  ErrorMessage,
+  StyleField,
+} from "@uploadthing/shared";
+import type { FileRouter } from "uploadthing/types";
 
 import type { UploadthingComponentProps } from "../types";
 import { INTERNAL_uploadthingHookGen } from "../useUploadThing";

--- a/packages/react/src/components/button.tsx
+++ b/packages/react/src/components/button.tsx
@@ -11,8 +11,8 @@ import {
   resolveMaybeUrlArg,
   styleFieldToClassName,
   styleFieldToCssObject,
-} from "uploadthing/client";
-import type { ContentField, StyleField } from "uploadthing/client";
+} from "@uploadthing/shared";
+import type { ContentField, StyleField } from "@uploadthing/shared";
 import type { ErrorMessage, FileRouter } from "uploadthing/server";
 
 import type { UploadthingComponentProps } from "../types";

--- a/packages/react/src/components/dropzone.tsx
+++ b/packages/react/src/components/dropzone.tsx
@@ -7,13 +7,13 @@ import { useDropzone } from "@uploadthing/dropzone/react";
 import {
   allowedContentTextLabelGenerator,
   contentFieldToContent,
-  generateClientDropzoneAccept,
   generatePermittedFileTypes,
   resolveMaybeUrlArg,
   styleFieldToClassName,
   styleFieldToCssObject,
-} from "uploadthing/client";
-import type { ContentField, StyleField } from "uploadthing/client";
+} from "@uploadthing/shared";
+import type { ContentField, StyleField } from "@uploadthing/shared";
+import { generateClientDropzoneAccept } from "uploadthing/client";
 import type { ErrorMessage, FileRouter } from "uploadthing/server";
 
 import type { UploadthingComponentProps } from "../types";

--- a/packages/react/src/components/dropzone.tsx
+++ b/packages/react/src/components/dropzone.tsx
@@ -29,25 +29,38 @@ type DropzoneStyleFieldCallbackArgs = {
   isDragActive: boolean;
 };
 
+type DropzoneAppearance = {
+  container?: StyleField<DropzoneStyleFieldCallbackArgs>;
+  uploadIcon?: StyleField<DropzoneStyleFieldCallbackArgs>;
+  label?: StyleField<DropzoneStyleFieldCallbackArgs>;
+  allowedContent?: StyleField<DropzoneStyleFieldCallbackArgs>;
+  button?: StyleField<DropzoneStyleFieldCallbackArgs>;
+};
+
+type DropzoneContent = {
+  uploadIcon?: ContentField<DropzoneStyleFieldCallbackArgs>;
+  label?: ContentField<DropzoneStyleFieldCallbackArgs>;
+  allowedContent?: ContentField<DropzoneStyleFieldCallbackArgs>;
+  button?: ContentField<DropzoneStyleFieldCallbackArgs>;
+};
+
 export type UploadDropzoneProps<
   TRouter extends FileRouter,
   TEndpoint extends keyof TRouter,
   TSkipPolling extends boolean = false,
 > = UploadthingComponentProps<TRouter, TEndpoint, TSkipPolling> & {
-  appearance?: {
-    container?: StyleField<DropzoneStyleFieldCallbackArgs>;
-    uploadIcon?: StyleField<DropzoneStyleFieldCallbackArgs>;
-    label?: StyleField<DropzoneStyleFieldCallbackArgs>;
-    allowedContent?: StyleField<DropzoneStyleFieldCallbackArgs>;
-    button?: StyleField<DropzoneStyleFieldCallbackArgs>;
-  };
-  content?: {
-    uploadIcon?: ContentField<DropzoneStyleFieldCallbackArgs>;
-    label?: ContentField<DropzoneStyleFieldCallbackArgs>;
-    allowedContent?: ContentField<DropzoneStyleFieldCallbackArgs>;
-    button?: ContentField<DropzoneStyleFieldCallbackArgs>;
-  };
+  /**
+   * @see https://docs.uploadthing.com/theming#style-using-the-classname-prop
+   */
   className?: string;
+  /**
+   * @see https://docs.uploadthing.com/theming#style-using-the-appearance-prop
+   */
+  appearance?: DropzoneAppearance;
+  /**
+   * @see https://docs.uploadthing.com/theming#content-customisation
+   */
+  content?: DropzoneContent;
 };
 
 export function UploadDropzone<

--- a/packages/react/src/components/dropzone.tsx
+++ b/packages/react/src/components/dropzone.tsx
@@ -13,8 +13,12 @@ import {
   styleFieldToClassName,
   styleFieldToCssObject,
 } from "@uploadthing/shared";
-import type { ContentField, StyleField } from "@uploadthing/shared";
-import type { ErrorMessage, FileRouter } from "uploadthing/server";
+import type {
+  ContentField,
+  ErrorMessage,
+  StyleField,
+} from "@uploadthing/shared";
+import type { FileRouter } from "uploadthing/types";
 
 import type { UploadthingComponentProps } from "../types";
 import { INTERNAL_uploadthingHookGen } from "../useUploadThing";

--- a/packages/react/src/components/dropzone.tsx
+++ b/packages/react/src/components/dropzone.tsx
@@ -7,13 +7,13 @@ import { useDropzone } from "@uploadthing/dropzone/react";
 import {
   allowedContentTextLabelGenerator,
   contentFieldToContent,
+  generateClientDropzoneAccept,
   generatePermittedFileTypes,
   resolveMaybeUrlArg,
   styleFieldToClassName,
   styleFieldToCssObject,
 } from "@uploadthing/shared";
 import type { ContentField, StyleField } from "@uploadthing/shared";
-import { generateClientDropzoneAccept } from "uploadthing/client";
 import type { ErrorMessage, FileRouter } from "uploadthing/server";
 
 import type { UploadthingComponentProps } from "../types";

--- a/packages/react/src/components/index.tsx
+++ b/packages/react/src/components/index.tsx
@@ -1,18 +1,17 @@
-import type { ComponentProps, JSXElementConstructor } from "react";
-
 import { resolveMaybeUrlArg } from "@uploadthing/shared";
 import type { FileRouter } from "uploadthing/server";
 
-import type { GenerateTypedHelpersOptions } from "../types";
+import type {
+  GenerateTypedHelpersOptions,
+  UploadthingComponentProps,
+} from "../types";
+import type { UploadButtonProps } from "./button";
 import { UploadButton } from "./button";
+import type { UploadDropzoneProps } from "./dropzone";
 import { UploadDropzone } from "./dropzone";
 import { Uploader } from "./uploader";
 
 export { UploadButton, UploadDropzone, Uploader };
-
-type OmitInitOpts<
-  T extends keyof JSX.IntrinsicElements | JSXElementConstructor<any>,
-> = Omit<ComponentProps<T>, keyof GenerateTypedHelpersOptions>;
 
 export const generateUploadButton = <TRouter extends FileRouter>(
   opts?: GenerateTypedHelpersOptions,
@@ -23,7 +22,10 @@ export const generateUploadButton = <TRouter extends FileRouter>(
     TEndpoint extends keyof TRouter,
     TSkipPolling extends boolean = false,
   >(
-    props: OmitInitOpts<typeof UploadButton<TRouter, TEndpoint, TSkipPolling>>,
+    props: Omit<
+      UploadButtonProps<TRouter, TEndpoint, TSkipPolling>,
+      keyof GenerateTypedHelpersOptions
+    >,
   ) => (
     <UploadButton<TRouter, TEndpoint, TSkipPolling>
       {...(props as any)}
@@ -42,8 +44,9 @@ export const generateUploadDropzone = <TRouter extends FileRouter>(
     TEndpoint extends keyof TRouter,
     TSkipPolling extends boolean = false,
   >(
-    props: OmitInitOpts<
-      typeof UploadDropzone<TRouter, TEndpoint, TSkipPolling>
+    props: Omit<
+      UploadDropzoneProps<TRouter, TEndpoint, TSkipPolling>,
+      keyof GenerateTypedHelpersOptions
     >,
   ) => (
     <UploadDropzone<TRouter, TEndpoint, TSkipPolling>
@@ -63,7 +66,10 @@ export const generateUploader = <TRouter extends FileRouter>(
     TEndpoint extends keyof TRouter,
     TSkipPolling extends boolean = false,
   >(
-    props: OmitInitOpts<typeof Uploader<TRouter, TEndpoint, TSkipPolling>>,
+    props: Omit<
+      UploadthingComponentProps<TRouter, TEndpoint, TSkipPolling>,
+      keyof GenerateTypedHelpersOptions
+    >,
   ) => (
     <Uploader<TRouter, TEndpoint, TSkipPolling> {...(props as any)} url={url} />
   );

--- a/packages/react/src/components/index.tsx
+++ b/packages/react/src/components/index.tsx
@@ -1,6 +1,6 @@
 import type { ComponentProps, JSXElementConstructor } from "react";
 
-import { resolveMaybeUrlArg } from "uploadthing/client";
+import { resolveMaybeUrlArg } from "@uploadthing/shared";
 import type { FileRouter } from "uploadthing/server";
 
 import type { GenerateTypedHelpersOptions } from "../types";

--- a/packages/react/src/components/index.tsx
+++ b/packages/react/src/components/index.tsx
@@ -1,5 +1,5 @@
 import { resolveMaybeUrlArg } from "@uploadthing/shared";
-import type { FileRouter } from "uploadthing/server";
+import type { FileRouter } from "uploadthing/types";
 
 import type {
   GenerateTypedHelpersOptions,

--- a/packages/react/src/components/uploader.tsx
+++ b/packages/react/src/components/uploader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import type { ErrorMessage, FileRouter } from "uploadthing/server";
+import type { ErrorMessage } from "@uploadthing/shared";
+import type { FileRouter } from "uploadthing/types";
 
 import type { UploadthingComponentProps } from "../types";
 import { UploadButton } from "./button";

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -4,7 +4,7 @@ import type {
   inferEndpointInput,
   inferEndpointOutput,
   inferErrorShape,
-  UploadFileResponse,
+  UploadedFile,
 } from "uploadthing/types";
 
 export interface GenerateTypedHelpersOptions {
@@ -55,7 +55,7 @@ export type UseUploadthingProps<
    * - If `skipPolling` is `false`, this will be called after
    *   the serverside `onUploadComplete` callback has finished
    */
-  onClientUploadComplete?: (res: UploadFileResponse<TServerOutput>[]) => void;
+  onClientUploadComplete?: (res: UploadedFile<TServerOutput>[]) => void;
   /**
    * Called if the upload fails
    */

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,11 +1,11 @@
 import type { ExtendObjectIf, UploadThingError } from "@uploadthing/shared";
-import type { UploadFileResponse } from "uploadthing/client";
 import type {
   FileRouter,
   inferEndpointInput,
   inferEndpointOutput,
   inferErrorShape,
-} from "uploadthing/server";
+  UploadFileResponse,
+} from "uploadthing/types";
 
 export interface GenerateTypedHelpersOptions {
   /**

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,4 +1,4 @@
-import type { UploadThingError } from "@uploadthing/shared";
+import type { ExtendObjectIf, UploadThingError } from "@uploadthing/shared";
 import type { UploadFileResponse } from "uploadthing/client";
 import type {
   FileRouter,
@@ -28,12 +28,38 @@ export type UseUploadthingProps<
     ? inferEndpointOutput<TRouter[TEndpoint]>
     : null,
 > = {
-  skipPolling?: TSkipPolling;
-  onClientUploadComplete?: (res: UploadFileResponse<TServerOutput>[]) => void;
-  onUploadProgress?: (p: number) => void;
-  onUploadError?: (e: UploadThingError<inferErrorShape<TRouter>>) => void;
-  onUploadBegin?: (fileName: string) => void;
+  /**
+   * Called when the upload is submitted and the server is about to be queried for presigned URLs
+   * Can be used to modify the files before they are uploaded, e.g. renaming them
+   */
   onBeforeUploadBegin?: (files: File[]) => Promise<File[]> | File[];
+  /**
+   * Called when presigned URLs have been retrieved and the file upload is about to begin
+   */
+  onUploadBegin?: (fileName: string) => void;
+  /**
+   * Called continuously as the file is uploaded to the storage provider
+   */
+  onUploadProgress?: (p: number) => void;
+  /**
+   * Skip polling for server data after upload is complete
+   * Useful if you want faster response times and don't need
+   * any data returned from the server `onUploadComplete` callback
+   * @default false
+   */
+  skipPolling?: TSkipPolling;
+  /**
+   * Called when the file uploads are completed
+   * - If `skipPolling` is `true`, this will be called once
+   *   all the files are uploaded to the storage provider.
+   * - If `skipPolling` is `false`, this will be called after
+   *   the serverside `onUploadComplete` callback has finished
+   */
+  onClientUploadComplete?: (res: UploadFileResponse<TServerOutput>[]) => void;
+  /**
+   * Called if the upload fails
+   */
+  onUploadError?: (e: UploadThingError<inferErrorShape<TRouter>>) => void;
 };
 
 export type UploadthingComponentProps<
@@ -41,6 +67,9 @@ export type UploadthingComponentProps<
   TEndpoint extends keyof TRouter,
   TSkipPolling extends boolean = false,
 > = UseUploadthingProps<TRouter, TEndpoint, TSkipPolling> & {
+  /**
+   * The endpoint from your FileRouter to use for the upload
+   */
   endpoint: TEndpoint;
   /**
    * URL to the UploadThing API endpoint
@@ -56,9 +85,13 @@ export type UploadthingComponentProps<
     mode?: "auto" | "manual";
     appendOnPaste?: boolean;
   };
-} & (undefined extends inferEndpointInput<TRouter[TEndpoint]>
-    ? // eslint-disable-next-line @typescript-eslint/ban-types
-      {}
-    : {
-        input: inferEndpointInput<TRouter[TEndpoint]>;
-      });
+} & ExtendObjectIf<
+    inferEndpointInput<TRouter[TEndpoint]>,
+    {
+      /**
+       * The input to the endpoint, as defined using `.input()` on the FileRouter endpoint
+       * @see https://docs.uploadthing.com/api-reference/server#input
+       */
+      input: inferEndpointInput<TRouter[TEndpoint]>;
+    }
+  >;

--- a/packages/react/src/useUploadThing.ts
+++ b/packages/react/src/useUploadThing.ts
@@ -15,7 +15,7 @@ import type {
   FileRouter,
   inferEndpointInput,
   inferErrorShape,
-} from "uploadthing/server";
+} from "uploadthing/types";
 
 import { peerDependencies } from "../package.json";
 import type { GenerateTypedHelpersOptions, UseUploadthingProps } from "./types";

--- a/packages/react/src/useUploadThing.ts
+++ b/packages/react/src/useUploadThing.ts
@@ -1,16 +1,17 @@
 import { useRef, useState } from "react";
 
 import type { EndpointMetadata } from "@uploadthing/shared";
-import { semverLite, UploadThingError } from "@uploadthing/shared";
-import type { UploadFilesOptions } from "uploadthing/client";
 import {
-  DANGEROUS__uploadFiles,
   INTERNAL_DO_NOT_USE__fatalClientError,
   resolveMaybeUrlArg,
+  semverLite,
+  UploadThingError,
+} from "@uploadthing/shared";
+import {
+  genUploader,
   version as uploadthingClientVersion,
 } from "uploadthing/client";
 import type {
-  DistributiveOmit,
   FileRouter,
   inferEndpointInput,
   inferErrorShape,
@@ -49,6 +50,10 @@ export const INTERNAL_uploadthingHookGen = <
       `!!!WARNING::: @uploadthing/react requires "uploadthing@${peerDependencies.uploadthing}", but version "${uploadthingClientVersion}" is installed`,
     );
   }
+  const uploadFiles = genUploader<TRouter>({
+    url: initOpts.url,
+    package: "@uploadthing/react",
+  });
 
   const useUploadThing = <
     TEndpoint extends keyof TRouter,
@@ -78,13 +83,8 @@ export const INTERNAL_uploadthingHookGen = <
       setUploading(true);
       opts?.onUploadProgress?.(0);
       try {
-        const res = await DANGEROUS__uploadFiles<
-          TRouter,
-          TEndpoint,
-          TSkipPolling
-        >(endpoint, {
+        const res = await uploadFiles(endpoint, {
           files,
-          input,
           skipPolling: opts?.skipPolling,
           onUploadProgress: (progress) => {
             if (!opts?.onUploadProgress) return;
@@ -105,8 +105,8 @@ export const INTERNAL_uploadthingHookGen = <
 
             opts.onUploadBegin(file);
           },
-          url: initOpts.url,
-          package: "@uploadthing/react",
+          // @ts-expect-error - input may not be defined on the type
+          input,
         });
 
         opts?.onClientUploadComplete?.(res);
@@ -147,21 +147,9 @@ export const generateReactHelpers = <TRouter extends FileRouter>(
 
   return {
     useUploadThing: INTERNAL_uploadthingHookGen<TRouter>({ url }),
-    uploadFiles: <
-      TEndpoint extends keyof TRouter,
-      TSkipPolling extends boolean = false,
-    >(
-      endpoint: TEndpoint,
-      opts: DistributiveOmit<
-        UploadFilesOptions<TRouter, TEndpoint, TSkipPolling>,
-        "url" | "package"
-      >,
-    ) =>
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      DANGEROUS__uploadFiles<TRouter, TEndpoint>(endpoint, {
-        ...opts,
-        url,
-        package: "@uploadthing/react",
-      } as any),
+    uploadFiles: genUploader<TRouter>({
+      url,
+      package: "@uploadthing/react",
+    }),
   } as const;
 };

--- a/packages/react/test/client-generator.test.ts
+++ b/packages/react/test/client-generator.test.ts
@@ -2,7 +2,7 @@ import { expectTypeOf, it } from "vitest";
 import * as z from "zod";
 
 import { createUploadthing } from "uploadthing/server";
-import type { UploadFileResponse } from "uploadthing/types";
+import type { UploadedFile } from "uploadthing/types";
 
 import { generateReactHelpers } from "../src";
 
@@ -108,46 +108,46 @@ it("infers output properly", () => {
     const { startUpload } = useUploadThing("exampleRoute");
     const res = await startUpload(files);
     // Undefined cause upload can silently throw and don't return anything
-    expectTypeOf<UploadFileResponse<{ foo: "bar" }>[] | undefined>(res);
+    expectTypeOf<UploadedFile<{ foo: "bar" }>[] | undefined>(res);
   });
 
   doNotExecute(async () => {
     const { startUpload } = useUploadThing("withFooInput");
     const res = await startUpload(files, { foo: "bar" });
-    expectTypeOf<UploadFileResponse<{ baz: "qux" }>[] | undefined>(res);
+    expectTypeOf<UploadedFile<{ baz: "qux" }>[] | undefined>(res);
   });
 
   doNotExecute(async () => {
     const { startUpload } = useUploadThing("withBarInput");
     const res = await startUpload(files, { bar: 1 });
-    expectTypeOf<UploadFileResponse<null>[] | undefined>(res);
+    expectTypeOf<UploadedFile<null>[] | undefined>(res);
   });
 
   doNotExecute(async () => {
     const { startUpload } = useUploadThing("returningUndefined");
     const res = await startUpload(files);
-    expectTypeOf<UploadFileResponse<null>[] | undefined>(res);
+    expectTypeOf<UploadedFile<null>[] | undefined>(res);
   });
 
   doNotExecute(async () => {
     const { startUpload } = useUploadThing("withFooInput", {
       skipPolling: true,
       onClientUploadComplete: (res) => {
-        expectTypeOf<UploadFileResponse<null>[]>(res);
+        expectTypeOf<UploadedFile<null>[]>(res);
       },
     });
     const res = await startUpload(files, { foo: "bar" });
-    expectTypeOf<UploadFileResponse<null>[] | undefined>(res);
+    expectTypeOf<UploadedFile<null>[] | undefined>(res);
   });
 
   doNotExecute(async () => {
     const { startUpload } = useUploadThing("withBarInput", {
       skipPolling: true,
       onClientUploadComplete: (res) => {
-        expectTypeOf<UploadFileResponse<null>[]>(res);
+        expectTypeOf<UploadedFile<null>[]>(res);
       },
     });
     const res = await startUpload(files, { bar: 1 });
-    expectTypeOf<UploadFileResponse<null>[] | undefined>(res);
+    expectTypeOf<UploadedFile<null>[] | undefined>(res);
   });
 });

--- a/packages/react/test/client-generator.test.ts
+++ b/packages/react/test/client-generator.test.ts
@@ -1,8 +1,8 @@
 import { expectTypeOf, it } from "vitest";
 import * as z from "zod";
 
-import type { UploadFileResponse } from "uploadthing/client";
 import { createUploadthing } from "uploadthing/server";
+import type { UploadFileResponse } from "uploadthing/types";
 
 import { generateReactHelpers } from "../src";
 

--- a/packages/shared/src/component-utils.ts
+++ b/packages/shared/src/component-utils.ts
@@ -1,8 +1,22 @@
 import type { CSSProperties, ReactNode } from "react";
 import type { JSX } from "solid-js/jsx-runtime";
 
-import { objectKeys } from "@uploadthing/shared";
-import type { ExpandedRouteConfig } from "@uploadthing/shared";
+import type { ExpandedRouteConfig } from "./types";
+import { objectKeys } from "./utils";
+
+export const generateMimeTypes = (fileTypes: string[]) => {
+  const accepted = fileTypes.map((type) => {
+    if (type === "blob") return "blob";
+    if (type === "pdf") return "application/pdf";
+    if (type.includes("/")) return type;
+    else return `${type}/*`;
+  });
+
+  if (accepted.includes("blob")) {
+    return undefined;
+  }
+  return accepted;
+};
 
 /**
  * Shared helpers for our premade components that's reusable by multiple frameworks

--- a/packages/shared/src/component-utils.ts
+++ b/packages/shared/src/component-utils.ts
@@ -18,6 +18,14 @@ export const generateMimeTypes = (fileTypes: string[]) => {
   return accepted;
 };
 
+export const generateClientDropzoneAccept = (fileTypes: string[]) => {
+  const mimeTypes = generateMimeTypes(fileTypes);
+
+  if (!mimeTypes) return undefined;
+
+  return Object.fromEntries(mimeTypes.map((type) => [type, []]));
+};
+
 /**
  * Shared helpers for our premade components that's reusable by multiple frameworks
  */

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -130,3 +130,10 @@ function getErrorTypeFromStatusCode(statusCode: number): ErrorCode {
   }
   return "INTERNAL_SERVER_ERROR";
 }
+
+export const INTERNAL_DO_NOT_USE__fatalClientError = (e: Error) =>
+  new UploadThingError({
+    code: "INTERNAL_CLIENT_ERROR",
+    message: "Something went wrong. Please report this to UploadThing.",
+    cause: e,
+  });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2,3 +2,4 @@ export * from "./types";
 export * from "./utils";
 export * from "./file-types";
 export * from "./error";
+export * from "./component-utils";

--- a/packages/shared/src/resolve-api-url.ts
+++ b/packages/shared/src/resolve-api-url.ts
@@ -1,22 +1,25 @@
 import { process } from "std-env";
 import { describe, expect, it } from "vitest";
 
-import { getFullApiUrl } from "./get-full-api-url";
+import { resolveMaybeUrlArg } from "./utils";
 
-describe("getFullApiUrl", () => {
+describe("resolveMaybeUrlArg", () => {
   it("should return the provided url if it is already absolute", () => {
     const url = "https://example.com/foo/bar";
-    expect(getFullApiUrl(url).href).toBe(url);
+    expect(resolveMaybeUrlArg(url).href).toBe(url);
   });
 
   it("should add `window.location.origin` if the url is relative and request is clientside", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     global.window = {
       location: {
         origin: "http://example.com",
       },
     } as any;
 
-    expect(getFullApiUrl("/foo/bar").href).toBe("http://example.com/foo/bar");
+    expect(resolveMaybeUrlArg("/foo/bar").href).toBe(
+      "http://example.com/foo/bar",
+    );
 
     // @ts-expect-error - delete globalThis
     delete global.window;
@@ -25,23 +28,27 @@ describe("getFullApiUrl", () => {
   it("should take VERCEL_URL if present and url is relative", () => {
     process.env.VERCEL_URL = "example.com";
 
-    expect(getFullApiUrl("/foo/bar").href).toBe("https://example.com/foo/bar");
+    expect(resolveMaybeUrlArg("/foo/bar").href).toBe(
+      "https://example.com/foo/bar",
+    );
 
     delete process.env.VERCEL_URL;
   });
 
   it("assumes localhost if no VERCEL_URL and url is relative", () => {
-    expect(getFullApiUrl("/foo/bar").href).toBe(
+    expect(resolveMaybeUrlArg("/foo/bar").href).toBe(
       "http://localhost:3000/foo/bar",
     );
   });
 
   it("should use `/api/uploadthing` pathname if no url is provided", () => {
-    expect(getFullApiUrl().href).toBe("http://localhost:3000/api/uploadthing");
+    expect(resolveMaybeUrlArg("http://example.com").href).toBe(
+      "http://localhost:3000/api/uploadthing",
+    );
   });
 
   it("should add `/api/uploadthing` if url only has a origin", () => {
-    expect(getFullApiUrl("http://example.com").href).toBe(
+    expect(resolveMaybeUrlArg("http://example.com").href).toBe(
       "http://example.com/api/uploadthing",
     );
   });

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -10,6 +10,11 @@ export type Json = JsonValue | JsonObject | JsonArray;
 export type Overwrite<T, U> = Omit<T, keyof U> & U;
 export type WithRequired<T, K extends keyof T> = T & Required<Pick<T, K>>;
 
+export type ExtendObjectIf<Predicate, ToAdd> = undefined extends Predicate
+  ? // eslint-disable-next-line @typescript-eslint/ban-types
+    {}
+  : ToAdd;
+
 /**
  * A subset of the standard RequestInit properties needed by UploadThing internally.
  * @see RequestInit from lib.dom.d.ts

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -14,7 +14,6 @@ export type ErrorMessage<TError extends string> = TError;
 export type Simplify<TType> = { [TKey in keyof TType]: TType[TKey] } & {};
 export type MaybePromise<TType> = TType | Promise<TType>;
 
-
 export type ExtendObjectIf<Predicate, ToAdd> = undefined extends Predicate
   ? // eslint-disable-next-line @typescript-eslint/ban-types
     {}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -9,6 +9,11 @@ export type Json = JsonValue | JsonObject | JsonArray;
 
 export type Overwrite<T, U> = Omit<T, keyof U> & U;
 export type WithRequired<T, K extends keyof T> = T & Required<Pick<T, K>>;
+export type ErrorMessage<TError extends string> = TError;
+// eslint-disable-next-line @typescript-eslint/ban-types
+export type Simplify<TType> = { [TKey in keyof TType]: TType[TKey] } & {};
+export type MaybePromise<TType> = TType | Promise<TType>;
+
 
 export type ExtendObjectIf<Predicate, ToAdd> = undefined extends Predicate
   ? // eslint-disable-next-line @typescript-eslint/ban-types

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -297,3 +297,33 @@ export function semverLite(required: string, toCheck: string) {
   // Exact match
   return rMajor === cMajor && rMinor === cMinor && rPatch === cPatch;
 }
+
+function getFullApiUrl(maybeUrl?: string): URL {
+  const base = (() => {
+    if (typeof window !== "undefined") return window.location.origin;
+    if (process.env?.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
+    return "http://localhost:3000";
+  })();
+
+  try {
+    const url = new URL(maybeUrl ?? "/api/uploadthing", base);
+    if (url.pathname === "/") {
+      url.pathname = "/api/uploadthing";
+    }
+    return url;
+  } catch (err) {
+    throw new Error(
+      `Failed to parse '${maybeUrl}' as a URL. Make sure it's a valid URL or path`,
+    );
+  }
+}
+
+/*
+ * Returns a full URL to the dev's uploadthing endpoint
+ * Can take either an origin, or a pathname, or a full URL
+ * and will return the "closest" url matching the default
+ * `<VERCEL_URL || localhost>/api/uploadthing`
+ */
+export function resolveMaybeUrlArg(maybeUrl: string | URL | undefined) {
+  return maybeUrl instanceof URL ? maybeUrl : getFullApiUrl(maybeUrl);
+}

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -126,7 +126,7 @@
   },
   "peerDependencies": {
     "solid-js": "^1.5.3",
-    "uploadthing": "^6.0.0"
+    "uploadthing": "^6.5.1"
   },
   "keywords": [
     "SolidJS",

--- a/packages/solid/src/components/button.tsx
+++ b/packages/solid/src/components/button.tsx
@@ -10,8 +10,12 @@ import {
   styleFieldToClassName,
   styleFieldToCssObject,
 } from "@uploadthing/shared";
-import type { ContentField, StyleField } from "@uploadthing/shared";
-import type { ErrorMessage, FileRouter } from "uploadthing/server";
+import type {
+  ContentField,
+  ErrorMessage,
+  StyleField,
+} from "@uploadthing/shared";
+import type { FileRouter } from "uploadthing/types";
 
 import type { UploadthingComponentProps } from "../types";
 import { INTERNAL_uploadthingHookGen } from "../useUploadThing";

--- a/packages/solid/src/components/button.tsx
+++ b/packages/solid/src/components/button.tsx
@@ -25,21 +25,36 @@ type ButtonStyleFieldCallbackArgs = {
   fileTypes: () => string[];
 };
 
+type ButtonAppearance = {
+  container?: StyleField<ButtonStyleFieldCallbackArgs>;
+  button?: StyleField<ButtonStyleFieldCallbackArgs>;
+  allowedContent?: StyleField<ButtonStyleFieldCallbackArgs>;
+  clearBtn?: StyleField<ButtonStyleFieldCallbackArgs>;
+};
+
+type ButtonContent = {
+  button?: ContentField<ButtonStyleFieldCallbackArgs>;
+  allowedContent?: ContentField<ButtonStyleFieldCallbackArgs>;
+  clearBtn?: ContentField<ButtonStyleFieldCallbackArgs>;
+};
+
 export type UploadButtonProps<
   TRouter extends FileRouter,
   TEndpoint extends keyof TRouter,
   TSkipPolling extends boolean = false,
 > = UploadthingComponentProps<TRouter, TEndpoint, TSkipPolling> & {
-  appearance?: {
-    container?: StyleField<ButtonStyleFieldCallbackArgs>;
-    button?: StyleField<ButtonStyleFieldCallbackArgs>;
-    allowedContent?: StyleField<ButtonStyleFieldCallbackArgs>;
-  };
-  content?: {
-    button?: ContentField<ButtonStyleFieldCallbackArgs>;
-    allowedContent?: ContentField<ButtonStyleFieldCallbackArgs>;
-  };
+  /**
+   * @see https://docs.uploadthing.com/theming#style-using-the-classname-prop
+   */
   class?: string;
+  /**
+   * @see https://docs.uploadthing.com/theming#style-using-the-appearance-prop
+   */
+  appearance?: ButtonAppearance;
+  /**
+   * @see https://docs.uploadthing.com/theming#content-customisation
+   */
+  content?: ButtonContent;
 };
 
 /**

--- a/packages/solid/src/components/button.tsx
+++ b/packages/solid/src/components/button.tsx
@@ -9,8 +9,8 @@ import {
   resolveMaybeUrlArg,
   styleFieldToClassName,
   styleFieldToCssObject,
-} from "uploadthing/client";
-import type { ContentField, StyleField } from "uploadthing/client";
+} from "@uploadthing/shared";
+import type { ContentField, StyleField } from "@uploadthing/shared";
 import type { ErrorMessage, FileRouter } from "uploadthing/server";
 
 import type { UploadthingComponentProps } from "../types";

--- a/packages/solid/src/components/dropzone.tsx
+++ b/packages/solid/src/components/dropzone.tsx
@@ -11,8 +11,12 @@ import {
   styleFieldToClassName,
   styleFieldToCssObject,
 } from "@uploadthing/shared";
-import type { ContentField, StyleField } from "@uploadthing/shared";
-import type { ErrorMessage, FileRouter } from "uploadthing/server";
+import type {
+  ContentField,
+  ErrorMessage,
+  StyleField,
+} from "@uploadthing/shared";
+import type { FileRouter } from "uploadthing/types";
 
 import type { UploadthingComponentProps } from "../types";
 import { INTERNAL_uploadthingHookGen } from "../useUploadThing";

--- a/packages/solid/src/components/dropzone.tsx
+++ b/packages/solid/src/components/dropzone.tsx
@@ -5,13 +5,13 @@ import { createDropzone } from "@uploadthing/dropzone/solid";
 import {
   allowedContentTextLabelGenerator,
   contentFieldToContent,
-  generateClientDropzoneAccept,
   generatePermittedFileTypes,
   resolveMaybeUrlArg,
   styleFieldToClassName,
   styleFieldToCssObject,
-} from "uploadthing/client";
-import type { ContentField, StyleField } from "uploadthing/client";
+} from "@uploadthing/shared";
+import type { ContentField, StyleField } from "@uploadthing/shared";
+import { generateClientDropzoneAccept } from "uploadthing/client";
 import type { ErrorMessage, FileRouter } from "uploadthing/server";
 
 import type { UploadthingComponentProps } from "../types";

--- a/packages/solid/src/components/dropzone.tsx
+++ b/packages/solid/src/components/dropzone.tsx
@@ -5,13 +5,13 @@ import { createDropzone } from "@uploadthing/dropzone/solid";
 import {
   allowedContentTextLabelGenerator,
   contentFieldToContent,
+  generateClientDropzoneAccept,
   generatePermittedFileTypes,
   resolveMaybeUrlArg,
   styleFieldToClassName,
   styleFieldToCssObject,
 } from "@uploadthing/shared";
 import type { ContentField, StyleField } from "@uploadthing/shared";
-import { generateClientDropzoneAccept } from "uploadthing/client";
 import type { ErrorMessage, FileRouter } from "uploadthing/server";
 
 import type { UploadthingComponentProps } from "../types";

--- a/packages/solid/src/components/dropzone.tsx
+++ b/packages/solid/src/components/dropzone.tsx
@@ -27,25 +27,38 @@ type DropzoneStyleFieldCallbackArgs = {
   isDragActive: () => boolean;
 };
 
+type DropzoneAppearance = {
+  container?: StyleField<DropzoneStyleFieldCallbackArgs>;
+  uploadIcon?: StyleField<DropzoneStyleFieldCallbackArgs>;
+  label?: StyleField<DropzoneStyleFieldCallbackArgs>;
+  allowedContent?: StyleField<DropzoneStyleFieldCallbackArgs>;
+  button?: StyleField<DropzoneStyleFieldCallbackArgs>;
+};
+
+type DropzoneContent = {
+  uploadIcon?: ContentField<DropzoneStyleFieldCallbackArgs>;
+  label?: ContentField<DropzoneStyleFieldCallbackArgs>;
+  allowedContent?: ContentField<DropzoneStyleFieldCallbackArgs>;
+  button?: ContentField<DropzoneStyleFieldCallbackArgs>;
+};
+
 export type UploadDropzoneProps<
   TRouter extends FileRouter,
   TEndpoint extends keyof TRouter,
   TSkipPolling extends boolean = false,
 > = UploadthingComponentProps<TRouter, TEndpoint, TSkipPolling> & {
-  appearance?: {
-    container?: StyleField<DropzoneStyleFieldCallbackArgs>;
-    uploadIcon?: StyleField<DropzoneStyleFieldCallbackArgs>;
-    label?: StyleField<DropzoneStyleFieldCallbackArgs>;
-    allowedContent?: StyleField<DropzoneStyleFieldCallbackArgs>;
-    button?: StyleField<DropzoneStyleFieldCallbackArgs>;
-  };
-  content?: {
-    uploadIcon?: ContentField<DropzoneStyleFieldCallbackArgs>;
-    label?: ContentField<DropzoneStyleFieldCallbackArgs>;
-    allowedContent?: ContentField<DropzoneStyleFieldCallbackArgs>;
-    button?: ContentField<DropzoneStyleFieldCallbackArgs>;
-  };
+  /**
+   * @see https://docs.uploadthing.com/theming#style-using-the-classname-prop
+   */
   class?: string;
+  /**
+   * @see https://docs.uploadthing.com/theming#style-using-the-appearance-prop
+   */
+  appearance?: DropzoneAppearance;
+  /**
+   * @see https://docs.uploadthing.com/theming#content-customisation
+   */
+  content?: DropzoneContent;
   config?: {
     mode?: "manual" | "auto";
   };

--- a/packages/solid/src/components/index.tsx
+++ b/packages/solid/src/components/index.tsx
@@ -1,19 +1,17 @@
-import type { ComponentProps, ValidComponent } from "solid-js";
-
 import { resolveMaybeUrlArg } from "@uploadthing/shared";
 import type { FileRouter } from "uploadthing/server";
 
-import type { GenerateTypedHelpersOptions } from "../types";
+import type {
+  GenerateTypedHelpersOptions,
+  UploadthingComponentProps,
+} from "../types";
+import type { UploadButtonProps } from "./button";
 import { UploadButton } from "./button";
+import type { UploadDropzoneProps } from "./dropzone";
 import { UploadDropzone } from "./dropzone";
 import { Uploader } from "./uploader";
 
 export { UploadButton, UploadDropzone, Uploader };
-
-type OmitInitOpts<T extends ValidComponent> = Omit<
-  ComponentProps<T>,
-  keyof GenerateTypedHelpersOptions
->;
 
 export const generateUploadButton = <TRouter extends FileRouter>(
   opts?: GenerateTypedHelpersOptions,
@@ -24,7 +22,10 @@ export const generateUploadButton = <TRouter extends FileRouter>(
     TEndpoint extends keyof TRouter,
     TSkipPolling extends boolean = false,
   >(
-    props: OmitInitOpts<typeof UploadButton<TRouter, TEndpoint, TSkipPolling>>,
+    props: Omit<
+      UploadButtonProps<TRouter, TEndpoint, TSkipPolling>,
+      keyof GenerateTypedHelpersOptions
+    >,
   ) => (
     <UploadButton<TRouter, TEndpoint, TSkipPolling>
       {...(props as any)}
@@ -43,8 +44,9 @@ export const generateUploadDropzone = <TRouter extends FileRouter>(
     TEndpoint extends keyof TRouter,
     TSkipPolling extends boolean = false,
   >(
-    props: OmitInitOpts<
-      typeof UploadDropzone<TRouter, TEndpoint, TSkipPolling>
+    props: Omit<
+      UploadDropzoneProps<TRouter, TEndpoint, TSkipPolling>,
+      keyof GenerateTypedHelpersOptions
     >,
   ) => (
     <UploadDropzone<TRouter, TEndpoint, TSkipPolling>
@@ -64,7 +66,10 @@ export const generateUploader = <TRouter extends FileRouter>(
     TEndpoint extends keyof TRouter,
     TSkipPolling extends boolean = false,
   >(
-    props: OmitInitOpts<typeof Uploader<TRouter, TEndpoint, TSkipPolling>>,
+    props: Omit<
+      UploadthingComponentProps<TRouter, TEndpoint, TSkipPolling>,
+      keyof GenerateTypedHelpersOptions
+    >,
   ) => (
     <Uploader<TRouter, TEndpoint, TSkipPolling> {...(props as any)} url={url} />
   );

--- a/packages/solid/src/components/index.tsx
+++ b/packages/solid/src/components/index.tsx
@@ -1,6 +1,6 @@
 import type { ComponentProps, ValidComponent } from "solid-js";
 
-import { resolveMaybeUrlArg } from "uploadthing/client";
+import { resolveMaybeUrlArg } from "@uploadthing/shared";
 import type { FileRouter } from "uploadthing/server";
 
 import type { GenerateTypedHelpersOptions } from "../types";

--- a/packages/solid/src/components/index.tsx
+++ b/packages/solid/src/components/index.tsx
@@ -1,5 +1,5 @@
 import { resolveMaybeUrlArg } from "@uploadthing/shared";
-import type { FileRouter } from "uploadthing/server";
+import type { FileRouter } from "uploadthing/types";
 
 import type {
   GenerateTypedHelpersOptions,

--- a/packages/solid/src/components/uploader.tsx
+++ b/packages/solid/src/components/uploader.tsx
@@ -1,4 +1,5 @@
-import type { ErrorMessage, FileRouter } from "uploadthing/server";
+import type { ErrorMessage } from "@uploadthing/shared";
+import type { FileRouter } from "uploadthing/types";
 
 import type { UploadthingComponentProps } from "../types";
 

--- a/packages/solid/src/types.ts
+++ b/packages/solid/src/types.ts
@@ -4,7 +4,7 @@ import type {
   inferEndpointInput,
   inferEndpointOutput,
   inferErrorShape,
-  UploadFileResponse,
+  UploadedFile,
 } from "uploadthing/types";
 
 export interface GenerateTypedHelpersOptions {
@@ -55,7 +55,7 @@ export type UseUploadthingProps<
    * - If `skipPolling` is `false`, this will be called after
    *   the serverside `onUploadComplete` callback has finished
    */
-  onClientUploadComplete?: (res: UploadFileResponse<TServerOutput>[]) => void;
+  onClientUploadComplete?: (res: UploadedFile<TServerOutput>[]) => void;
   /**
    * Called if the upload fails
    */

--- a/packages/solid/src/types.ts
+++ b/packages/solid/src/types.ts
@@ -1,11 +1,11 @@
 import type { ExtendObjectIf, UploadThingError } from "@uploadthing/shared";
-import type { UploadFileResponse } from "uploadthing/client";
 import type {
   FileRouter,
   inferEndpointInput,
   inferEndpointOutput,
   inferErrorShape,
-} from "uploadthing/server";
+  UploadFileResponse,
+} from "uploadthing/types";
 
 export interface GenerateTypedHelpersOptions {
   /**

--- a/packages/solid/src/types.ts
+++ b/packages/solid/src/types.ts
@@ -1,4 +1,4 @@
-import type { UploadThingError } from "@uploadthing/shared";
+import type { ExtendObjectIf, UploadThingError } from "@uploadthing/shared";
 import type { UploadFileResponse } from "uploadthing/client";
 import type {
   FileRouter,
@@ -28,12 +28,38 @@ export type UseUploadthingProps<
     ? inferEndpointOutput<TRouter[TEndpoint]>
     : null,
 > = {
-  skipPolling?: TSkipPolling;
-  onClientUploadComplete?: (res: UploadFileResponse<TServerOutput>[]) => void;
-  onUploadProgress?: (p: number) => void;
-  onUploadError?: (e: UploadThingError<inferErrorShape<TRouter>>) => void;
+  /**
+   * Called when the upload is submitted and the server is about to be queried for presigned URLs
+   * Can be used to modify the files before they are uploaded, e.g. renaming them
+   */
+  onBeforeUploadBegin?: (files: File[]) => Promise<File[]> | File[];
+  /**
+   * Called when presigned URLs have been retrieved and the file upload is about to begin
+   */
   onUploadBegin?: (fileName: string) => void;
-  onBeforeUploadBegin?: (files: File[]) => File[] | Promise<File[]>;
+  /**
+   * Called continuously as the file is uploaded to the storage provider
+   */
+  onUploadProgress?: (p: number) => void;
+  /**
+   * Skip polling for server data after upload is complete
+   * Useful if you want faster response times and don't need
+   * any data returned from the server `onUploadComplete` callback
+   * @default false
+   */
+  skipPolling?: TSkipPolling;
+  /**
+   * Called when the file uploads are completed
+   * - If `skipPolling` is `true`, this will be called once
+   *   all the files are uploaded to the storage provider.
+   * - If `skipPolling` is `false`, this will be called after
+   *   the serverside `onUploadComplete` callback has finished
+   */
+  onClientUploadComplete?: (res: UploadFileResponse<TServerOutput>[]) => void;
+  /**
+   * Called if the upload fails
+   */
+  onUploadError?: (e: UploadThingError<inferErrorShape<TRouter>>) => void;
 };
 
 export type UploadthingComponentProps<
@@ -41,6 +67,9 @@ export type UploadthingComponentProps<
   TEndpoint extends keyof TRouter,
   TSkipPolling extends boolean = false,
 > = UseUploadthingProps<TRouter, TEndpoint, TSkipPolling> & {
+  /**
+   * The endpoint from your FileRouter to use for the upload
+   */
   endpoint: TEndpoint;
   /**
    * URL to the UploadThing API endpoint
@@ -52,9 +81,13 @@ export type UploadthingComponentProps<
    * @default (VERCEL_URL ?? window.location.origin) + "/api/uploadthing"
    */
   url?: string | URL;
-} & (undefined extends inferEndpointInput<TRouter[TEndpoint]>
-    ? // eslint-disable-next-line @typescript-eslint/ban-types
-      {}
-    : {
-        input: inferEndpointInput<TRouter[TEndpoint]>;
-      });
+} & ExtendObjectIf<
+    inferEndpointInput<TRouter[TEndpoint]>,
+    {
+      /**
+       * The input to the endpoint, as defined using `.input()` on the FileRouter endpoint
+       * @see https://docs.uploadthing.com/api-reference/server#input
+       */
+      input: inferEndpointInput<TRouter[TEndpoint]>;
+    }
+  >;

--- a/packages/solid/src/useUploadThing.ts
+++ b/packages/solid/src/useUploadThing.ts
@@ -11,7 +11,7 @@ import type {
   FileRouter,
   inferEndpointInput,
   inferErrorShape,
-} from "uploadthing/server";
+} from "uploadthing/types";
 
 import type { GenerateTypedHelpersOptions, UseUploadthingProps } from "./types";
 import { createFetch } from "./utils/createFetch";

--- a/packages/uploadthing/package.json
+++ b/packages/uploadthing/package.json
@@ -88,6 +88,10 @@
         "default": "./h3/index.cjs"
       }
     },
+    "./types": {
+      "types": "./types/index.d.ts",
+      "default": "./types/index.js"
+    },
     "./internal/types": {
       "import": {
         "types": "./internal/types.d.ts",
@@ -108,6 +112,7 @@
     "next",
     "next-legacy",
     "server",
+    "types",
     "tw"
   ],
   "publishConfig": {

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -18,7 +18,7 @@ import type {
   GenerateUploaderOptions,
   MPUResponse,
   PSPResponse,
-  UploadFileResponse,
+  UploadedFile,
   UploadFilesOptions,
   UploadThingResponse,
 } from "./types";
@@ -42,7 +42,7 @@ const uploadFilesInternal = async <
 >(
   endpoint: TEndpoint,
   opts: UploadFilesOptions<TRouter, TEndpoint, TSkipPolling>,
-): Promise<UploadFileResponse<TServerOutput>[]> => {
+): Promise<UploadedFile<TServerOutput>[]> => {
   // Fine to use global fetch in browser
   const fetch = globalThis.fetch.bind(globalThis);
 

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -208,7 +208,7 @@ const uploadFilesInternal = async <
   return Promise.all(fileUploadPromises) as any;
 };
 
-export type GenerateTypedHelpersOptions = {
+type GenerateUploaderOptions = {
   /**
    * URL to the UploadThing API endpoint
    * @example /api/uploadthing
@@ -229,7 +229,7 @@ export type GenerateTypedHelpersOptions = {
 };
 
 export const genUploader = <TRouter extends FileRouter>(
-  initOpts: GenerateTypedHelpersOptions,
+  initOpts: GenerateUploaderOptions,
 ) => {
   return <
     TEndpoint extends keyof TRouter,
@@ -238,7 +238,7 @@ export const genUploader = <TRouter extends FileRouter>(
     endpoint: TEndpoint,
     opts: Omit<
       UploadFilesOptions<TRouter, TEndpoint, TSkipPolling>,
-      keyof GenerateTypedHelpersOptions
+      keyof GenerateUploaderOptions
     >,
   ) =>
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -3,7 +3,6 @@
 
 import type { ExtendObjectIf } from "@uploadthing/shared";
 import {
-  generateMimeTypes,
   safeParseJSON,
   UploadThingError,
   withExponentialBackoff,
@@ -25,6 +24,13 @@ import type {
 } from "./internal/types";
 import type { UTReporter } from "./internal/ut-reporter";
 import { createAPIRequestUrl, createUTReporter } from "./internal/ut-reporter";
+
+export {
+  /** @public */
+  generateMimeTypes,
+  /** @public */
+  generateClientDropzoneAccept,
+} from "@uploadthing/shared";
 
 export const version = pkgJson.version;
 
@@ -241,14 +247,6 @@ export const genUploader = <TRouter extends FileRouter>(
       url: resolveMaybeUrlArg(initOpts?.url),
       package: initOpts.package,
     } as any);
-};
-
-export const generateClientDropzoneAccept = (fileTypes: string[]) => {
-  const mimeTypes = generateMimeTypes(fileTypes);
-
-  if (!mimeTypes) return undefined;
-
-  return Object.fromEntries(mimeTypes.map((type) => [type, []]));
 };
 
 async function uploadMultipart(

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -22,6 +22,7 @@ import type {
   inferEndpointInput,
   inferEndpointOutput,
 } from "./internal/types";
+import type { UTReporter } from "./internal/ut-reporter";
 import { createAPIRequestUrl, createUTReporter } from "./internal/ut-reporter";
 
 export const version = pkgJson.version;
@@ -74,7 +75,7 @@ export type UploadFileResponse<TServerOutput> = {
   serverData: TServerOutput;
 };
 
-const DANGEROUS__uploadFiles = async <
+const uploadFilesInternal = async <
   TRouter extends FileRouter,
   TEndpoint extends keyof TRouter,
   TSkipPolling extends boolean = false,
@@ -232,7 +233,7 @@ export const genUploader = <TRouter extends FileRouter>(initOpts: {
     >,
   ) =>
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    DANGEROUS__uploadFiles<TRouter, TEndpoint, TSkipPolling>(endpoint, {
+    uploadFilesInternal<TRouter, TEndpoint, TSkipPolling>(endpoint, {
       ...opts,
       url,
       package: utPkg,
@@ -251,7 +252,7 @@ async function uploadMultipart(
   file: File,
   presigned: MPUResponse,
   opts: {
-    reportEventToUT: ReturnType<typeof createUTReporter>;
+    reportEventToUT: UTReporter;
     onUploadProgress?: UploadFilesOptions<any, any>["onUploadProgress"];
   },
 ) {
@@ -311,7 +312,7 @@ async function uploadPresignedPost(
   file: File,
   presigned: PSPResponse,
   opts: {
-    reportEventToUT: ReturnType<typeof createUTReporter>;
+    reportEventToUT: UTReporter;
     onUploadProgress?: UploadFilesOptions<any, any>["onUploadProgress"];
   },
 ) {

--- a/packages/uploadthing/src/express.ts
+++ b/packages/uploadthing/src/express.ts
@@ -9,7 +9,6 @@ import { getStatusCodeFromError, UploadThingError } from "@uploadthing/shared";
 
 import { UPLOADTHING_VERSION } from "./internal/constants";
 import { formatError } from "./internal/error-formatter";
-import type { RouterWithConfig } from "./internal/handler";
 import {
   buildPermissionsInfoHandler,
   buildRequestHandler,
@@ -18,7 +17,7 @@ import { incompatibleNodeGuard } from "./internal/incompat-node-guard";
 import { initLogger, logger } from "./internal/logger";
 import { getPostBody } from "./internal/node-http/getBody";
 import { toWebRequest } from "./internal/node-http/toWebRequest";
-import type { FileRouter } from "./internal/types";
+import type { FileRouter, RouterWithConfig } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
 

--- a/packages/uploadthing/src/express.ts
+++ b/packages/uploadthing/src/express.ts
@@ -68,10 +68,8 @@ export const createRouteHandler = <TRouter extends FileRouter>(
     }
 
     const response = await requestHandler({
-      nativeRequest: toWebRequest(req, bodyResult.data),
-      originalRequest: req,
-      res,
-      event: undefined,
+      req: toWebRequest(req, bodyResult.data),
+      middlewareArgs: { req, res, event: undefined },
     });
 
     if (response instanceof UploadThingError) {

--- a/packages/uploadthing/src/fastify.ts
+++ b/packages/uploadthing/src/fastify.ts
@@ -50,10 +50,8 @@ export const createRouteHandler = <TRouter extends FileRouter>(
 
   const POST: RouteHandlerMethod = async (req, res) => {
     const response = await requestHandler({
-      nativeRequest: toWebRequest(req),
-      originalRequest: req,
-      res,
-      event: undefined,
+      req: toWebRequest(req),
+      middlewareArgs: { req, res, event: undefined },
     });
 
     if (response instanceof UploadThingError) {

--- a/packages/uploadthing/src/fastify.ts
+++ b/packages/uploadthing/src/fastify.ts
@@ -10,7 +10,6 @@ import { getStatusCodeFromError, UploadThingError } from "@uploadthing/shared";
 
 import { UPLOADTHING_VERSION } from "./internal/constants";
 import { formatError } from "./internal/error-formatter";
-import type { RouterWithConfig } from "./internal/handler";
 import {
   buildPermissionsInfoHandler,
   buildRequestHandler,
@@ -18,7 +17,7 @@ import {
 import { incompatibleNodeGuard } from "./internal/incompat-node-guard";
 import { initLogger } from "./internal/logger";
 import { toWebRequest } from "./internal/node-http/toWebRequest";
-import type { FileRouter } from "./internal/types";
+import type { FileRouter, RouterWithConfig } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
 

--- a/packages/uploadthing/src/h3.ts
+++ b/packages/uploadthing/src/h3.ts
@@ -16,10 +16,9 @@ import {
   buildPermissionsInfoHandler,
   buildRequestHandler,
 } from "./internal/handler";
-import type { RouterWithConfig } from "./internal/handler";
 import { incompatibleNodeGuard } from "./internal/incompat-node-guard";
 import { initLogger } from "./internal/logger";
-import type { FileRouter } from "./internal/types";
+import type { FileRouter, RouterWithConfig } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
 

--- a/packages/uploadthing/src/h3.ts
+++ b/packages/uploadthing/src/h3.ts
@@ -54,10 +54,8 @@ export const createRouteHandler = <TRouter extends FileRouter>(
 
     // POST
     const response = await requestHandler({
-      nativeRequest: toWebRequest(event),
-      event,
-      originalRequest: undefined,
-      res: undefined,
+      req: toWebRequest(event),
+      middlewareArgs: { req: undefined, res: undefined, event },
     });
 
     if (response instanceof UploadThingError) {

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -10,7 +10,6 @@ import {
   UploadThingError,
 } from "@uploadthing/shared";
 import type {
-  ContentDisposition,
   ExpandedRouteConfig,
   FetchEsque,
   FileRouterInputKey,
@@ -18,10 +17,10 @@ import type {
   UploadedFile,
 } from "@uploadthing/shared";
 
+import type { UploadThingResponse } from "../types";
 import { UPLOADTHING_VERSION } from "./constants";
 import { conditionalDevServer } from "./dev-hook";
 import { getFullApiUrl } from "./get-full-api-url";
-import type { LogLevel } from "./logger";
 import { logger } from "./logger";
 import { getParseFn } from "./parser";
 import { UTFiles, VALID_ACTION_TYPES } from "./types";
@@ -29,6 +28,7 @@ import type {
   ActionType,
   FileRouter,
   MiddlewareFnArgs,
+  RouterWithConfig,
   UTEvents,
   ValidMiddlewareObject,
 } from "./types";
@@ -97,52 +97,6 @@ const fileCountLimitHit = (
 
   return { limitHit: false };
 };
-
-type RouteHandlerConfig = {
-  logLevel?: LogLevel;
-  callbackUrl?: string;
-  uploadthingId?: string;
-  uploadthingSecret?: string;
-  /**
-   * Used to determine whether to run dev hook or not
-   * @default `env.NODE_ENV === "development" || env.NODE_ENV === "dev"`
-   */
-  isDev?: boolean;
-  /**
-   * Used to override the fetch implementation
-   * @default `globalThis.fetch`
-   */
-  fetch?: FetchEsque;
-};
-
-export type RouterWithConfig<TRouter extends FileRouter> = {
-  router: TRouter;
-  config?: RouteHandlerConfig;
-};
-
-interface UploadThingBaseResponse {
-  key: string;
-  fileName: string;
-  fileType: FileRouterInputKey;
-  fileUrl: string;
-  contentDisposition: ContentDisposition;
-  pollingJwt: string;
-  pollingUrl: string;
-}
-
-export interface PSPResponse extends UploadThingBaseResponse {
-  url: string;
-  fields: Record<string, string>;
-}
-
-export interface MPUResponse extends UploadThingBaseResponse {
-  urls: string[];
-  uploadId: string;
-  chunkSize: number;
-  chunkCount: number;
-}
-
-export type UploadThingResponse = (PSPResponse | MPUResponse)[];
 
 export const buildRequestHandler = <
   TRouter extends FileRouter,

--- a/packages/uploadthing/src/internal/parser.ts
+++ b/packages/uploadthing/src/internal/parser.ts
@@ -1,6 +1,4 @@
-import type { Json } from "@uploadthing/shared";
-
-import type { MaybePromise } from "./types";
+import type { Json, MaybePromise } from "@uploadthing/shared";
 
 // Don't want to use Zod cause it's an optional dependency
 export type ParseFn<TType> = (input: unknown) => MaybePromise<TType>;

--- a/packages/uploadthing/src/internal/types.ts
+++ b/packages/uploadthing/src/internal/types.ts
@@ -11,6 +11,7 @@ import type {
   UploadThingError,
 } from "@uploadthing/shared";
 
+import type { UploadThingResponse } from "../types";
 import type { LogLevel } from "./logger";
 import type { JsonParser } from "./parser";
 
@@ -46,6 +47,8 @@ export type MiddlewareFnArgs<TRequest, TResponse, TEvent> = {
   res: TResponse;
   event: TEvent;
 };
+export type AnyMiddlewareFnArgs = MiddlewareFnArgs<any, any, any>;
+
 export interface AnyParams {
   _input: any;
   _metadata: any; // imaginary field used to bind metadata return type to an Upload resolver
@@ -163,6 +166,23 @@ export type RouterWithConfig<TRouter extends FileRouter> = {
   router: TRouter;
   config?: RouteHandlerConfig;
 };
+
+type RequestHandlerInput<TArgs extends AnyMiddlewareFnArgs> = {
+  req: Request;
+  middlewareArgs: TArgs;
+};
+type RequestHandlerOutput = Promise<
+  | {
+      status: number;
+      body?: UploadThingResponse;
+      cleanup?: Promise<unknown>;
+    }
+  | UploadThingError
+>;
+
+export type RequestHandler<TArgs extends AnyMiddlewareFnArgs> = (
+  input: RequestHandlerInput<TArgs>,
+) => RequestHandlerOutput;
 
 export type inferEndpointInput<TUploader extends Uploader<any>> =
   TUploader["_def"]["_input"] extends UnsetMarker

--- a/packages/uploadthing/src/internal/types.ts
+++ b/packages/uploadthing/src/internal/types.ts
@@ -1,12 +1,17 @@
 /* eslint-disable @typescript-eslint/ban-types */
 
 import type {
+  ErrorMessage,
+  FetchEsque,
   FileRouterInputConfig,
   Json,
+  MaybePromise,
+  Simplify,
   UploadedFile,
   UploadThingError,
 } from "@uploadthing/shared";
 
+import type { LogLevel } from "./logger";
 import type { JsonParser } from "./parser";
 
 //
@@ -15,10 +20,6 @@ export const unsetMarker = "unsetMarker" as "unsetMarker" & {
   __brand: "unsetMarker";
 };
 export type UnsetMarker = typeof unsetMarker;
-
-export type Simplify<TType> = { [TKey in keyof TType]: TType[TKey] } & {};
-
-export type MaybePromise<TType> = TType | Promise<TType>;
 
 //
 // Package
@@ -73,8 +74,6 @@ type UploadErrorFn = (input: {
   error: UploadThingError;
   fileKey: string;
 }) => void;
-
-export type ErrorMessage<TError extends string> = TError;
 
 export interface UploadBuilder<TParams extends AnyParams> {
   input: <TParser extends JsonParser>(
@@ -142,6 +141,28 @@ export type FileRouter<TParams extends AnyParams = AnyParams> = Record<
   string,
   Uploader<TParams>
 >;
+
+type RouteHandlerConfig = {
+  logLevel?: LogLevel;
+  callbackUrl?: string;
+  uploadthingId?: string;
+  uploadthingSecret?: string;
+  /**
+   * Used to determine whether to run dev hook or not
+   * @default `env.NODE_ENV === "development" || env.NODE_ENV === "dev"`
+   */
+  isDev?: boolean;
+  /**
+   * Used to override the fetch implementation
+   * @default `globalThis.fetch`
+   */
+  fetch?: FetchEsque;
+};
+
+export type RouterWithConfig<TRouter extends FileRouter> = {
+  router: TRouter;
+  config?: RouteHandlerConfig;
+};
 
 export type inferEndpointInput<TUploader extends Uploader<any>> =
   TUploader["_def"]["_input"] extends UnsetMarker

--- a/packages/uploadthing/src/internal/types.ts
+++ b/packages/uploadthing/src/internal/types.ts
@@ -20,14 +20,6 @@ export type Simplify<TType> = { [TKey in keyof TType]: TType[TKey] } & {};
 
 export type MaybePromise<TType> = TType | Promise<TType>;
 
-/**
- * Omits the key without removing a potential union
- * @internal
- */
-export type DistributiveOmit<TObj, TKey extends keyof any> = TObj extends any
-  ? Omit<TObj, TKey>
-  : never;
-
 //
 // Package
 export const UTFiles = Symbol("uploadthing-custom-id-symbol");

--- a/packages/uploadthing/src/internal/ut-reporter.ts
+++ b/packages/uploadthing/src/internal/ut-reporter.ts
@@ -25,6 +25,11 @@ export const createAPIRequestUrl = (config: {
   return url;
 };
 
+export type UTReporter = <TEvent extends keyof UTEvents>(
+  type: TEvent,
+  payload: UTEvents[TEvent],
+) => Promise<boolean>;
+
 /**
  * Creates a "client" for reporting events to the UploadThing server via the user's API endpoint.
  * Events are handled in "./handler.ts starting at L200"
@@ -34,11 +39,8 @@ export const createUTReporter = (cfg: {
   endpoint: string;
   package: string;
   fetch: FetchEsque;
-}) => {
-  return async <TEvent extends keyof UTEvents>(
-    type: TEvent,
-    payload: UTEvents[TEvent],
-  ) => {
+}): UTReporter => {
+  return async (type, payload) => {
     const url = createAPIRequestUrl({
       url: cfg.url,
       slug: cfg.endpoint,

--- a/packages/uploadthing/src/next-legacy.ts
+++ b/packages/uploadthing/src/next-legacy.ts
@@ -52,10 +52,8 @@ export const createRouteHandler = <TRouter extends FileRouter>(
     }
 
     const response = await requestHandler({
-      nativeRequest: toWebRequest(req),
-      originalRequest: req,
-      res,
-      event: undefined,
+      req: toWebRequest(req),
+      middlewareArgs: { req, res, event: undefined },
     });
 
     res.setHeader("x-uploadthing-version", UPLOADTHING_VERSION);

--- a/packages/uploadthing/src/next-legacy.ts
+++ b/packages/uploadthing/src/next-legacy.ts
@@ -11,11 +11,10 @@ import {
   buildPermissionsInfoHandler,
   buildRequestHandler,
 } from "./internal/handler";
-import type { RouterWithConfig } from "./internal/handler";
 import { incompatibleNodeGuard } from "./internal/incompat-node-guard";
 import { initLogger } from "./internal/logger";
 import { toWebRequest } from "./internal/node-http/toWebRequest";
-import type { FileRouter } from "./internal/types";
+import type { FileRouter, RouterWithConfig } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
 

--- a/packages/uploadthing/src/next.ts
+++ b/packages/uploadthing/src/next.ts
@@ -2,8 +2,7 @@ import type { NextRequest } from "next/server";
 
 import type { Json } from "@uploadthing/shared";
 
-import type { RouterWithConfig } from "./internal/handler";
-import type { FileRouter } from "./internal/types";
+import type { FileRouter, RouterWithConfig } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
 import { INTERNAL_DO_NOT_USE_createRouteHandlerCore } from "./server";

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -32,8 +32,6 @@ import {
   uploadFilesInternal,
 } from "./utils";
 
-export type * from "./types";
-
 interface UTFilePropertyBag extends BlobPropertyBag {
   lastModified?: number;
   customId?: string;

--- a/packages/uploadthing/src/sdk/types.ts
+++ b/packages/uploadthing/src/sdk/types.ts
@@ -1,6 +1,14 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
 import type { File as UndiciFile } from "undici";
 
-import type { FetchEsque, MaybeUrl } from "@uploadthing/shared";
+import type {
+  ACL,
+  ContentDisposition,
+  FetchEsque,
+  Json,
+  MaybeUrl,
+  Time,
+} from "@uploadthing/shared";
 
 import type { LogLevel } from "../internal/logger";
 
@@ -53,3 +61,42 @@ export type UploadError = {
 export type UploadFileResponse =
   | { data: UploadData; error: null }
   | { data: null; error: UploadError };
+
+export interface UploadFilesOptions {
+  metadata?: Json;
+  contentDisposition?: ContentDisposition;
+  acl?: ACL;
+}
+
+interface KeyTypeOptionsBase {
+  /**
+   * Whether the provided key is a fileKey or a custom identifier. fileKey is the
+   * identifier you get from UploadThing after uploading a file, customId is a
+   * custom identifier you provided when uploading a file.
+   * @default fileKey
+   */
+  keyType?: "fileKey" | "customId";
+}
+
+export interface DeleteFilesOptions extends KeyTypeOptionsBase {}
+
+export interface GetFileUrlsOptions extends KeyTypeOptionsBase {}
+
+export interface ListFilesOptions {
+  limit?: number;
+  offset?: number;
+}
+
+type KeyRename = { key: string; newName: string };
+type CustomIdRename = { customId: string; newName: string };
+export type RenameFileUpdate = KeyRename | CustomIdRename;
+
+export interface GetSignedURLOptions extends KeyTypeOptionsBase {
+  /**
+   * How long the URL will be valid for.
+   * - Must be positive and less than 7 days (604800 seconds).
+   * - You must accept overrides on the UploadThing dashboard for this option to be accepted.
+   * @default app default on UploadThing dashboard
+   */
+  expiresIn?: Time;
+}

--- a/packages/uploadthing/src/sdk/utils.ts
+++ b/packages/uploadthing/src/sdk/utils.ts
@@ -1,13 +1,6 @@
 import { process } from "std-env";
 
-import type {
-  ACL,
-  ContentDisposition,
-  FetchEsque,
-  Json,
-  Time,
-  TimeShort,
-} from "@uploadthing/shared";
+import type { FetchEsque, Time, TimeShort } from "@uploadthing/shared";
 import {
   generateUploadThingURL,
   pollForFileData,
@@ -19,7 +12,12 @@ import { logger } from "../internal/logger";
 import { uploadPart } from "../internal/multi-part";
 import type { UTEvents } from "../internal/types";
 import type { MPUResponse, PSPResponse, UploadThingResponse } from "../types";
-import type { FileEsque, UploadData, UploadError } from "./types";
+import type {
+  FileEsque,
+  UploadData,
+  UploadError,
+  UploadFilesOptions,
+} from "./types";
 
 export function guardServerOnly() {
   if (typeof window !== "undefined") {
@@ -41,11 +39,8 @@ export function getApiKeyOrThrow(apiKey?: string) {
 }
 
 export const uploadFilesInternal = async (
-  data: {
+  data: UploadFilesOptions & {
     files: FileEsque[];
-    metadata: Json;
-    contentDisposition: ContentDisposition;
-    acl?: ACL;
   },
   opts: {
     fetch: FetchEsque;

--- a/packages/uploadthing/src/sdk/utils.ts
+++ b/packages/uploadthing/src/sdk/utils.ts
@@ -15,14 +15,10 @@ import {
 } from "@uploadthing/shared";
 
 import { UPLOADTHING_VERSION } from "../internal/constants";
-import type {
-  MPUResponse,
-  PSPResponse,
-  UploadThingResponse,
-} from "../internal/handler";
 import { logger } from "../internal/logger";
 import { uploadPart } from "../internal/multi-part";
 import type { UTEvents } from "../internal/types";
+import type { MPUResponse, PSPResponse, UploadThingResponse } from "../types";
 import type { FileEsque, UploadData, UploadError } from "./types";
 
 export function guardServerOnly() {

--- a/packages/uploadthing/src/server.ts
+++ b/packages/uploadthing/src/server.ts
@@ -14,7 +14,7 @@ import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
 
 export { UTFiles } from "./internal/types";
-export * from "./sdk";
+export { UTApi, UTFile } from "./sdk";
 export { UploadThingError, type FileRouter };
 
 type MiddlewareArgs = { req: Request; res: undefined; event: undefined };

--- a/packages/uploadthing/src/server.ts
+++ b/packages/uploadthing/src/server.ts
@@ -49,10 +49,8 @@ export const INTERNAL_DO_NOT_USE_createRouteHandlerCore = <
   ): Promise<Response | ResponseWithCleanup> => {
     const req = request instanceof Request ? request : request.request;
     const response = await requestHandler({
-      nativeRequest: req,
-      originalRequest: req,
-      event: undefined,
-      res: undefined,
+      req,
+      middlewareArgs: { req, res: undefined, event: undefined },
     });
 
     if (response instanceof UploadThingError) {

--- a/packages/uploadthing/src/server.ts
+++ b/packages/uploadthing/src/server.ts
@@ -3,21 +3,19 @@ import type { Json } from "@uploadthing/shared";
 
 import { UPLOADTHING_VERSION } from "./internal/constants";
 import { formatError } from "./internal/error-formatter";
-import type { RouterWithConfig } from "./internal/handler";
 import {
   buildPermissionsInfoHandler,
   buildRequestHandler,
 } from "./internal/handler";
 import { incompatibleNodeGuard } from "./internal/incompat-node-guard";
 import { initLogger } from "./internal/logger";
-import type { FileRouter } from "./internal/types";
+import type { FileRouter, RouterWithConfig } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
 
-export type * from "./internal/types";
 export { UTFiles } from "./internal/types";
 export { UTApi, UTFile } from "./sdk";
-export { UploadThingError };
+export { UploadThingError, type FileRouter };
 
 type MiddlewareArgs = { req: Request; res: undefined; event: undefined };
 

--- a/packages/uploadthing/src/server.ts
+++ b/packages/uploadthing/src/server.ts
@@ -14,7 +14,7 @@ import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
 
 export { UTFiles } from "./internal/types";
-export { UTApi, UTFile } from "./sdk";
+export * from "./sdk";
 export { UploadThingError, type FileRouter };
 
 type MiddlewareArgs = { req: Request; res: undefined; event: undefined };

--- a/packages/uploadthing/src/types.ts
+++ b/packages/uploadthing/src/types.ts
@@ -58,7 +58,7 @@ export type UploadFilesOptions<
   { input: inferEndpointInput<TRouter[TEndpoint]> }
 >;
 
-export type UploadFileResponse<TServerOutput> = {
+export type UploadedFile<TServerOutput> = {
   name: string;
   size: number;
   key: string;

--- a/packages/uploadthing/src/types.ts
+++ b/packages/uploadthing/src/types.ts
@@ -14,6 +14,8 @@ export type {
   FileRouter,
 } from "./internal/types";
 
+export * from "./sdk/types";
+
 export type UploadFilesOptions<
   TRouter extends FileRouter,
   TEndpoint extends keyof TRouter,

--- a/packages/uploadthing/src/types.ts
+++ b/packages/uploadthing/src/types.ts
@@ -1,0 +1,110 @@
+import type {
+  ContentDisposition,
+  ExtendObjectIf,
+  FileRouterInputKey,
+} from "@uploadthing/shared";
+
+import type { FileRouter } from "./express";
+import type { inferEndpointInput } from "./internal/types";
+
+export type {
+  inferEndpointInput,
+  inferEndpointOutput,
+  inferErrorShape,
+  FileRouter,
+} from "./internal/types";
+
+export type UploadFilesOptions<
+  TRouter extends FileRouter,
+  TEndpoint extends keyof TRouter,
+  TSkipPolling extends boolean = false,
+> = {
+  /**
+   * The files to upload
+   */
+  files: File[];
+  /**
+   * Called when presigned URLs have been retrieved and the file upload is about to begin
+   */
+  onUploadBegin?: (opts: { file: string }) => void;
+  /**
+   * Called continuously as the file is uploaded to the storage provider
+   */
+  onUploadProgress?: (opts: { file: string; progress: number }) => void;
+  /**
+   * Skip polling for server data after upload is complete
+   * Useful if you want faster response times and don't need
+   * any data returned from the server `onUploadComplete` callback
+   * @default false
+   */
+  skipPolling?: TSkipPolling;
+  /**
+   * URL to the UploadThing API endpoint
+   * @example URL { http://localhost:3000/api/uploadthing }
+   * @example URL { https://www.example.com/api/uploadthing }
+   * @remarks This option is not required when `uploadFiles` has been generated with `genUploader`
+   */
+  url: URL;
+  /**
+   * The uploadthing package that is making this request, used to identify the client in the server logs
+   * @example "@uploadthing/react"
+   * @remarks This option is not required when `uploadFiles` has been generated with `genUploader`
+   */
+  package: string;
+} & ExtendObjectIf<
+  inferEndpointInput<TRouter[TEndpoint]>,
+  { input: inferEndpointInput<TRouter[TEndpoint]> }
+>;
+
+export type UploadFileResponse<TServerOutput> = {
+  name: string;
+  size: number;
+  key: string;
+  url: string;
+  // Matches what's returned from the serverside `onUploadComplete` callback
+  serverData: TServerOutput;
+};
+
+export type GenerateUploaderOptions = {
+  /**
+   * URL to the UploadThing API endpoint
+   * @example /api/uploadthing
+   * @example URL { https://www.example.com/api/uploadthing }
+   *
+   * If relative, host will be inferred from either the `VERCEL_URL` environment variable or `window.location.origin`
+   *
+   * @default (VERCEL_URL ?? window.location.origin) + "/api/uploadthing"
+   */
+  url?: string | URL;
+  /**
+   * The uploadthing package that is making this request
+   * @example "@uploadthing/react"
+   *
+   * This is used to identify the client in the server logs
+   */
+  package: string;
+};
+
+interface UploadThingBaseResponse {
+  key: string;
+  fileName: string;
+  fileType: FileRouterInputKey;
+  fileUrl: string;
+  contentDisposition: ContentDisposition;
+  pollingJwt: string;
+  pollingUrl: string;
+}
+
+export interface PSPResponse extends UploadThingBaseResponse {
+  url: string;
+  fields: Record<string, string>;
+}
+
+export interface MPUResponse extends UploadThingBaseResponse {
+  urls: string[];
+  uploadId: string;
+  chunkSize: number;
+  chunkCount: number;
+}
+
+export type UploadThingResponse = (PSPResponse | MPUResponse)[];

--- a/packages/uploadthing/test/__test-helpers.ts
+++ b/packages/uploadthing/test/__test-helpers.ts
@@ -3,8 +3,8 @@ import { beforeEach, vi } from "vitest";
 import type { FetchEsque } from "@uploadthing/shared";
 
 import { UPLOADTHING_VERSION } from "../src/internal/constants";
-import type { PSPResponse } from "../src/internal/handler";
-import type { ActionType } from "../src/server";
+import type { ActionType } from "../src/internal/types";
+import type { PSPResponse } from "../src/types";
 
 export const fetchMock = vi.fn();
 export const middlewareMock = vi.fn();

--- a/packages/uploadthing/test/gen-uploader.test.ts
+++ b/packages/uploadthing/test/gen-uploader.test.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { genUploader } from "../src/client";
 import type { FileRouter } from "../src/internal/types";
 import { createBuilder } from "../src/internal/upload-builder";
-import type { UploadFileResponse } from "../src/types";
+import type { UploadedFile } from "../src/types";
 
 const doNotExecute = (_fn: (...args: any[]) => any) => {
   // noop
@@ -39,14 +39,14 @@ describe("genuploader", () => {
     doNotExecute(async () => {
       // @ts-expect-error - Input should be required here
       const res = await uploader("uploadable2", { files });
-      expectTypeOf<UploadFileResponse<{ baz: "qux" }>[]>(res);
+      expectTypeOf<UploadedFile<{ baz: "qux" }>[]>(res);
     });
   });
 
   it("types serverData as null if polling is skipped", () => {
     doNotExecute(async () => {
       const res = await uploader("uploadable1", { files, skipPolling: true });
-      expectTypeOf<UploadFileResponse<null>[]>(res);
+      expectTypeOf<UploadedFile<null>[]>(res);
     });
   });
 });

--- a/packages/uploadthing/test/gen-uploader.test.ts
+++ b/packages/uploadthing/test/gen-uploader.test.ts
@@ -1,10 +1,10 @@
 import { describe, expectTypeOf, it } from "vitest";
 import { z } from "zod";
 
-import type { UploadFileResponse } from "../src/client";
 import { genUploader } from "../src/client";
 import type { FileRouter } from "../src/internal/types";
 import { createBuilder } from "../src/internal/upload-builder";
+import type { UploadFileResponse } from "../src/types";
 
 const doNotExecute = (_fn: (...args: any[]) => any) => {
   // noop


### PR DESCRIPTION
cleanup entrypoints to only contain public stuff, moves internal stuff to `@uploadthing/shared`

- extracts deep inline types to named types for better hover-ability
- adds jsdoc comments, again for better hover-ability

There's potentially some breaking changes here since I've moved some types around, but none of which should have been used publically so I think it's fine.