### PR TITLE
fix(docs): noindex fix, the second part

### DIFF
--- a/docs/src/theme.config.js
+++ b/docs/src/theme.config.js
@@ -61,7 +61,7 @@ const Head = () => {
   const { asPath, defaultLocale, locale } = useRouter();
   const { frontMatter } = useConfig();
   const url =
-    "https://my-app.com" +
+    "https://docs.uploadthing.com" +
     (defaultLocale === locale ? asPath : `/${locale}${asPath}`);
 
   return (
@@ -129,6 +129,7 @@ const config = {
   },
   useNextSeoProps() {
     const currentUrl = usePathname();
+    console.log(process.env);
     return {
       additionalLinkTags: [
         {
@@ -166,7 +167,8 @@ const config = {
         ],
       },
       canonical: `https://docs.uploadthing.com${currentUrl}`,
-      noindex: !!process.env.NEXT_PUBLIC_DISABLE_INDEXING,
+      noindex:
+        process.env.NEXT_PUBLIC_DISABLE_INDEXING === "true" ? true : false,
       titleTemplate: "%s – uploadthing",
       twitter: {
         cardType: "summary_large_image",

--- a/docs/src/theme.config.js
+++ b/docs/src/theme.config.js
@@ -129,7 +129,6 @@ const config = {
   },
   useNextSeoProps() {
     const currentUrl = usePathname();
-    console.log(process.env);
     return {
       additionalLinkTags: [
         {

--- a/docs/src/theme.config.js
+++ b/docs/src/theme.config.js
@@ -166,8 +166,7 @@ const config = {
         ],
       },
       canonical: `https://docs.uploadthing.com${currentUrl}`,
-      noindex:
-        process.env.NEXT_PUBLIC_DISABLE_INDEXING === "true" ? true : false,
+      noindex: process.env.NEXT_PUBLIC_DISABLE_INDEXING === "true",
       titleTemplate: "%s – uploadthing",
       twitter: {
         cardType: "summary_large_image",


### PR DESCRIPTION
Was validating my last PR on the docs site and saw it was set to noindex for some reason
![image](https://github.com/pingdotgg/uploadthing/assets/39114868/6518a1a4-e42c-4cf9-9d5a-96d69a6a0d77)

Found that there's a bug where if NEXT_PUBLIC_DISABLE_INDEXING is set to 'true', it will be considered true since it's a string not a boolean. Missed this in my testing since I was just using undefined, sorry about that! 

This also updates og:url from "my-app" to "docs.uploadthing.com" as I noticed that was pointing to the wrong url