### PR TITLE
docs: comment out config by default for solidstart

### DIFF
--- a/docs/src/pages/getting-started/solid.mdx
+++ b/docs/src/pages/getting-started/solid.mdx
@@ -90,7 +90,9 @@ import { uploadRouter } from "~/server/uploadthing";
 
 export const { GET, POST } = createRouteHandler({
   router: uploadRouter,
-  config: { ... },
+
+  // Apply an (optional) custom config:
+  // config: { ... },
 });
 ```
 


### PR DESCRIPTION
Related: #697

Also comment out the optional config variable in the docs for solidstart