### PR TITLE
fix(docs): Consistency between examples

### DIFF
--- a/docs/src/pages/backend-adapters/express.mdx
+++ b/docs/src/pages/backend-adapters/express.mdx
@@ -35,10 +35,16 @@ UPLOADTHING_APP_ID=... # Your app id
 
 ### Creating your first FileRoute
 
-All files uploaded to uploadthing are associated with a FileRoute. Following
-example is very minimalistic. To get full insight into what you can do with the
-FileRoutes, please refer to the
-[File Router API](/api-reference/server#file-routes).
+All files uploaded to uploadthing are associated with a FileRoute. The following
+is a very minimalistic example, with a single FileRoute "imageUploader". To get
+full insight into what you can do with the FileRoutes, please refer to the
+[File Router API](/api-reference/server#file-routes).Think of a FileRoute
+similar to an endpoint, it has:
+
+- Permitted types ["image", "video", etc]
+- Max file size
+- (Optional) `middleware` to authenticate and tag requests
+- `onUploadComplete` callback for when uploads are completed
 
 ```ts copy filename="src/uploadthing.ts"
 import { createUploadthing, type FileRouter } from "uploadthing/express";

--- a/docs/src/pages/backend-adapters/express.mdx
+++ b/docs/src/pages/backend-adapters/express.mdx
@@ -46,13 +46,10 @@ import { createUploadthing, type FileRouter } from "uploadthing/express";
 const f = createUploadthing();
 
 export const uploadRouter = {
-  videoAndImage: f({
+  imageUploader: f({
     image: {
       maxFileSize: "4MB",
       maxFileCount: 4,
-    },
-    video: {
-      maxFileSize: "16MB",
     },
   }).onUploadComplete((data) => {
     console.log("upload completed", data);

--- a/docs/src/pages/backend-adapters/express.mdx
+++ b/docs/src/pages/backend-adapters/express.mdx
@@ -36,15 +36,16 @@ UPLOADTHING_APP_ID=... # Your app id
 ### Creating your first FileRoute
 
 All files uploaded to uploadthing are associated with a FileRoute. The following
-is a very minimalistic example, with a single FileRoute "imageUploader". To get
-full insight into what you can do with the FileRoutes, please refer to the
-[File Router API](/api-reference/server#file-routes).Think of a FileRoute
-similar to an endpoint, it has:
+is a very minimalistic example, with a single FileRoute "imageUploader". Think
+of a FileRoute similar to an endpoint, it has:
 
 - Permitted types ["image", "video", etc]
 - Max file size
 - (Optional) `middleware` to authenticate and tag requests
 - `onUploadComplete` callback for when uploads are completed
+
+To get full insight into what you can do with the FileRoutes, please refer to
+the [File Router API](/api-reference/server#file-routes).
 
 ```ts copy filename="src/uploadthing.ts"
 import { createUploadthing, type FileRouter } from "uploadthing/express";

--- a/docs/src/pages/backend-adapters/fastify.mdx
+++ b/docs/src/pages/backend-adapters/fastify.mdx
@@ -48,13 +48,10 @@ import { createUploadthing, type FileRouter } from "uploadthing/fastify";
 const f = createUploadthing();
 
 export const uploadRouter = {
-  videoAndImage: f({
+  imageUploader: f({
     image: {
       maxFileSize: "4MB",
       maxFileCount: 4,
-    },
-    video: {
-      maxFileSize: "16MB",
     },
   }).onUploadComplete((data) => {
     console.log("upload completed", data);

--- a/docs/src/pages/backend-adapters/fastify.mdx
+++ b/docs/src/pages/backend-adapters/fastify.mdx
@@ -37,10 +37,16 @@ UPLOADTHING_APP_ID=... # Your app id
 
 ### Creating your first FileRoute
 
-All files uploaded to uploadthing are associated with a FileRoute. Following
-example is very minimalistic. To get full insight into what you can do with the
-FileRoutes, please refer to the
-[File Router API](/api-reference/server#file-routes).
+All files uploaded to uploadthing are associated with a FileRoute. The following
+is a very minimalistic example, with a single FileRoute "imageUploader". To get
+full insight into what you can do with the FileRoutes, please refer to the
+[File Router API](/api-reference/server#file-routes).Think of a FileRoute
+similar to an endpoint, it has:
+
+- Permitted types ["image", "video", etc]
+- Max file size
+- (Optional) `middleware` to authenticate and tag requests
+- `onUploadComplete` callback for when uploads are completed
 
 ```ts copy filename="src/uploadthing.ts"
 import { createUploadthing, type FileRouter } from "uploadthing/fastify";

--- a/docs/src/pages/backend-adapters/fastify.mdx
+++ b/docs/src/pages/backend-adapters/fastify.mdx
@@ -38,15 +38,16 @@ UPLOADTHING_APP_ID=... # Your app id
 ### Creating your first FileRoute
 
 All files uploaded to uploadthing are associated with a FileRoute. The following
-is a very minimalistic example, with a single FileRoute "imageUploader". To get
-full insight into what you can do with the FileRoutes, please refer to the
-[File Router API](/api-reference/server#file-routes).Think of a FileRoute
-similar to an endpoint, it has:
+is a very minimalistic example, with a single FileRoute "imageUploader". Think
+of a FileRoute similar to an endpoint, it has:
 
 - Permitted types ["image", "video", etc]
 - Max file size
 - (Optional) `middleware` to authenticate and tag requests
 - `onUploadComplete` callback for when uploads are completed
+
+To get full insight into what you can do with the FileRoutes, please refer to
+the [File Router API](/api-reference/server#file-routes).
 
 ```ts copy filename="src/uploadthing.ts"
 import { createUploadthing, type FileRouter } from "uploadthing/fastify";

--- a/docs/src/pages/backend-adapters/fetch.mdx
+++ b/docs/src/pages/backend-adapters/fetch.mdx
@@ -34,10 +34,16 @@ UPLOADTHING_APP_ID=... # Your app id
 
 ### Set Up A FileRouter
 
-All files uploaded to uploadthing are associated with a FileRoute. Following
-example is very minimalistic. To get full insight into what you can do with the
-FileRoutes, please refer to the
-[File Router API](/api-reference/server#file-routes).
+All files uploaded to uploadthing are associated with a FileRoute. The following
+is a very minimalistic example, with a single FileRoute "imageUploader". To get
+full insight into what you can do with the FileRoutes, please refer to the
+[File Router API](/api-reference/server#file-routes).Think of a FileRoute
+similar to an endpoint, it has:
+
+- Permitted types ["image", "video", etc]
+- Max file size
+- (Optional) `middleware` to authenticate and tag requests
+- `onUploadComplete` callback for when uploads are completed
 
 ```ts copy filename="uploadthing.ts"
 import { createUploadthing, type FileRouter } from "uploadthing/server";

--- a/docs/src/pages/backend-adapters/fetch.mdx
+++ b/docs/src/pages/backend-adapters/fetch.mdx
@@ -35,15 +35,16 @@ UPLOADTHING_APP_ID=... # Your app id
 ### Set Up A FileRouter
 
 All files uploaded to uploadthing are associated with a FileRoute. The following
-is a very minimalistic example, with a single FileRoute "imageUploader". To get
-full insight into what you can do with the FileRoutes, please refer to the
-[File Router API](/api-reference/server#file-routes).Think of a FileRoute
-similar to an endpoint, it has:
+is a very minimalistic example, with a single FileRoute "imageUploader". Think
+of a FileRoute similar to an endpoint, it has:
 
 - Permitted types ["image", "video", etc]
 - Max file size
 - (Optional) `middleware` to authenticate and tag requests
 - `onUploadComplete` callback for when uploads are completed
+
+To get full insight into what you can do with the FileRoutes, please refer to
+the [File Router API](/api-reference/server#file-routes).
 
 ```ts copy filename="uploadthing.ts"
 import { createUploadthing, type FileRouter } from "uploadthing/server";

--- a/docs/src/pages/backend-adapters/fetch.mdx
+++ b/docs/src/pages/backend-adapters/fetch.mdx
@@ -45,13 +45,10 @@ import { createUploadthing, type FileRouter } from "uploadthing/server";
 const f = createUploadthing();
 
 export const uploadRouter = {
-  videoAndImage: f({
+  imageUploader: f({
     image: {
       maxFileSize: "4MB",
       maxFileCount: 4,
-    },
-    video: {
-      maxFileSize: "16MB",
     },
   }).onUploadComplete((data) => {
     console.log("upload completed", data);

--- a/docs/src/pages/backend-adapters/h3.mdx
+++ b/docs/src/pages/backend-adapters/h3.mdx
@@ -50,13 +50,10 @@ import { createUploadthing, type FileRouter } from "uploadthing/h3";
 const f = createUploadthing();
 
 export const uploadRouter = {
-  videoAndImage: f({
+  imageUploader: f({
     image: {
       maxFileSize: "4MB",
       maxFileCount: 4,
-    },
-    video: {
-      maxFileSize: "16MB",
     },
   }).onUploadComplete((data) => {
     console.log("upload completed", data);

--- a/docs/src/pages/backend-adapters/h3.mdx
+++ b/docs/src/pages/backend-adapters/h3.mdx
@@ -40,15 +40,16 @@ UPLOADTHING_APP_ID=... # Your app id
 ### Creating your first FileRoute
 
 All files uploaded to uploadthing are associated with a FileRoute. The following
-is a very minimalistic example, with a single FileRoute "imageUploader". To get
-full insight into what you can do with the FileRoutes, please refer to the
-[File Router API](/api-reference/server#file-routes).Think of a FileRoute
-similar to an endpoint, it has:
+is a very minimalistic example, with a single FileRoute "imageUploader". Think
+of a FileRoute similar to an endpoint, it has:
 
 - Permitted types ["image", "video", etc]
 - Max file size
 - (Optional) `middleware` to authenticate and tag requests
 - `onUploadComplete` callback for when uploads are completed
+
+To get full insight into what you can do with the FileRoutes, please refer to
+the [File Router API](/api-reference/server#file-routes).
 
 ```ts copy filename="src/uploadthing.ts"
 import { createUploadthing, type FileRouter } from "uploadthing/h3";

--- a/docs/src/pages/backend-adapters/h3.mdx
+++ b/docs/src/pages/backend-adapters/h3.mdx
@@ -39,10 +39,16 @@ UPLOADTHING_APP_ID=... # Your app id
 
 ### Creating your first FileRoute
 
-All files uploaded to uploadthing are associated with a FileRoute. Following
-example is very minimalistic. To get full insight into what you can do with the
-FileRoutes, please refer to the
-[File Router API](/api-reference/server#file-routes).
+All files uploaded to uploadthing are associated with a FileRoute. The following
+is a very minimalistic example, with a single FileRoute "imageUploader". To get
+full insight into what you can do with the FileRoutes, please refer to the
+[File Router API](/api-reference/server#file-routes).Think of a FileRoute
+similar to an endpoint, it has:
+
+- Permitted types ["image", "video", etc]
+- Max file size
+- (Optional) `middleware` to authenticate and tag requests
+- `onUploadComplete` callback for when uploads are completed
 
 ```ts copy filename="src/uploadthing.ts"
 import { createUploadthing, type FileRouter } from "uploadthing/h3";

--- a/docs/src/pages/getting-started/appdir.mdx
+++ b/docs/src/pages/getting-started/appdir.mdx
@@ -15,8 +15,11 @@ components, and we think you'll love what we've built 🙏
 <Steps>
 ### Creating your first FileRoute
 
-All files uploaded to uploadthing are associated with a FileRoute. Think of a
-FileRoute similar to an endpoint, it has:
+All files uploaded to uploadthing are associated with a FileRoute. The following
+is a very minimalistic example, with a single FileRoute "imageUploader". To get
+full insight into what you can do with the FileRoutes, please refer to the
+[File Router API](/api-reference/server#file-routes).Think of a FileRoute
+similar to an endpoint, it has:
 
 - Permitted types ["image", "video", etc]
 - Max file size

--- a/docs/src/pages/getting-started/appdir.mdx
+++ b/docs/src/pages/getting-started/appdir.mdx
@@ -16,15 +16,16 @@ components, and we think you'll love what we've built 🙏
 ### Creating your first FileRoute
 
 All files uploaded to uploadthing are associated with a FileRoute. The following
-is a very minimalistic example, with a single FileRoute "imageUploader". To get
-full insight into what you can do with the FileRoutes, please refer to the
-[File Router API](/api-reference/server#file-routes).Think of a FileRoute
-similar to an endpoint, it has:
+is a very minimalistic example, with a single FileRoute "imageUploader". Think
+of a FileRoute similar to an endpoint, it has:
 
 - Permitted types ["image", "video", etc]
 - Max file size
 - (Optional) `middleware` to authenticate and tag requests
 - `onUploadComplete` callback for when uploads are completed
+
+To get full insight into what you can do with the FileRoutes, please refer to
+the [File Router API](/api-reference/server#file-routes).
 
 ```ts copy filename="app/api/uploadthing/core.ts"
 import { createUploadthing, type FileRouter } from "uploadthing/next";

--- a/docs/src/pages/getting-started/astro.mdx
+++ b/docs/src/pages/getting-started/astro.mdx
@@ -21,8 +21,11 @@ identical for other frameworks too.
 <Steps>
 ### Creating your first FileRoute
 
-All files uploaded to uploadthing are associated with a FileRoute. Think of a
-FileRoute similar to an endpoint, it has:
+All files uploaded to uploadthing are associated with a FileRoute. The following
+is a very minimalistic example, with a single FileRoute "imageUploader". To get
+full insight into what you can do with the FileRoutes, please refer to the
+[File Router API](/api-reference/server#file-routes).Think of a FileRoute
+similar to an endpoint, it has:
 
 - Permitted types ["image", "video", etc]
 - Max file size

--- a/docs/src/pages/getting-started/astro.mdx
+++ b/docs/src/pages/getting-started/astro.mdx
@@ -22,15 +22,16 @@ identical for other frameworks too.
 ### Creating your first FileRoute
 
 All files uploaded to uploadthing are associated with a FileRoute. The following
-is a very minimalistic example, with a single FileRoute "imageUploader". To get
-full insight into what you can do with the FileRoutes, please refer to the
-[File Router API](/api-reference/server#file-routes).Think of a FileRoute
-similar to an endpoint, it has:
+is a very minimalistic example, with a single FileRoute "imageUploader". Think
+of a FileRoute similar to an endpoint, it has:
 
 - Permitted types ["image", "video", etc]
 - Max file size
 - (Optional) `middleware` to authenticate and tag requests
 - `onUploadComplete` callback for when uploads are completed
+
+To get full insight into what you can do with the FileRoutes, please refer to
+the [File Router API](/api-reference/server#file-routes).
 
 ```ts copy filename="src/server/uploadthing.ts"
 import { createUploadthing, type FileRouter } from "uploadthing/server";

--- a/docs/src/pages/getting-started/pagedir.mdx
+++ b/docs/src/pages/getting-started/pagedir.mdx
@@ -16,8 +16,11 @@ where you want to be
 <Steps>
 ### Creating your first FileRoute
 
-All files uploaded to uploadthing are associated with a FileRoute. Think of a
-FileRoute similar to an endpoint, it has:
+All files uploaded to uploadthing are associated with a FileRoute. The following
+is a very minimalistic example, with a single FileRoute "imageUploader". To get
+full insight into what you can do with the FileRoutes, please refer to the
+[File Router API](/api-reference/server#file-routes).Think of a FileRoute
+similar to an endpoint, it has:
 
 - Permitted types ["image", "video", etc]
 - Max file size

--- a/docs/src/pages/getting-started/pagedir.mdx
+++ b/docs/src/pages/getting-started/pagedir.mdx
@@ -17,15 +17,16 @@ where you want to be
 ### Creating your first FileRoute
 
 All files uploaded to uploadthing are associated with a FileRoute. The following
-is a very minimalistic example, with a single FileRoute "imageUploader". To get
-full insight into what you can do with the FileRoutes, please refer to the
-[File Router API](/api-reference/server#file-routes).Think of a FileRoute
-similar to an endpoint, it has:
+is a very minimalistic example, with a single FileRoute "imageUploader". Think
+of a FileRoute similar to an endpoint, it has:
 
 - Permitted types ["image", "video", etc]
 - Max file size
 - (Optional) `middleware` to authenticate and tag requests
 - `onUploadComplete` callback for when uploads are completed
+
+To get full insight into what you can do with the FileRoutes, please refer to
+the [File Router API](/api-reference/server#file-routes).
 
 ```tsx copy filename="server/uploadthing.ts"
 import type { NextApiRequest, NextApiResponse } from "next";

--- a/docs/src/pages/getting-started/solid.mdx
+++ b/docs/src/pages/getting-started/solid.mdx
@@ -37,8 +37,11 @@ UPLOADTHING_APP_ID=... # Your app id
   [router](/api-reference/server#file-routes) docs
 </Callout>
 
-All files uploaded to uploadthing are associated with a FileRoute. Think of a
-FileRoute similar to an endpoint, it has:
+All files uploaded to uploadthing are associated with a FileRoute. The following
+is a very minimalistic example, with a single FileRoute "imageUploader". To get
+full insight into what you can do with the FileRoutes, please refer to the
+[File Router API](/api-reference/server#file-routes).Think of a FileRoute
+similar to an endpoint, it has:
 
 - Permitted types ["image", "video", etc]
 - Max file size

--- a/docs/src/pages/getting-started/solid.mdx
+++ b/docs/src/pages/getting-started/solid.mdx
@@ -38,15 +38,16 @@ UPLOADTHING_APP_ID=... # Your app id
 </Callout>
 
 All files uploaded to uploadthing are associated with a FileRoute. The following
-is a very minimalistic example, with a single FileRoute "imageUploader". To get
-full insight into what you can do with the FileRoutes, please refer to the
-[File Router API](/api-reference/server#file-routes).Think of a FileRoute
-similar to an endpoint, it has:
+is a very minimalistic example, with a single FileRoute "imageUploader". Think
+of a FileRoute similar to an endpoint, it has:
 
 - Permitted types ["image", "video", etc]
 - Max file size
 - (Optional) `middleware` to authenticate and tag requests
 - `onUploadComplete` callback for when uploads are completed
+
+To get full insight into what you can do with the FileRoutes, please refer to
+the [File Router API](/api-reference/server#file-routes).
 
 ```ts copy filename="src/server/uploadthing.ts"
 import { createUploadthing, UploadThingError } from "uploadthing/server";


### PR DESCRIPTION
Addresses #712

All examples in docs should now be consistent with the name of the FileRoute, so FE examples work with alternative BE examples. 

Additionally included short note about FileRoutes in all BE docs (was in FE docs only before)
