### PR TITLE
chore(ci): limit jobs runtime

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -35,6 +36,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -48,6 +50,7 @@ jobs:
 
   format:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -61,6 +64,7 @@ jobs:
 
   typecheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   e2e-node:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         dir:

--- a/.github/workflows/release-canary.yaml
+++ b/.github/workflows/release-canary.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   release:
     if: contains(github.event.pull_request.labels.*.name, 'release canary')
+    timeout-minutes: 10
     name: Build & Publish a canary release
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,7 @@ env:
 jobs:
   release:
     name: Release
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/docs/src/pages/faq.mdx
+++ b/docs/src/pages/faq.mdx
@@ -96,9 +96,9 @@ to expose your application to the internet. Start the application with the
 
 The automatic URL inference unfortunately breaks for certain reverse proxy
 setups. In this case, set either the
-[`config.callbackUrl`](/api-reference/server#config) when you're creating
-the server entrypoints or the `UPLOADTHING_URL` environment variable to the
-public URL of your application.
+[`config.callbackUrl`](/api-reference/server#config) when you're creating the
+server entrypoints or the `UPLOADTHING_URL` environment variable to the public
+URL of your application.
 
 You will get a warning in the console if we detect a localhost URL is being used
 as the callback URL in production.


### PR DESCRIPTION
I think there was a bug in Bun 1.0.31 that caused installs to just forever stall:

![image](https://github.com/pingdotgg/uploadthing/assets/51714798/c3bcc8d1-2c84-41fc-aa84-3a82f42cf630)

Which caused our plan to run out:

![image](https://github.com/pingdotgg/uploadthing/assets/51714798/2ab616c4-865d-4d5f-984e-591a2123f3d1)

This should prevent something similar from happening in the future...