### PR TITLE
refactor(docs): remove unnecessary useEffect for openapi spec

### DIFF
--- a/docs/src/components/scalar.tsx
+++ b/docs/src/components/scalar.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { ApiReference as VueComponent } from "@scalar/api-reference";
 import { useTheme } from "nextra-theme-docs";
 import { applyVueInReact } from "veaury";
@@ -10,14 +9,6 @@ const specUrl = "https://uploadthing.com/api/openapi-spec.json";
 export function ScalarApiRef() {
   const theme = useTheme();
   const isDark = theme.resolvedTheme === "dark";
-
-  useEffect(() => {
-    const toc = document.querySelector('nav[aria-label="table of contents"]');
-    toc?.classList.add("hidden");
-    return () => {
-      toc?.classList.remove("hidden");
-    };
-  }, []);
 
   return (
     // @ts-ignore

--- a/docs/src/pages/api-reference/_meta.json
+++ b/docs/src/pages/api-reference/_meta.json
@@ -1,6 +1,11 @@
 {
   "react": "React",
   "server": "Server",
-  "openapi-spec": "OpenAPI Spec",
+  "openapi-spec": {
+    "title": "OpenAPI Spec",
+    "theme": {
+      "toc": false
+    }
+  },
   "ut-api": "UTApi (Server SDK)"
 }


### PR DESCRIPTION
We can remove the `useEffect` and just hide the TOC by leveraging `layout: "full"`.

Reference: https://nextra.site/docs/docs-theme/page-configuration#full-layout