### PR TITLE
feat: allow fetch override on client

### DIFF
--- a/packages/react/src/components/button.tsx
+++ b/packages/react/src/components/button.tsx
@@ -101,6 +101,7 @@ export function UploadButton<
   const { mode = "auto", appendOnPaste = false } = $props.config ?? {};
 
   const useUploadThing = INTERNAL_uploadthingHookGen<TRouter>({
+    fetch: $props.fetch ?? globalThis.fetch.bind(globalThis),
     url: resolveMaybeUrlArg($props.url),
   });
 

--- a/packages/react/src/components/dropzone.tsx
+++ b/packages/react/src/components/dropzone.tsx
@@ -100,6 +100,7 @@ export function UploadDropzone<
   const { mode = "manual", appendOnPaste = false } = $props.config ?? {};
 
   const useUploadThing = INTERNAL_uploadthingHookGen<TRouter>({
+    fetch: $props.fetch ?? globalThis.fetch.bind(globalThis),
     url: resolveMaybeUrlArg($props.url),
   });
 

--- a/packages/react/src/components/index.tsx
+++ b/packages/react/src/components/index.tsx
@@ -17,6 +17,7 @@ export const generateUploadButton = <TRouter extends FileRouter>(
   opts?: GenerateTypedHelpersOptions,
 ) => {
   const url = resolveMaybeUrlArg(opts?.url);
+  const fetch = opts?.fetch ?? globalThis.fetch.bind(globalThis);
 
   const TypedButton = <
     TEndpoint extends keyof TRouter,
@@ -30,6 +31,7 @@ export const generateUploadButton = <TRouter extends FileRouter>(
     <UploadButton<TRouter, TEndpoint, TSkipPolling>
       {...(props as any)}
       url={url}
+      fetch={fetch}
     />
   );
   return TypedButton;
@@ -39,6 +41,7 @@ export const generateUploadDropzone = <TRouter extends FileRouter>(
   opts?: GenerateTypedHelpersOptions,
 ) => {
   const url = resolveMaybeUrlArg(opts?.url);
+  const fetch = opts?.fetch ?? globalThis.fetch.bind(globalThis);
 
   const TypedDropzone = <
     TEndpoint extends keyof TRouter,
@@ -52,6 +55,7 @@ export const generateUploadDropzone = <TRouter extends FileRouter>(
     <UploadDropzone<TRouter, TEndpoint, TSkipPolling>
       {...(props as any)}
       url={url}
+      fetch={fetch}
     />
   );
   return TypedDropzone;
@@ -61,6 +65,7 @@ export const generateUploader = <TRouter extends FileRouter>(
   opts?: GenerateTypedHelpersOptions,
 ) => {
   const url = resolveMaybeUrlArg(opts?.url);
+  const fetch = opts?.fetch ?? globalThis.fetch.bind(globalThis);
 
   const TypedUploader = <
     TEndpoint extends keyof TRouter,
@@ -71,7 +76,11 @@ export const generateUploader = <TRouter extends FileRouter>(
       keyof GenerateTypedHelpersOptions
     >,
   ) => (
-    <Uploader<TRouter, TEndpoint, TSkipPolling> {...(props as any)} url={url} />
+    <Uploader<TRouter, TEndpoint, TSkipPolling>
+      {...(props as any)}
+      url={url}
+      fetch={fetch}
+    />
   );
   return TypedUploader;
 };

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,4 +1,8 @@
-import type { ExtendObjectIf, UploadThingError } from "@uploadthing/shared";
+import type {
+  ExtendObjectIf,
+  FetchEsque,
+  UploadThingError,
+} from "@uploadthing/shared";
 import type {
   ClientUploadedFileData,
   FileRouter,
@@ -18,6 +22,25 @@ export interface GenerateTypedHelpersOptions {
    * @default (VERCEL_URL ?? window.location.origin) + "/api/uploadthing"
    */
   url?: string | URL;
+  /**
+   * Override the default fetch implementation
+   * Useful if you need to send custom headers etc.
+   * @example
+   * ```ts
+   * {
+   *   fetch: async (url, init) => {
+   *     const token = await getToken();
+   *     return fetch(url, {
+   *       ...init,
+   *       headers: { ...init.headers, Authorization: `Bearer ${token}` }
+   *     })
+   *   }
+   * }
+   * ```
+   *
+   * @default globalThis.fetch
+   */
+  fetch?: FetchEsque;
 }
 
 export type UseUploadthingProps<
@@ -83,6 +106,25 @@ export type UploadthingComponentProps<
    * @default (VERCEL_URL ?? window.location.origin) + "/api/uploadthing"
    */
   url?: string | URL;
+  /**
+   * Override the default fetch implementation
+   * Useful if you need to send custom headers etc.
+   * @example
+   * ```ts
+   * {
+   *   fetch: async (url, init) => {
+   *     const token = await getToken();
+   *     return fetch(url, {
+   *       ...init,
+   *       headers: { ...init.headers, Authorization: `Bearer ${token}` }
+   *     })
+   *   }
+   * }
+   * ```
+   *
+   * @default globalThis.fetch
+   */
+  fetch?: FetchEsque;
   config?: {
     mode?: "auto" | "manual";
     appendOnPaste?: boolean;

--- a/packages/react/src/utils/useFetch.ts
+++ b/packages/react/src/utils/useFetch.ts
@@ -1,6 +1,7 @@
 // Ripped from https://usehooks-ts.com/react-hook/use-fetch
 import { useEffect, useReducer, useRef } from "react";
 
+import type { FetchEsque } from "@uploadthing/shared";
 import { safeParseJSON } from "@uploadthing/shared";
 
 interface State<T> {
@@ -16,7 +17,11 @@ type Action<T> =
   | { type: "fetched"; payload: T }
   | { type: "error"; payload: Error };
 
-function useFetch<T = unknown>(url?: string, options?: RequestInit): State<T> {
+function useFetch<T = unknown>(
+  fetch: FetchEsque,
+  url?: string,
+  options?: RequestInit,
+): State<T> {
   const cache = useRef<Cache<T>>({});
 
   // Used to prevent state update if the component is unmounted

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -49,6 +49,7 @@ export interface RequestInitEsque {
  */
 export interface ResponseEsque {
   status: number;
+  statusText: string;
   ok: boolean;
   /**
    * @remarks

--- a/packages/solid/src/components/button.tsx
+++ b/packages/solid/src/components/button.tsx
@@ -82,6 +82,7 @@ export function UploadButton<
   const $props = props as UploadButtonProps<TRouter, TEndpoint, TSkipPolling>;
 
   const useUploadThing = INTERNAL_uploadthingHookGen<TRouter>({
+    fetch: $props.fetch ?? globalThis.fetch.bind(globalThis),
     url: resolveMaybeUrlArg($props.url),
   });
 

--- a/packages/solid/src/components/dropzone.tsx
+++ b/packages/solid/src/components/dropzone.tsx
@@ -83,6 +83,7 @@ export const UploadDropzone = <
   const { mode = "manual" } = $props.config ?? {};
 
   const useUploadThing = INTERNAL_uploadthingHookGen<TRouter>({
+    fetch: $props.fetch ?? globalThis.fetch.bind(globalThis),
     url: resolveMaybeUrlArg($props.url),
   });
   const uploadThing = useUploadThing($props.endpoint, {

--- a/packages/solid/src/components/index.tsx
+++ b/packages/solid/src/components/index.tsx
@@ -17,6 +17,7 @@ export const generateUploadButton = <TRouter extends FileRouter>(
   opts?: GenerateTypedHelpersOptions,
 ) => {
   const url = resolveMaybeUrlArg(opts?.url);
+  const fetch = opts?.fetch ?? globalThis.fetch.bind(globalThis);
 
   const TypedButton = <
     TEndpoint extends keyof TRouter,
@@ -30,6 +31,7 @@ export const generateUploadButton = <TRouter extends FileRouter>(
     <UploadButton<TRouter, TEndpoint, TSkipPolling>
       {...(props as any)}
       url={url}
+      fetch={fetch}
     />
   );
   return TypedButton;
@@ -39,6 +41,7 @@ export const generateUploadDropzone = <TRouter extends FileRouter>(
   opts?: GenerateTypedHelpersOptions,
 ) => {
   const url = resolveMaybeUrlArg(opts?.url);
+  const fetch = opts?.fetch ?? globalThis.fetch.bind(globalThis);
 
   const TypedDropzone = <
     TEndpoint extends keyof TRouter,
@@ -52,6 +55,7 @@ export const generateUploadDropzone = <TRouter extends FileRouter>(
     <UploadDropzone<TRouter, TEndpoint, TSkipPolling>
       {...(props as any)}
       url={url}
+      fetch={fetch}
     />
   );
   return TypedDropzone;
@@ -61,6 +65,7 @@ export const generateUploader = <TRouter extends FileRouter>(
   opts?: GenerateTypedHelpersOptions,
 ) => {
   const url = resolveMaybeUrlArg(opts?.url);
+  const fetch = opts?.fetch ?? globalThis.fetch.bind(globalThis);
 
   const TypedUploader = <
     TEndpoint extends keyof TRouter,
@@ -71,7 +76,11 @@ export const generateUploader = <TRouter extends FileRouter>(
       keyof GenerateTypedHelpersOptions
     >,
   ) => (
-    <Uploader<TRouter, TEndpoint, TSkipPolling> {...(props as any)} url={url} />
+    <Uploader<TRouter, TEndpoint, TSkipPolling>
+      {...(props as any)}
+      url={url}
+      fetch={fetch}
+    />
   );
   return TypedUploader;
 };

--- a/packages/solid/src/types.ts
+++ b/packages/solid/src/types.ts
@@ -1,4 +1,8 @@
-import type { ExtendObjectIf, UploadThingError } from "@uploadthing/shared";
+import type {
+  ExtendObjectIf,
+  FetchEsque,
+  UploadThingError,
+} from "@uploadthing/shared";
 import type {
   ClientUploadedFileData,
   FileRouter,
@@ -18,6 +22,25 @@ export interface GenerateTypedHelpersOptions {
    * @default (VERCEL_URL ?? window.location.origin) + "/api/uploadthing"
    */
   url?: string | URL;
+  /**
+   * Override the default fetch implementation
+   * Useful if you need to send custom headers etc.
+   * @example
+   * ```ts
+   * {
+   *   fetch: async (url, init) => {
+   *     const token = await getToken();
+   *     return fetch(url, {
+   *       ...init,
+   *       headers: { ...init.headers, Authorization: `Bearer ${token}` }
+   *     })
+   *   }
+   * }
+   * ```
+   *
+   * @default globalThis.fetch
+   */
+  fetch?: FetchEsque;
 }
 
 export type UseUploadthingProps<
@@ -83,6 +106,25 @@ export type UploadthingComponentProps<
    * @default (VERCEL_URL ?? window.location.origin) + "/api/uploadthing"
    */
   url?: string | URL;
+  /**
+   * Override the default fetch implementation
+   * Useful if you need to send custom headers etc.
+   * @example
+   * ```ts
+   * {
+   *   fetch: async (url, init) => {
+   *     const token = await getToken();
+   *     return fetch(url, {
+   *       ...init,
+   *       headers: { ...init.headers, Authorization: `Bearer ${token}` }
+   *     })
+   *   }
+   * }
+   * ```
+   *
+   * @default globalThis.fetch
+   */
+  fetch?: FetchEsque;
 } & ExtendObjectIf<
     inferEndpointInput<TRouter[TEndpoint]>,
     {

--- a/packages/solid/src/utils/createFetch.ts
+++ b/packages/solid/src/utils/createFetch.ts
@@ -1,6 +1,7 @@
 import type { Resource } from "solid-js";
 import { createResource } from "solid-js";
 
+import type { FetchEsque } from "@uploadthing/shared";
 import { safeParseJSON } from "@uploadthing/shared";
 
 interface State<T> {
@@ -11,7 +12,11 @@ interface State<T> {
 
 type Cache<T> = Record<string, T>;
 
-export function createFetch<T = unknown>(url?: string, options?: RequestInit) {
+export function createFetch<T = unknown>(
+  fetch: FetchEsque,
+  url?: string,
+  options?: RequestInit,
+) {
   const cache: Cache<T> = {};
   const [res] = createResource(async () => {
     if (!url)

--- a/packages/uploadthing/package.json
+++ b/packages/uploadthing/package.json
@@ -184,17 +184,6 @@
     ],
     "rules": {
       "no-console": "error",
-      "no-restricted-globals": [
-        "error",
-        {
-          "name": "fetch",
-          "message": "fetch should be passed as parameter to support overriding default behaviors"
-        },
-        {
-          "name": "process",
-          "message": "Use `import { process } from 'std-env` instead"
-        }
-      ],
       "no-restricted-imports": [
         "error",
         {

--- a/packages/uploadthing/src/types.ts
+++ b/packages/uploadthing/src/types.ts
@@ -1,4 +1,4 @@
-import type { ExtendObjectIf } from "@uploadthing/shared";
+import type { ExtendObjectIf, FetchEsque } from "@uploadthing/shared";
 
 import type { FileRouter, inferEndpointInput } from "./internal/types";
 
@@ -43,6 +43,25 @@ export type UploadFilesOptions<
    */
   url: URL;
   /**
+   * Override the default fetch implementation
+   * Useful if you need to send custom headers etc.
+   * @example
+   * ```ts
+   * {
+   *   fetch: async (url, init) => {
+   *     const token = await getToken();
+   *     return fetch(url, {
+   *       ...init,
+   *       headers: { ...init.headers, Authorization: `Bearer ${token}` }
+   *     })
+   *   }
+   * }
+   * ```
+   *
+   * @default globalThis.fetch
+   */
+  fetch: FetchEsque;
+  /**
    * The uploadthing package that is making this request, used to identify the client in the server logs
    * @example "@uploadthing/react"
    * @remarks This option is not required when `uploadFiles` has been generated with `genUploader`
@@ -71,6 +90,25 @@ export type GenerateUploaderOptions = {
    * This is used to identify the client in the server logs
    */
   package: string;
+  /**
+   * Override the default fetch implementation
+   * Useful if you need to send custom headers etc.
+   * @example
+   * ```ts
+   * {
+   *   fetch: async (url, init) => {
+   *     const token = await getToken();
+   *     return fetch(url, {
+   *       ...init,
+   *       headers: { ...init.headers, Authorization: `Bearer ${token}` }
+   *     })
+   *   }
+   * }
+   * ```
+   *
+   * @default globalThis.fetch
+   */
+  fetch?: FetchEsque;
 };
 
 /**

--- a/packages/uploadthing/test/__test-helpers.ts
+++ b/packages/uploadthing/test/__test-helpers.ts
@@ -164,6 +164,9 @@ export const mockExternalRequests =
       if (url.pathname === "/api/requestFileAccess") {
         return Response.json({ url: "https://example.com" });
       }
+      if (url.pathname === "/api/serverCallback") {
+        return Response.json({ success: true });
+      }
     }
 
     // Mock S3

--- a/packages/uploadthing/test/adapters.test.ts
+++ b/packages/uploadthing/test/adapters.test.ts
@@ -6,13 +6,13 @@ import * as fastify from "fastify";
 import { createApp, H3Event, toWebHandler } from "h3";
 import { describe, expect, expectTypeOf, vi } from "vitest";
 
+import type { MockDbInterface } from "./__test-helpers";
 import {
   baseHeaders,
   createApiUrl,
   fetchMock,
   it,
   middlewareMock,
-  MockDbInterface,
   mockExternalRequests,
   uploadCompleteMock,
 } from "./__test-helpers";

--- a/tooling/eslint-config/base.js
+++ b/tooling/eslint-config/base.js
@@ -45,6 +45,18 @@ const config = {
       extends: ["plugin:@typescript-eslint/disable-type-checked"],
       rules: {
         "@uploadthing/no-throwing-promises": "off",
+        "no-restricted-globals": [
+          "error",
+          {
+            name: "fetch",
+            message:
+              "fetch should be passed as parameter to support overriding default behaviors",
+          },
+          {
+            name: "process",
+            message: "Use `import { process } from 'std-env` instead",
+          },
+        ],
       },
     },
   ],


### PR DESCRIPTION
quickly spun up the ability to allow fetch override to set headers. Ref: https://discord.com/channels/966627436387266600/1102510616326967306/1216240077605310576

### Questions

- do we need full fetch override? or is `headers` enough? or both?
- currently only possible to set on the `genUploader`, `generateReactHelpers`, `generateUploadButton` etc etc. Maybe we should also have a way to allow this override when doing the call / on the components? Thinking if the token requires React context?

```ts
const { token } = useUser();
const { startUpload } = useUploadThing({
  headers: {
    Authorization: `Bearer ${token}`
  }
})
```
- is it even useful at all to have it on the generators? Maybe it should just be on individual calls