### PR TITLE
refactor: make @uploadthing/shared tree-shakeable

### DIFF
--- a/.changeset/famous-forks-attend.md
+++ b/.changeset/famous-forks-attend.md
@@ -1,5 +1,5 @@
 ---
-"@uploadthing/mime-types": minor
+"@uploadthing/mime-types": patch
 ---
 
 dont initialize exported value in the global scope to improve treeshaking

--- a/.changeset/famous-forks-attend.md
+++ b/.changeset/famous-forks-attend.md
@@ -1,0 +1,5 @@
+---
+"@uploadthing/mime-types": minor
+---
+
+dont initialize exported value in the global scope to improve treeshaking

--- a/packages/mime-types/src/index.ts
+++ b/packages/mime-types/src/index.ts
@@ -27,11 +27,19 @@ function extname(path: string) {
   return index < 0 ? "" : path.substring(index);
 }
 
-export const extensions = {} as Record<MimeType, FileExtension[]>;
-export const types = {} as Record<FileExtension, MimeType>;
+const extensions = {} as Record<MimeType, FileExtension[]>;
+const types = {} as Record<FileExtension, MimeType>;
 
-// Populate the extensions/types maps
-populateMaps(extensions, types);
+// Introduce getters to improve tree-shakeability
+export function getTypes() {
+  populateMaps(extensions, types);
+  return types;
+}
+
+export function getExtensions() {
+  populateMaps(extensions, types);
+  return extensions;
+}
 
 /**
  * Lookup the MIME type for a file path/extension.
@@ -53,9 +61,10 @@ export function lookup(path: string) {
     return false;
   }
 
-  return types[extension] || false;
+  return getTypes()[extension] || false;
 }
 
+let inittedMaps = false;
 /**
  * Populate the extensions and types maps.
  * @private
@@ -65,6 +74,8 @@ function populateMaps(
   extensions: Record<MimeType, FileExtension[]>,
   types: Record<FileExtension, MimeType>,
 ) {
+  if (inittedMaps) return;
+  inittedMaps = true;
   // source preference (least -> most)
   const preference = ["nginx", "apache", undefined, "iana"];
 


### PR DESCRIPTION
POC stackblitz: https://stackblitz.com/edit/vitejs-vite-ogve7t?file=build.js

This is a breaking change in the internal package "mime-types", and from what I know it has to be a breaking change. I could not figure out a way to do it without it. In my pr `getExtensions()` and `getTypes()` are exported instead of `extensions` and `types`.

fixes #726 