### PR TITLE
feat: Add support for 'model/step' MIME type

### DIFF
--- a/.changeset/two-melons-shop.md
+++ b/.changeset/two-melons-shop.md
@@ -1,0 +1,5 @@
+---
+"@uploadthing/mime-types": patch
+---
+
+Add support for 'model/step' MIME type

--- a/packages/mime-types/src/db.ts
+++ b/packages/mime-types/src/db.ts
@@ -4035,6 +4035,11 @@ const mimeTypesInternal = {
     extensions: ["obj"],
     compressible: null,
   },
+  "model/step": {
+    source: "iana",
+    compressible: false,
+    extensions: [".p21", ".stp", ".step", ".stpnc", ".210"],
+  },
   "model/step+xml": {
     source: "iana",
     compressible: true,


### PR DESCRIPTION
Was missing from this allowlist. Does this require additional work?