### PR TITLE
fix(docs): add noindex option & canonical url

### DIFF
--- a/docs/src/theme.config.js
+++ b/docs/src/theme.config.js
@@ -163,6 +163,7 @@ const config = {
           { url: "https://docs.uploadthing.com/og.jpg?random=aaaaaaaaaaaaa" },
         ],
       },
+      noindex: !!process.env.DISABLE_INDEXING,
       titleTemplate: "%s – uploadthing",
       twitter: {
         cardType: "summary_large_image",

--- a/docs/src/theme.config.js
+++ b/docs/src/theme.config.js
@@ -166,7 +166,7 @@ const config = {
         ],
       },
       canonical: `https://docs.uploadthing.com${currentUrl}`,
-      noindex: !!process.env.DISABLE_INDEXING,
+      noindex: !!process.env.NEXT_PUBLIC_DISABLE_INDEXING,
       titleTemplate: "%s – uploadthing",
       twitter: {
         cardType: "summary_large_image",

--- a/docs/src/theme.config.js
+++ b/docs/src/theme.config.js
@@ -1,3 +1,4 @@
+import { usePathname } from "next/navigation";
 import { useRouter } from "next/router";
 import { useConfig } from "nextra-theme-docs";
 
@@ -127,6 +128,7 @@ const config = {
     link: "https://github.com/pingdotgg/uploadthing",
   },
   useNextSeoProps() {
+    const currentUrl = usePathname();
     return {
       additionalLinkTags: [
         {
@@ -163,6 +165,7 @@ const config = {
           { url: "https://docs.uploadthing.com/og.jpg?random=aaaaaaaaaaaaa" },
         ],
       },
+      canonical: `https://docs.uploadthing.com${currentUrl}`,
       noindex: !!process.env.DISABLE_INDEXING,
       titleTemplate: "%s – uploadthing",
       twitter: {


### PR DESCRIPTION
Fixes https://x.com/t3dotgg/status/1766445250527351012?s=20

Noindex:

While there are ways to auto detect this, i.e off of the Vercel env variable. But given that noindex is more of a destructive action imo it should be manually set. 

In the dev & preview branches, set NEXT_PUBLIC_DISABLE_INDEXING to true in the env vars & validate

Canonical Url:

Uses https://docs.uploadthing.com as the default, adds on the path name. Should also help with deduplication & and forks that don't have the environment variable set.
<img width="1710" alt="Screenshot 2024-03-10 at 1 43 37 AM" src="https://github.com/pingdotgg/uploadthing/assets/39114868/4951c338-946d-48b0-918c-142b1d6d3633">
