### PR TITLE
fix: turbo cache not including svelte output

### DIFF
--- a/.changeset/heavy-points-hear.md
+++ b/.changeset/heavy-points-hear.md
@@ -1,0 +1,5 @@
+---
+"@uploadthing/dropzone": patch
+---
+
+fix: turbo cached build output

--- a/packages/dropzone/turbo.json
+++ b/packages/dropzone/turbo.json
@@ -3,7 +3,7 @@
   "extends": ["//"],
   "pipeline": {
     "build": {
-      "outputs": ["core/**", "react/**", "solid/**"]
+      "outputs": ["core/**", "react/**", "solid/**", "svelte/**"]
     }
   }
 }


### PR DESCRIPTION
didn't get included on npm build ![CleanShot 2024-04-09 at 23 04 38@2x](https://github.com/pingdotgg/uploadthing/assets/51714798/136c27c7-eaf5-469f-a9c5-38c7bad4941a)
