### PR TITLE
chore: rename solid helper to `createUploadThing`

### DIFF
--- a/.changeset/modern-mangos-punch.md
+++ b/.changeset/modern-mangos-punch.md
@@ -1,0 +1,5 @@
+---
+"@uploadthing/solid": minor
+---
+
+refactor: rename `useUploadThing` to `createUploadThing` to follow ecosystem naming convention

--- a/docs/src/pages/getting-started/solid.mdx
+++ b/docs/src/pages/getting-started/solid.mdx
@@ -177,7 +177,7 @@ export default function Home() {
 UploadThing provides a few premade components that you can use to upload files
 in your app. For component customization, see [Theming](/theming), and for even
 more advanced use cases check out the
-[hook usage](#advanced-usage-useuploadthing)
+[hook usage](#advanced-usage-createuploadthing)
 
 #### UploadButton
 
@@ -293,7 +293,7 @@ export default function Home() {
 }
 ```
 
-## Advanced usage: `useUploadThing`
+## Advanced usage: `createUploadThing`
 
 For advanced use cases, the premade components might not be flexible enough to
 suit your needs. In that case, you can use the `useUploadThing` hook to build
@@ -301,9 +301,9 @@ your own components with a custom upload flow:
 
 <Steps>
 
-### Create the hook
+### Create the helper
 
-First, generate a typed hook using the `generateSolidHelpers` function from
+First, generate a typed helper using the `generateSolidHelpers` function from
 `@uploadthing/solid`:
 
 ```tsx copy filename="src/utils/uploadthing.ts"
@@ -311,16 +311,17 @@ import { generateSolidHelpers } from "@uploadthing/solid";
 
 import type { OurFileRouter } from "~/server/uploadthing";
 
-export const { useUploadThing } = generateSolidHelpers<OurFileRouter>();
+export const { createUploadThing } = generateSolidHelpers<OurFileRouter>();
 ```
 
-### Use the hook
+### Use the generated helper
 
-Then, use the hook in your component. By using the hook, you have full control
-of when and how to upload files.
+Then, use the `createUploadThing` function in your component. By using the raw
+`createUploadThing` function, you have full control of when and how to upload
+files.
 
 ```tsx copy filename="src/routes/index.tsx"
-import { useUploadThing } from "~/utils/uploadthing";
+import { createUploadThing } from "~/utils/uploadthing";
 
 async function compress(file: File) {
   // Run some compression algorithm on the file
@@ -328,7 +329,7 @@ async function compress(file: File) {
 }
 
 export default function Home() {
-  const { startUpload } = useUploadThing("profileImage", {
+  const { startUpload } = createUploadThing("profileImage", {
     onClientUploadComplete: () => {
       alert("Upload Completed");
     },

--- a/examples/minimal-solidstart/src/routes/index.tsx
+++ b/examples/minimal-solidstart/src/routes/index.tsx
@@ -1,11 +1,11 @@
 import {
+  createUploadThing,
   UploadButton,
   UploadDropzone,
-  useUploadThing,
 } from "~/utils/uploadthing";
 
 export default function Home() {
-  const { startUpload } = useUploadThing("videoAndImage", {
+  const { startUpload } = createUploadThing("videoAndImage", {
     /**
      * @see https://docs.uploadthing.com/api-reference/react#useuploadthing
      */

--- a/examples/minimal-solidstart/src/utils/uploadthing.ts
+++ b/examples/minimal-solidstart/src/utils/uploadthing.ts
@@ -15,4 +15,5 @@ const initOpts = {
 
 export const UploadButton = generateUploadButton<OurFileRouter>(initOpts);
 export const UploadDropzone = generateUploadDropzone<OurFileRouter>(initOpts);
-export const { useUploadThing } = generateSolidHelpers<OurFileRouter>(initOpts);
+export const { createUploadThing } =
+  generateSolidHelpers<OurFileRouter>(initOpts);

--- a/packages/solid/src/components/button.tsx
+++ b/packages/solid/src/components/button.tsx
@@ -17,8 +17,8 @@ import type {
 } from "@uploadthing/shared";
 import type { FileRouter } from "uploadthing/types";
 
+import { INTERNAL_createUploadThingGen } from "../create-uploadthing";
 import type { UploadthingComponentProps } from "../types";
-import { INTERNAL_uploadthingHookGen } from "../useUploadThing";
 import { progressWidths, Spinner } from "./shared";
 
 type ButtonStyleFieldCallbackArgs = {
@@ -81,11 +81,11 @@ export function UploadButton<
   let inputRef: HTMLInputElement;
   const $props = props as UploadButtonProps<TRouter, TEndpoint, TSkipPolling>;
 
-  const useUploadThing = INTERNAL_uploadthingHookGen<TRouter>({
+  const createUploadThing = INTERNAL_createUploadThingGen<TRouter>({
     url: resolveMaybeUrlArg($props.url),
   });
 
-  const uploadedThing = useUploadThing($props.endpoint, {
+  const uploadedThing = createUploadThing($props.endpoint, {
     headers: $props.headers,
     skipPolling: $props.skipPolling,
     onClientUploadComplete: (res) => {

--- a/packages/solid/src/components/dropzone.tsx
+++ b/packages/solid/src/components/dropzone.tsx
@@ -18,8 +18,8 @@ import type {
 } from "@uploadthing/shared";
 import type { FileRouter } from "uploadthing/types";
 
+import { INTERNAL_createUploadThingGen } from "../create-uploadthing";
 import type { UploadthingComponentProps } from "../types";
-import { INTERNAL_uploadthingHookGen } from "../useUploadThing";
 import { progressWidths, Spinner } from "./shared";
 
 type DropzoneStyleFieldCallbackArgs = {
@@ -82,10 +82,10 @@ export const UploadDropzone = <
 
   const { mode = "manual" } = $props.config ?? {};
 
-  const useUploadThing = INTERNAL_uploadthingHookGen<TRouter>({
+  const createUploadThing = INTERNAL_createUploadThingGen<TRouter>({
     url: resolveMaybeUrlArg($props.url),
   });
-  const uploadThing = useUploadThing($props.endpoint, {
+  const uploadThing = createUploadThing($props.endpoint, {
     headers: $props.headers,
     skipPolling: $props.skipPolling,
     onClientUploadComplete: (res) => {

--- a/packages/solid/src/create-uploadthing.ts
+++ b/packages/solid/src/create-uploadthing.ts
@@ -21,7 +21,7 @@ const createEndpointMetadata = (url: URL, endpoint: string) => {
   return () => dataGetter()?.data?.find((x) => x.slug === endpoint);
 };
 
-export const INTERNAL_uploadthingHookGen = <
+export const INTERNAL_createUploadThingGen = <
   TRouter extends FileRouter,
 >(initOpts: {
   /**
@@ -36,7 +36,7 @@ export const INTERNAL_uploadthingHookGen = <
     package: "@uploadthing/solid",
   });
 
-  const useUploadThing = <
+  const createUploadThing = <
     TEndpoint extends keyof TRouter,
     TSkipPolling extends boolean = false,
   >(
@@ -119,16 +119,21 @@ export const INTERNAL_uploadthingHookGen = <
     } as const;
   };
 
-  return useUploadThing;
+  return createUploadThing;
 };
 
 export const generateSolidHelpers = <TRouter extends FileRouter>(
   initOpts?: GenerateTypedHelpersOptions,
 ) => {
   const url = resolveMaybeUrlArg(initOpts?.url);
+  const createUploadThing = INTERNAL_createUploadThingGen<TRouter>({ url });
 
   return {
-    useUploadThing: INTERNAL_uploadthingHookGen<TRouter>({ url }),
+    createUploadThing,
+    /**
+     * @deprecated use `createUploadThing` instead
+     */
+    useUploadThing: createUploadThing,
     uploadFiles: genUploader<TRouter>({
       url,
       package: "@uploadthing/solid",

--- a/packages/solid/src/index.tsx
+++ b/packages/solid/src/index.tsx
@@ -1,6 +1,6 @@
 import "./styles.css";
 
-export * from "./useUploadThing";
+export * from "./create-uploadthing";
 export {
   UploadButton,
   UploadDropzone,


### PR DESCRIPTION
Ref: https://github.com/pingdotgg/uploadthing/pull/225#issuecomment-2041461668

Follows `createSignal`, `createEffect`, `createMemo` etc etc, as well as some community libs (`createQuery` for TanStack Query for example)