### PR TITLE
fix: update styles for scalar api code blocks

### DIFF
--- a/docs/src/globals.css
+++ b/docs/src/globals.css
@@ -102,6 +102,10 @@
   background: var(--theme-color-accent) !important;
 }
 
+.scalar-codeblock-code {
+  display: unset;
+}
+
 :root {
   --theme-color-accent: hsla(4, 61%, 49%, 1);
   --theme-color-background: hsla(348, 71%, 93%, 1);


### PR DESCRIPTION
Before:
<img width="709" alt="image" src="https://github.com/pingdotgg/uploadthing/assets/2293095/dccc1057-5089-4fa1-827b-a56f2b499ab2">

After: 
<img width="709" alt="image" src="https://github.com/pingdotgg/uploadthing/assets/2293095/e4029229-bedf-49dc-aacf-40c9b24fb3ae">
