### PR TITLE
fix: Slightly better server error messages

### DIFF
--- a/.changeset/eight-cows-fly.md
+++ b/.changeset/eight-cows-fly.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+fix: Slightly better server error messages

--- a/packages/uploadthing/src/express.ts
+++ b/packages/uploadthing/src/express.ts
@@ -83,7 +83,7 @@ export const createRouteHandler = <TRouter extends FileRouter>(
       // We messed up - this should never happen
       res.status(500);
       res.setHeader("x-uploadthing-version", UPLOADTHING_VERSION);
-      res.send("An unknown error occured");
+      res.send("An unknown error occurred");
 
       return;
     }

--- a/packages/uploadthing/src/fastify.ts
+++ b/packages/uploadthing/src/fastify.ts
@@ -71,7 +71,7 @@ export const createRouteHandler = <TRouter extends FileRouter>(
         .headers({
           "x-uploadthing-version": UPLOADTHING_VERSION,
         })
-        .send("An unknown error occured");
+        .send("An unknown error occurred");
       return;
     }
 

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -332,7 +332,7 @@ export const buildRequestHandler = <
           parsedInput = await getParseFn(inputParser)(userInput);
           logger.debug("Input parsed successfully", parsedInput);
         } catch (error) {
-          logger.error("An error occured trying to parse input:", error);
+          logger.error("An error occurred trying to parse input:", error);
           return new UploadThingError({
             code: "BAD_REQUEST",
             message: "Invalid input.",
@@ -350,7 +350,7 @@ export const buildRequestHandler = <
           });
           logger.debug("Middleware finished successfully with:", metadata);
         } catch (error) {
-          logger.error("An error occured in your middleware function:", error);
+          logger.error("An error occurred in your middleware function:", error);
           if (error instanceof UploadThingError) return error;
           return new UploadThingError({
             code: "INTERNAL_SERVER_ERROR",

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -332,7 +332,7 @@ export const buildRequestHandler = <
           parsedInput = await getParseFn(inputParser)(userInput);
           logger.debug("Input parsed successfully", parsedInput);
         } catch (error) {
-          logger.error("An error occured trying to parse input", error);
+          logger.error("An error occured trying to parse input:", error);
           return new UploadThingError({
             code: "BAD_REQUEST",
             message: "Invalid input.",
@@ -350,7 +350,7 @@ export const buildRequestHandler = <
           });
           logger.debug("Middleware finished successfully with:", metadata);
         } catch (error) {
-          logger.error("An error occured in your middleware function", error);
+          logger.error("An error occured in your middleware function:", error);
           if (error instanceof UploadThingError) return error;
           return new UploadThingError({
             code: "INTERNAL_SERVER_ERROR",

--- a/packages/uploadthing/src/next-legacy.ts
+++ b/packages/uploadthing/src/next-legacy.ts
@@ -67,7 +67,7 @@ export const createRouteHandler = <TRouter extends FileRouter>(
     if (response.status !== 200) {
       // We messed up - this should never happen
       res.status(500);
-      return res.send("An unknown error occured");
+      return res.send("An unknown error occurred");
     }
 
     res.status(response.status);

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -302,7 +302,7 @@ export class UTApi {
       keyType === "fileKey"
         ? { fileKeys: asArray(keys) }
         : { customIds: asArray(keys) },
-      "An unknown error occured while deleting files.",
+      "An unknown error occurred while deleting files.",
     );
   };
 
@@ -329,7 +329,7 @@ export class UTApi {
       keyType === "fileKey"
         ? { fileKeys: asArray(keys) }
         : { customIds: asArray(keys) },
-      "An unknown error occured while retrieving file URLs.",
+      "An unknown error occurred while retrieving file URLs.",
     );
 
     return json.data;
@@ -359,7 +359,7 @@ export class UTApi {
     }>(
       "/api/listFiles",
       { ...opts },
-      "An unknown error occured while listing files.",
+      "An unknown error occurred while listing files.",
     );
 
     return json.files;
@@ -371,7 +371,7 @@ export class UTApi {
     return this.requestUploadThing<{ success: true }>(
       "/api/renameFiles",
       { updates: asArray(updates) },
-      "An unknown error occured while renaming files.",
+      "An unknown error occurred while renaming files.",
     );
   };
   /** @deprecated Use {@link renameFiles} instead. */
@@ -391,7 +391,7 @@ export class UTApi {
     }>(
       "/api/getUsageInfo",
       {},
-      "An unknown error occured while getting usage info.",
+      "An unknown error occurred while getting usage info.",
     );
   };
 
@@ -423,7 +423,7 @@ export class UTApi {
       keyType === "fileKey"
         ? { fileKey: key, expiresIn }
         : { customId: key, expiresIn },
-      "An unknown error occured while retrieving presigned URLs.",
+      "An unknown error occurred while retrieving presigned URLs.",
     );
 
     return json.url;

--- a/packages/uploadthing/src/server.ts
+++ b/packages/uploadthing/src/server.ts
@@ -63,7 +63,7 @@ export const INTERNAL_DO_NOT_USE_createRouteHandlerCore = <
     }
     if (response.status !== 200) {
       // We messed up - this should never happen
-      return new Response("An unknown error occured", {
+      return new Response("An unknown error occurred", {
         status: 500,
         headers: {
           "x-uploadthing-version": UPLOADTHING_VERSION,


### PR DESCRIPTION
Console might log errors like `An error occured in your middleware function Unauthorized`. A colon should separate the actual error message.

Also changes the incorrect spelling of the work "occurred" everywhere.