### PR TITLE
docs: Update ut-api.mdx to match type defs

### DIFF
--- a/docs/src/pages/api-reference/ut-api.mdx
+++ b/docs/src/pages/api-reference/ut-api.mdx
@@ -257,17 +257,17 @@ appropriate files on the server.
 import { utapi } from "~/server/uploadthing.ts";
 
 await utapi.renameFiles({
-  fileKey: "2e0fdb64-9957-4262-8e45-f372ba903ac8_image.jpg",
+  key: "2e0fdb64-9957-4262-8e45-f372ba903ac8_image.jpg",
   newName: "myImage.jpg",
 });
 
 await utapi.renameFiles([
   {
-    fileKey: "2e0fdb64-9957-4262-8e45-f372ba903ac8_image.jpg",
+    key: "2e0fdb64-9957-4262-8e45-f372ba903ac8_image.jpg",
     newName: "myImage.jpg",
   },
   {
-    fileKey: "1649353b-04ea-48a2-9db7-31de7f562c8d_image2.jpg",
+    key: "1649353b-04ea-48a2-9db7-31de7f562c8d_image2.jpg",
     newName: "myOtherImage.jpg",
   },
 ]);
@@ -278,7 +278,7 @@ await utapi.renameFiles([
 ```ts
 type Rename =
   | {
-      fileKey: string;
+      key: string;
       newName: string; // should include file extension
     }
   | {


### PR DESCRIPTION
Looking at `uploadthing/packages/uploadthing/src/sdk/types.ts` lines `83-85` I see the following lines of code that do not match the documentation.
```ts
type KeyRename = { key: string; newName: string };
type CustomIdRename = { customId: string; newName: string };
export type RenameFileUpdate = KeyRename | CustomIdRename;
```