### PR TITLE
chore: make sure type match in devhook

### DIFF
--- a/packages/uploadthing/src/internal/dev-hook.ts
+++ b/packages/uploadthing/src/internal/dev-hook.ts
@@ -6,6 +6,7 @@ import {
 } from "@uploadthing/shared";
 import type { FetchEsque, ResponseEsque } from "@uploadthing/shared";
 
+import type { UploadedFileData } from "../types";
 import { UPLOADTHING_VERSION } from "./constants";
 import { logger } from "./logger";
 
@@ -58,7 +59,7 @@ export const conditionalDevServer = async (opts: {
           size: file.fileSize,
           type: file.fileType,
           customId: file.customId,
-        },
+        } satisfies UploadedFileData,
       });
 
       const signature = await signPayload(payload, opts.apiKey);


### PR DESCRIPTION
makes sure the payload from devhook matches the `opts.file` in `onUploadComplete`