### PR TITLE
docs: allow deployments from forks

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -13,4 +13,7 @@ const withNextra = nextra({
 export default withNextra({
   reactStrictMode: true,
   eslint: { ignoreDuringBuilds: true },
+  env: {
+    NO_INDEX: process.env.VERCEL_ENV !== "production" ? "true" : "false",
+  },
 });

--- a/docs/src/theme.config.js
+++ b/docs/src/theme.config.js
@@ -166,7 +166,7 @@ const config = {
         ],
       },
       canonical: `https://docs.uploadthing.com${currentUrl}`,
-      noindex: process.env.NEXT_PUBLIC_DISABLE_INDEXING === "true",
+      noindex: process.env.NO_INDEX === "true",
       titleTemplate: "%s – uploadthing",
       twitter: {
         cardType: "summary_large_image",


### PR DESCRIPTION
since adding the custom env the docs are no longer auto-deployed from forks since it requires reading environment variables from vercel.

this approach uses a system-env instead so we can remove the env from vercel and thus allowing forks to auto-deploy