### PR TITLE
chore: Automatically mark/close stale issues

### DIFF
--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -1,0 +1,22 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 14
+          days-before-issue-close: 7
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue has been automatically marked as stale because it has not had any activity for 2 weeks. It will be closed in 7 days if no further activity occurs."
+          close-issue-message: "This issue has been closed because it has not had any activity for 7 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          only-issue-labels: "more info, 🐛bug: unconfirmed"

--- a/.github/workflows/stale-issues.yaml
+++ b/.github/workflows/stale-issues.yaml
@@ -11,12 +11,12 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          days-before-issue-stale: 14
-          days-before-issue-close: 7
+          days-before-issue-stale: 10
+          days-before-issue-close: 5
           stale-issue-label: "stale"
           stale-issue-message: "This issue has been automatically marked as stale because it has not had any activity for 2 weeks. It will be closed in 7 days if no further activity occurs."
           close-issue-message: "This issue has been closed because it has not had any activity for 7 days since being marked as stale."
           days-before-pr-stale: -1
           days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          only-issue-labels: "more info, 🐛bug: unconfirmed"
+          exempt-issue-labels: "planned,PRs Accepted,bug: low priority,bug: medium priority,bug: high priority,workaround available,🙋‍♂️ help wanted,in progress"


### PR DESCRIPTION
Automatically marks issues as stale after 2 weeks of inactivity. Closes stale issues after a further 7 days of inactivity. 

Would consider making these shorter as well. 
