### PR TITLE
fix: don't validate schema for non-ok requests

### DIFF
--- a/.changeset/kind-years-double.md
+++ b/.changeset/kind-years-double.md
@@ -1,5 +1,7 @@
 ---
 "@uploadthing/shared": patch
+uploadthing: patch
 ---
 
 fix: better error logging for bad requests
+fix: add missing peer dep

--- a/.changeset/kind-years-double.md
+++ b/.changeset/kind-years-double.md
@@ -1,0 +1,5 @@
+---
+"@uploadthing/shared": patch
+---
+
+fix: better error logging for bad requests

--- a/.vscode/operators.code-snippets
+++ b/.vscode/operators.code-snippets
@@ -6,12 +6,7 @@
   },
   "Gen Function": {
     "prefix": "gen",
-    "body": ["function* ($) {}"],
+    "body": ["function* () {}"],
     "description": "Generator FUnction with $ input",
-  },
-  "Gen Yield * tmp": {
-    "prefix": "yy",
-    "body": ["yield* $($0)"],
-    "description": "Yield generator calling $()",
   },
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -34,8 +34,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@effect/schema": "^0.66.0",
-    "effect": "^3.0.0",
+    "@effect/schema": "^0.66.9",
+    "effect": "^3.0.6",
     "fast-check": "^3.17.2",
     "std-env": "^3.7.0"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -35,8 +35,8 @@
   },
   "dependencies": {
     "@effect/schema": "^0.66.0",
-    "fast-check": "^3.17.2",
     "effect": "^3.0.0",
+    "fast-check": "^3.17.2",
     "std-env": "^3.7.0"
   },
   "devDependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -34,9 +34,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@effect/schema": "^0.66.9",
-    "effect": "^3.0.6",
-    "fast-check": "^3.17.2",
+    "@effect/schema": "^0.66.10",
+    "effect": "^3.0.7",
+    "fast-check": "^3.18.0",
     "std-env": "^3.7.0"
   },
   "devDependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@effect/schema": "^0.66.0",
+    "fast-check": "^3.17.2",
     "effect": "^3.0.0",
     "std-env": "^3.7.0"
   },

--- a/packages/shared/src/effect.ts
+++ b/packages/shared/src/effect.ts
@@ -3,7 +3,7 @@ import * as S from "@effect/schema/Schema";
 import { Context, Duration, Effect, pipe, Schedule } from "effect";
 
 import { FetchError } from "./tagged-errors";
-import type { FetchEsque, ResponseEsque } from "./types";
+import type { FetchEsque, Json, ResponseEsque } from "./types";
 import { filterObjectValues } from "./utils";
 
 export type FetchContextTag = {
@@ -72,7 +72,8 @@ export const fetchEffJson = <Schema>(
         ? Effect.succeed(json)
         : Effect.fail(
             new FetchError({
-              error: `Request to ${requestUrl} failed with status ${status}: ${JSON.stringify(json)}`,
+              error: `Request to ${requestUrl} failed with status ${status}`,
+              data: json as Json,
               input,
             }),
           ),

--- a/packages/shared/src/tagged-errors.ts
+++ b/packages/shared/src/tagged-errors.ts
@@ -1,5 +1,7 @@
 import { TaggedError } from "effect/Data";
 
+import type { Json } from "./types";
+
 export class InvalidRouteConfigError extends TaggedError("InvalidRouteConfig")<{
   reason: string;
 }> {
@@ -51,4 +53,5 @@ export class RetryError extends TaggedError("RetryError") {}
 export class FetchError extends TaggedError("FetchError")<{
   readonly input: RequestInfo | URL;
   readonly error: unknown;
+  readonly data?: Json;
 }> {}

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -276,7 +276,7 @@ export const getFullApiUrl = (
     const url = yield* Effect.try({
       try: () => new URL(maybeUrl ?? "/api/uploadthing", base),
       catch: () => new InvalidURLError(maybeUrl ?? "/api/uploadthing"),
-    })
+    });
 
     if (url.pathname === "/") {
       url.pathname = "/api/uploadthing";

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -266,19 +266,17 @@ export function semverLite(required: string, toCheck: string) {
 export const getFullApiUrl = (
   maybeUrl?: string,
 ): Effect.Effect<URL, InvalidURLError> =>
-  Effect.gen(function* ($) {
+  Effect.gen(function* () {
     const base = (() => {
       if (typeof window !== "undefined") return window.location.origin;
       if (process.env?.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
       return "http://localhost:3000";
     })();
 
-    const url = yield* $(
-      Effect.try({
-        try: () => new URL(maybeUrl ?? "/api/uploadthing", base),
-        catch: () => new InvalidURLError(maybeUrl ?? "/api/uploadthing"),
-      }),
-    );
+    const url = yield* Effect.try({
+      try: () => new URL(maybeUrl ?? "/api/uploadthing", base),
+      catch: () => new InvalidURLError(maybeUrl ?? "/api/uploadthing"),
+    })
 
     if (url.pathname === "/") {
       url.pathname = "/api/uploadthing";

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -1,4 +1,4 @@
-import { Effect, Unify } from "effect";
+import { Effect } from "effect";
 import { process } from "std-env";
 
 import { lookup } from "@uploadthing/mime-types";
@@ -46,86 +46,82 @@ export function getDefaultSizeForType(fileType: FileRouterInputKey): FileSize {
  * ```
  */
 
-export const fillInputRouteConfig = Unify.unify(
-  (
-    routeConfig: FileRouterInputConfig,
-  ): Effect.Effect<ExpandedRouteConfig, InvalidRouteConfigError> => {
-    // If array, apply defaults
-    if (isRouteArray(routeConfig)) {
-      return Effect.succeed(
-        routeConfig.reduce<ExpandedRouteConfig>((acc, fileType) => {
-          acc[fileType] = {
-            // Apply defaults
-            maxFileSize: getDefaultSizeForType(fileType),
-            maxFileCount: 1,
-            minFileCount: 1,
-            contentDisposition: "inline" as const,
-          };
-          return acc;
-        }, {}),
-      );
+export const fillInputRouteConfig = (
+  routeConfig: FileRouterInputConfig,
+): Effect.Effect<ExpandedRouteConfig, InvalidRouteConfigError> => {
+  // If array, apply defaults
+  if (isRouteArray(routeConfig)) {
+    return Effect.succeed(
+      routeConfig.reduce<ExpandedRouteConfig>((acc, fileType) => {
+        acc[fileType] = {
+          // Apply defaults
+          maxFileSize: getDefaultSizeForType(fileType),
+          maxFileCount: 1,
+          minFileCount: 1,
+          contentDisposition: "inline" as const,
+        };
+        return acc;
+      }, {}),
+    );
+  }
+
+  // Backfill defaults onto config
+  const newConfig: ExpandedRouteConfig = {};
+  for (const key of objectKeys(routeConfig)) {
+    const value = routeConfig[key];
+    if (!value) return Effect.fail(new InvalidRouteConfigError(key));
+
+    const defaultValues = {
+      maxFileSize: getDefaultSizeForType(key),
+      maxFileCount: 1,
+      minFileCount: 1,
+      contentDisposition: "inline" as const,
+    };
+
+    newConfig[key] = { ...defaultValues, ...value };
+  }
+
+  return Effect.succeed(newConfig);
+};
+
+export const getTypeFromFileName = (
+  fileName: string,
+  allowedTypes: FileRouterInputKey[],
+): Effect.Effect<
+  FileRouterInputKey,
+  UnknownFileTypeError | InvalidFileTypeError
+> => {
+  const mimeType = lookup(fileName);
+  if (!mimeType) {
+    if (allowedTypes.includes("blob")) return Effect.succeed("blob");
+    return Effect.fail(new UnknownFileTypeError(fileName));
+  }
+
+  // If the user has specified a specific mime type, use that
+  if (allowedTypes.some((type) => type.includes("/"))) {
+    if (allowedTypes.includes(mimeType)) {
+      return Effect.succeed(mimeType);
     }
+  }
 
-    // Backfill defaults onto config
-    const newConfig: ExpandedRouteConfig = {};
-    for (const key of objectKeys(routeConfig)) {
-      const value = routeConfig[key];
-      if (!value) return Effect.fail(new InvalidRouteConfigError(key));
+  // Otherwise, we have a "magic" type eg. "image" or "video"
+  const type = (
+    mimeType.toLowerCase() === "application/pdf"
+      ? "pdf"
+      : mimeType.split("/")[0]
+  ) as AllowedFileType;
 
-      const defaultValues = {
-        maxFileSize: getDefaultSizeForType(key),
-        maxFileCount: 1,
-        minFileCount: 1,
-        contentDisposition: "inline" as const,
-      };
-
-      newConfig[key] = { ...defaultValues, ...value };
+  if (!allowedTypes.includes(type)) {
+    // Blob is a catch-all for any file type not explicitly supported
+    if (allowedTypes.includes("blob")) {
+      return Effect.succeed("blob");
+    } else {
+      return Effect.fail(new InvalidFileTypeError(type, fileName));
     }
+  }
 
-    return Effect.succeed(newConfig);
-  },
-);
-
-export const getTypeFromFileName = Unify.unify(
-  (
-    fileName: string,
-    allowedTypes: FileRouterInputKey[],
-  ): Effect.Effect<
-    FileRouterInputKey,
-    UnknownFileTypeError | InvalidFileTypeError
-  > => {
-    const mimeType = lookup(fileName);
-    if (!mimeType) {
-      if (allowedTypes.includes("blob")) return Effect.succeed("blob");
-      return Effect.fail(new UnknownFileTypeError(fileName));
-    }
-
-    // If the user has specified a specific mime type, use that
-    if (allowedTypes.some((type) => type.includes("/"))) {
-      if (allowedTypes.includes(mimeType)) {
-        return Effect.succeed(mimeType);
-      }
-    }
-
-    // Otherwise, we have a "magic" type eg. "image" or "video"
-    const type = (
-      mimeType.toLowerCase() === "application/pdf"
-        ? "pdf"
-        : mimeType.split("/")[0]
-    ) as AllowedFileType;
-
-    if (!allowedTypes.includes(type)) {
-      // Blob is a catch-all for any file type not explicitly supported
-      if (allowedTypes.includes("blob")) {
-        return Effect.succeed("blob");
-      } else {
-        return Effect.fail(new InvalidFileTypeError(type, fileName));
-      }
-    }
-
-    return Effect.succeed(type);
-  },
-);
+  return Effect.succeed(type);
+};
 
 export function generateUploadThingURL(path: `/${string}`) {
   let host = "https://uploadthing.com";
@@ -137,25 +133,25 @@ export function generateUploadThingURL(path: `/${string}`) {
 
 export const FILESIZE_UNITS = ["B", "KB", "MB", "GB"] as const;
 export type FileSizeUnit = (typeof FILESIZE_UNITS)[number];
-export const fileSizeToBytes = Unify.unify(
-  (fileSize: FileSize): Effect.Effect<number, InvalidFileSizeError> => {
-    const regex = new RegExp(
-      `^(\\d+)(\\.\\d+)?\\s*(${FILESIZE_UNITS.join("|")})$`,
-      "i",
-    );
+export const fileSizeToBytes = (
+  fileSize: FileSize,
+): Effect.Effect<number, InvalidFileSizeError> => {
+  const regex = new RegExp(
+    `^(\\d+)(\\.\\d+)?\\s*(${FILESIZE_UNITS.join("|")})$`,
+    "i",
+  );
 
-    // make sure the string is in the format of 123KB
-    const match = fileSize.match(regex);
-    if (!match) {
-      return Effect.fail(new InvalidFileSizeError(fileSize));
-    }
+  // make sure the string is in the format of 123KB
+  const match = fileSize.match(regex);
+  if (!match) {
+    return Effect.fail(new InvalidFileSizeError(fileSize));
+  }
 
-    const sizeValue = parseFloat(match[1]);
-    const sizeUnit = match[3].toUpperCase() as FileSizeUnit;
-    const bytes = sizeValue * Math.pow(1024, FILESIZE_UNITS.indexOf(sizeUnit));
-    return Effect.succeed(Math.floor(bytes));
-  },
-);
+  const sizeValue = parseFloat(match[1]);
+  const sizeUnit = match[3].toUpperCase() as FileSizeUnit;
+  const bytes = sizeValue * Math.pow(1024, FILESIZE_UNITS.indexOf(sizeUnit));
+  return Effect.succeed(Math.floor(bytes));
+};
 
 export const bytesToFileSize = (bytes: number) => {
   if (bytes === 0 || bytes === -1) {

--- a/packages/uploadthing/package.json
+++ b/packages/uploadthing/package.json
@@ -127,12 +127,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@effect/schema": "^0.66.9",
+    "@effect/schema": "^0.66.10",
     "@uploadthing/mime-types": "workspace:*",
     "@uploadthing/shared": "workspace:*",
     "consola": "^3.2.3",
-    "effect": "^3.0.6",
-    "fast-check": "^3.17.2",
+    "effect": "^3.0.7",
+    "fast-check": "^3.18.0",
     "std-env": "^3.7.0"
   },
   "devDependencies": {

--- a/packages/uploadthing/package.json
+++ b/packages/uploadthing/package.json
@@ -127,11 +127,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@effect/schema": "^0.66.0",
+    "@effect/schema": "^0.66.9",
     "@uploadthing/mime-types": "workspace:*",
     "@uploadthing/shared": "workspace:*",
     "consola": "^3.2.3",
-    "effect": "^3.0.0",
+    "effect": "^3.0.6",
+    "fast-check": "^3.17.2",
     "std-env": "^3.7.0"
   },
   "devDependencies": {

--- a/packages/uploadthing/src/express.ts
+++ b/packages/uploadthing/src/express.ts
@@ -16,7 +16,6 @@ import {
   runRequestHandlerAsync,
 } from "./internal/handler";
 import { incompatibleNodeGuard } from "./internal/incompat-node-guard";
-import { initLogger } from "./internal/logger";
 import { getPostBody, toWebRequest } from "./internal/to-web-request";
 import type { FileRouter, RouteHandlerOptions } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
@@ -38,7 +37,6 @@ export const createUploadthing = <TErrorShape extends Json>(
 export const createRouteHandler = <TRouter extends FileRouter>(
   opts: RouteHandlerOptions<TRouter>,
 ): ExpressRouter => {
-  initLogger(opts.config?.logLevel);
   incompatibleNodeGuard();
 
   const requestHandler = buildRequestHandler<TRouter, MiddlewareArgs>(

--- a/packages/uploadthing/src/fastify.ts
+++ b/packages/uploadthing/src/fastify.ts
@@ -16,7 +16,6 @@ import {
   runRequestHandlerAsync,
 } from "./internal/handler";
 import { incompatibleNodeGuard } from "./internal/incompat-node-guard";
-import { initLogger } from "./internal/logger";
 import { toWebRequest } from "./internal/to-web-request";
 import type { FileRouter, RouteHandlerOptions } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
@@ -40,7 +39,6 @@ export const createRouteHandler = <TRouter extends FileRouter>(
   opts: RouteHandlerOptions<TRouter>,
   done: (err?: Error) => void,
 ) => {
-  initLogger(opts.config?.logLevel);
   incompatibleNodeGuard();
 
   const requestHandler = buildRequestHandler<TRouter, MiddlewareArgs>(

--- a/packages/uploadthing/src/h3.ts
+++ b/packages/uploadthing/src/h3.ts
@@ -18,7 +18,6 @@ import {
   runRequestHandlerAsync,
 } from "./internal/handler";
 import { incompatibleNodeGuard } from "./internal/incompat-node-guard";
-import { initLogger } from "./internal/logger";
 import type { FileRouter, RouteHandlerOptions } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
@@ -35,7 +34,6 @@ export const createUploadthing = <TErrorShape extends Json>(
 export const createRouteHandler = <TRouter extends FileRouter>(
   opts: RouteHandlerOptions<TRouter>,
 ) => {
-  initLogger(opts.config?.logLevel);
   incompatibleNodeGuard();
 
   const requestHandler = buildRequestHandler<TRouter, MiddlewareArgs>(

--- a/packages/uploadthing/src/internal/dev-hook.ts
+++ b/packages/uploadthing/src/internal/dev-hook.ts
@@ -23,12 +23,11 @@ const isValidResponse = (response: ResponseEsque) => {
 };
 
 export const conditionalDevServer = (fileKey: string, apiKey: string) => {
-  return Effect.gen(function* ($) {
-    const file = yield* $(
-      fetchEffJson(
-        generateUploadThingURL(`/api/pollUpload/${fileKey}`),
-        PollUploadResponseSchema,
-      ),
+  return Effect.gen(function* () {
+    const file = yield* fetchEffJson(
+      generateUploadThingURL(`/api/pollUpload/${fileKey}`),
+      PollUploadResponseSchema,
+    ).pipe(
       Effect.andThen((res) =>
         res.status === "done"
           ? Effect.succeed(res.fileData)
@@ -42,22 +41,19 @@ export const conditionalDevServer = (fileKey: string, apiKey: string) => {
     );
 
     if (file === undefined) {
-      yield* $(
-        Effect.logError(`Failed to simulate callback for file ${fileKey}`),
-      );
-      return yield* $(
-        new UploadThingError({
-          code: "UPLOAD_FAILED",
-          message: "File took too long to upload",
-        }),
-      );
+      yield* Effect.logError(`Failed to simulate callback for file ${fileKey}`);
+      return yield* new UploadThingError({
+        code: "UPLOAD_FAILED",
+        message: "File took too long to upload",
+      });
     }
 
     let callbackUrl = file.callbackUrl + `?slug=${file.callbackSlug}`;
     if (!callbackUrl.startsWith("http")) callbackUrl = "http://" + callbackUrl;
 
-    yield* $(
-      Effect.logInfo(`SIMULATING FILE UPLOAD WEBHOOK CALLBACK`, callbackUrl),
+    yield* Effect.logInfo(
+      `SIMULATING FILE UPLOAD WEBHOOK CALLBACK`,
+      callbackUrl,
     );
 
     const payload = JSON.stringify({
@@ -73,46 +69,42 @@ export const conditionalDevServer = (fileKey: string, apiKey: string) => {
       } satisfies UploadedFileData,
     });
 
-    const signature = yield* $(
-      Effect.tryPromise({
-        try: () => signPayload(payload, apiKey),
-        catch: (e) =>
-          new UploadThingError({
-            code: "INTERNAL_SERVER_ERROR",
-            message: "Failed to sign payload",
-            cause: e,
-          }),
-      }),
-    );
+    const signature = yield* Effect.tryPromise({
+      try: () => signPayload(payload, apiKey),
+      catch: (e) =>
+        new UploadThingError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to sign payload",
+          cause: e,
+        }),
+    });
 
-    const callbackResponse = yield* $(
-      fetchEff(callbackUrl, {
-        method: "POST",
-        body: payload,
-        headers: {
-          "Content-Type": "application/json",
-          "uploadthing-hook": "callback",
-          "x-uploadthing-signature": signature,
-        },
-      }),
+    const callbackResponse = yield* fetchEff(callbackUrl, {
+      method: "POST",
+      body: payload,
+      headers: {
+        "Content-Type": "application/json",
+        "uploadthing-hook": "callback",
+        "x-uploadthing-signature": signature,
+      },
+    }).pipe(
       Effect.catchTag("FetchError", () =>
         Effect.succeed(new Response(null, { status: 500 })),
       ),
     );
 
     if (isValidResponse(callbackResponse)) {
-      yield* $(
-        Effect.logInfo("Successfully simulated callback for file", fileKey),
+      yield* Effect.logInfo(
+        "Successfully simulated callback for file",
+        fileKey,
       );
     } else {
-      yield* $(
-        Effect.logError(
-          `
+      yield* Effect.logError(
+        `
 Failed to simulate callback for file '${file.fileKey}'. Is your webhook configured correctly?
   - Make sure the URL '${callbackUrl}' is accessible without any authentication. You can verify this by running 'curl -X POST ${callbackUrl}' in your terminal
   - Still facing issues? Read https://docs.uploadthing.com/faq for common issues
 `.trim(),
-        ),
       );
     }
     return file;

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -151,6 +151,7 @@ export const buildRequestHandler =
                   message:
                     typeof err.error === "string" ? err.error : err.message,
                   cause: err,
+                  data: err.data,
                 }),
             ),
           ),

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -144,7 +144,15 @@ export const buildRequestHandler =
       Effect.catchTags({
         FetchError: (err) =>
           Effect.logError("An error occurred while fetching", err).pipe(
-            Effect.andThen(() => Effect.die(err)),
+            Effect.andThen(
+              () =>
+                new UploadThingError({
+                  code: "INTERNAL_SERVER_ERROR",
+                  message:
+                    typeof err.error === "string" ? err.error : err.message,
+                  cause: err,
+                }),
+            ),
           ),
         ParseError: (err) =>
           Effect.logError(

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -151,7 +151,8 @@ export const buildRequestHandler =
                   message:
                     typeof err.error === "string" ? err.error : err.message,
                   cause: err,
-                  data: err.data,
+                  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+                  data: err.data as any,
                 }),
             ),
           ),

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -144,13 +144,13 @@ export const buildRequestHandler =
       Effect.catchTags({
         FetchError: (err) =>
           Effect.logError("An error occurred while fetching", err).pipe(
-            Effect.die,
+            Effect.andThen(() => Effect.die(err)),
           ),
         ParseError: (err) =>
           Effect.logError(
             "An error occurred while parsing input/output",
             err,
-          ).pipe(Effect.die),
+          ).pipe(Effect.andThen(() => Effect.die(err))),
       }),
       // By here we either have a successful result or an UploadThingError defect, return either
       Effect.match({

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -16,7 +16,7 @@ import {
 
 import { UPLOADTHING_VERSION } from "./constants";
 import { conditionalDevServer } from "./dev-hook";
-import { withLogger } from "./logger";
+import { ConsolaLogger, withMinimalLogLevel } from "./logger";
 import {
   abortMultipartUpload,
   completeMultipartUpload,
@@ -70,7 +70,8 @@ export const runRequestHandlerAsync = <
   });
 
   return handler(args).pipe(
-    Effect.provide(withLogger(config?.logLevel)),
+    withMinimalLogLevel(config?.logLevel),
+    Effect.provide(ConsolaLogger),
     Effect.provide(layer),
     Effect.andThen((data) => {
       if ("status" in data && data.status !== 200) {
@@ -432,7 +433,11 @@ const handleUploadAction = (opts: {
         presignedUrls,
         (file) => conditionalDevServer(file.key, opts.apiKey),
         { concurrency: 10 },
-      ).pipe(Effect.provide(layer), Effect.runPromise);
+      ).pipe(
+        Effect.provide(ConsolaLogger),
+        Effect.provide(layer),
+        Effect.runPromise,
+      );
     }
 
     return {

--- a/packages/uploadthing/src/internal/incompat-node-guard.ts
+++ b/packages/uploadthing/src/internal/incompat-node-guard.ts
@@ -1,6 +1,5 @@
+import { Effect } from "effect";
 import { process } from "std-env";
-
-import { logger } from "./logger";
 
 export function incompatibleNodeGuard() {
   if (typeof process === "undefined") return;
@@ -30,10 +29,11 @@ export function incompatibleNodeGuard() {
   if (major > 18) return;
   if (major === 18 && minor >= 13) return;
 
-  logger.fatal(
-    `YOU ARE USING A LEGACY (${major}.${minor}) NODE VERSION WHICH ISN'T OFFICIALLY SUPPORTED. PLEASE UPGRADE TO NODE ^18.13.`,
+  Effect.runSync(
+    Effect.logError(
+      `YOU ARE USING A LEGACY (${major}.${minor}) NODE VERSION WHICH ISN'T OFFICIALLY SUPPORTED. PLEASE UPGRADE TO NODE ^18.13.`,
+    ),
   );
-
   // Kill the process if it isn't going to work correctly anyway
   // If we've gotten this far we know we have a Node.js runtime so exit is defined. Override std-env type.
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call

--- a/packages/uploadthing/src/internal/incompat-node-guard.ts
+++ b/packages/uploadthing/src/internal/incompat-node-guard.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import * as Effect from "effect/Effect";
 import { process } from "std-env";
 
 export function incompatibleNodeGuard() {

--- a/packages/uploadthing/src/internal/logger.ts
+++ b/packages/uploadthing/src/internal/logger.ts
@@ -124,11 +124,13 @@ const effectLoggerLevelToConsolaLevel: Record<EffectLogLevel.Literal, LogType> =
 export const withMinimalLogLevel = (level: LogLevel = "info") => {
   return Logger.withMinimumLogLevel(
     {
+      silent: EffectLogLevel.None,
       error: EffectLogLevel.Error,
       warn: EffectLogLevel.Warning,
       info: EffectLogLevel.Info,
       debug: EffectLogLevel.Debug,
       trace: EffectLogLevel.Trace,
+      verbose: EffectLogLevel.All,
     }[level],
   );
 };

--- a/packages/uploadthing/src/internal/logger.ts
+++ b/packages/uploadthing/src/internal/logger.ts
@@ -82,7 +82,7 @@ function formatArgs(args: any[]) {
   });
 }
 
-export const logger = createConsola({
+const logger = createConsola({
   reporters: [
     {
       log: (logObj: LogObject) => {
@@ -108,11 +108,6 @@ export const logger = createConsola({
     tag: "UPLOADTHING",
   },
 });
-
-export const initLogger = (level: LogLevel | undefined) => {
-  // logger.wrapConsole();
-  logger.level = LogLevels[level ?? "info"];
-};
 
 const effectLoggerLevelToConsolaLevel: Record<EffectLogLevel.Literal, LogType> =
   {

--- a/packages/uploadthing/src/internal/logger.ts
+++ b/packages/uploadthing/src/internal/logger.ts
@@ -1,7 +1,7 @@
 import type { LogObject, LogType } from "consola/core";
-import { createConsola, LogLevels } from "consola/core";
-import type { LogLevel as EffectLogLevel } from "effect";
-import { Logger } from "effect";
+import { createConsola } from "consola/core";
+import * as Logger from "effect/Logger";
+import * as EffectLogLevel from "effect/LogLevel";
 import { process } from "std-env";
 
 import { isObject } from "@uploadthing/shared";
@@ -121,13 +121,22 @@ const effectLoggerLevelToConsolaLevel: Record<EffectLogLevel.Literal, LogType> =
     None: "silent",
   };
 
-export const withLogger = (level: LogLevel = "info") => {
-  logger.level = LogLevels[level];
-  return Logger.replace(
-    Logger.defaultLogger,
-    Logger.make(({ logLevel, message }) => {
-      // FIXME: Probably log other stuff than just message?
-      logger[effectLoggerLevelToConsolaLevel[logLevel._tag]](message);
-    }),
+export const withMinimalLogLevel = (level: LogLevel = "info") => {
+  return Logger.withMinimumLogLevel(
+    {
+      error: EffectLogLevel.Error,
+      warn: EffectLogLevel.Warning,
+      info: EffectLogLevel.Info,
+      debug: EffectLogLevel.Debug,
+      trace: EffectLogLevel.Trace,
+    }[level],
   );
 };
+
+export const ConsolaLogger = Logger.replace(
+  Logger.defaultLogger,
+  Logger.make(({ logLevel, message }) => {
+    // FIXME: Probably log other stuff than just message?
+    logger[effectLoggerLevelToConsolaLevel[logLevel._tag]](message);
+  }),
+);

--- a/packages/uploadthing/src/internal/logger.ts
+++ b/packages/uploadthing/src/internal/logger.ts
@@ -1,5 +1,6 @@
 import type { LogObject, LogType } from "consola/core";
 import { createConsola, LogLevels } from "consola/core";
+import { Logger } from "effect";
 import { process } from "std-env";
 
 import { isObject } from "@uploadthing/shared";
@@ -108,3 +109,17 @@ export const initLogger = (level: LogLevel | undefined) => {
   // logger.wrapConsole();
   logger.level = LogLevels[level ?? "info"];
 };
+
+// export const withLogger = Logger.replace(
+//   Logger.defaultLogger,
+//   Logger.make(({ logLevel, message }) => {
+//     console.log("Creaing logger", logLevel, message);
+//     logger.info(message);
+//   }),
+// );
+
+export const withLogger = (level: LogLevel = "info") =>
+  Logger.replace(
+    Logger.defaultLogger,
+    Logger.make((opts) => logger.log(opts)),
+  );

--- a/packages/uploadthing/src/internal/multi-part.browser.ts
+++ b/packages/uploadthing/src/internal/multi-part.browser.ts
@@ -24,38 +24,37 @@ export const uploadMultipartWithProgress = (
       | undefined;
   },
 ) =>
-  Effect.gen(function* ($) {
+  Effect.gen(function* () {
     let uploadedBytes = 0;
-    const etags = yield* $(
-      Effect.forEach(
-        presigned.urls,
-        (url, index) => {
-          const offset = presigned.chunkSize * index;
-          const end = Math.min(offset + presigned.chunkSize, file.size);
-          const chunk = file.slice(offset, end);
+    const etags = yield* Effect.forEach(
+      presigned.urls,
+      (url, index) => {
+        const offset = presigned.chunkSize * index;
+        const end = Math.min(offset + presigned.chunkSize, file.size);
+        const chunk = file.slice(offset, end);
 
-          return uploadPart({
-            url,
-            chunk: chunk,
-            contentDisposition: presigned.contentDisposition,
-            fileType: file.type,
-            fileName: file.name,
-            onProgress: (delta) => {
-              uploadedBytes += delta;
-              const percent = (uploadedBytes / file.size) * 100;
-              opts.onUploadProgress?.({ file: file.name, progress: percent });
-            },
-          }).pipe(
-            Effect.andThen((tag) => ({ tag, partNumber: index + 1 })),
-            Effect.retry({
-              while: (error) => error instanceof RetryError,
-              times: isTest ? 3 : 10, // less retries in tests just to make it faster
-              schedule: exponentialBackoff,
-            }),
-          );
-        },
-        { concurrency: "inherit" },
-      ),
+        return uploadPart({
+          url,
+          chunk: chunk,
+          contentDisposition: presigned.contentDisposition,
+          fileType: file.type,
+          fileName: file.name,
+          onProgress: (delta) => {
+            uploadedBytes += delta;
+            const percent = (uploadedBytes / file.size) * 100;
+            opts.onUploadProgress?.({ file: file.name, progress: percent });
+          },
+        }).pipe(
+          Effect.andThen((tag) => ({ tag, partNumber: index + 1 })),
+          Effect.retry({
+            while: (error) => error instanceof RetryError,
+            times: isTest ? 3 : 10, // less retries in tests just to make it faster
+            schedule: exponentialBackoff,
+          }),
+        );
+      },
+      { concurrency: "inherit" },
+    ).pipe(
       Effect.tapErrorCause((error) =>
         opts.reportEventToUT(
           "failure",
@@ -71,16 +70,14 @@ export const uploadMultipartWithProgress = (
     );
 
     // Tell the server that the upload is complete
-    yield* $(
-      opts.reportEventToUT(
-        "multipart-complete",
-        {
-          uploadId: presigned.uploadId,
-          fileKey: presigned.key,
-          etags,
-        },
-        S.Null,
-      ),
+    yield* opts.reportEventToUT(
+      "multipart-complete",
+      {
+        uploadId: presigned.uploadId,
+        fileKey: presigned.key,
+        etags,
+      },
+      S.Null,
     );
   });
 

--- a/packages/uploadthing/src/internal/multi-part.server.ts
+++ b/packages/uploadthing/src/internal/multi-part.server.ts
@@ -13,14 +13,15 @@ import {
 import type { ContentDisposition } from "@uploadthing/shared";
 
 import type { FileEsque } from "../sdk/types";
-import { logger } from "./logger";
 import { FailureCallbackResponseSchema } from "./shared-schemas";
 import type { MPUResponse } from "./types";
 
 export const uploadMultipart = (file: FileEsque, presigned: MPUResponse) =>
   Effect.gen(function* ($) {
-    logger.debug(
-      `Uploading file ${file.name} with ${presigned.urls.length} chunks of size ${presigned.chunkSize} bytes each`,
+    yield* $(
+      Effect.logDebug(
+        `Uploading file ${file.name} with ${presigned.urls.length} chunks of size ${presigned.chunkSize} bytes each`,
+      ),
     );
 
     const etags = yield* $(
@@ -49,10 +50,10 @@ export const uploadMultipart = (file: FileEsque, presigned: MPUResponse) =>
       ),
     );
 
-    logger.debug("File", file.name, "uploaded successfully.");
-    logger.debug("Completing multipart upload...");
+    yield* $(Effect.logDebug("File", file.name, "uploaded successfully."));
+    yield* $(Effect.logDebug("Completing multipart upload..."));
     yield* $(completeMultipartUpload(presigned, etags));
-    logger.debug("Multipart upload complete.");
+    yield* $(Effect.logDebug("Multipart upload complete."));
   });
 
 /**

--- a/packages/uploadthing/src/internal/presigned-post.server.ts
+++ b/packages/uploadthing/src/internal/presigned-post.server.ts
@@ -12,22 +12,21 @@ import { FailureCallbackResponseSchema } from "./shared-schemas";
 import type { PSPResponse } from "./types";
 
 export const uploadPresignedPost = (file: FileEsque, presigned: PSPResponse) =>
-  Effect.gen(function* ($) {
-    yield* $(
-      Effect.logDebug(`Uploading file ${file.name} using presigned POST URL`),
+  Effect.gen(function* () {
+    yield* Effect.logDebug(
+      `Uploading file ${file.name} using presigned POST URL`,
     );
     const formData = new FormData();
     Object.entries(presigned.fields).forEach(([k, v]) => formData.append(k, v));
     formData.append("file", file as Blob); // File data **MUST GO LAST**
 
-    const res = yield* $(
-      fetchEff(presigned.url, {
-        method: "POST",
-        body: formData,
-        headers: new Headers({
-          Accept: "application/xml",
-        }),
+    const res = yield* fetchEff(presigned.url, {
+      method: "POST",
+      body: formData,
+      headers: new Headers({
+        Accept: "application/xml",
       }),
+    }).pipe(
       Effect.tapErrorCause(() =>
         fetchEffJson(
           generateUploadThingURL("/api/failureCallback"),
@@ -45,20 +44,16 @@ export const uploadPresignedPost = (file: FileEsque, presigned: PSPResponse) =>
     );
 
     if (!res.ok) {
-      const text = yield* $(Effect.promise(res.text));
-      yield* $(
-        Effect.logError(
-          `Failed to upload file ${file.name} to presigned POST URL. Response: ${text}`,
-        ),
+      const text = yield* Effect.promise(res.text);
+      yield* Effect.logError(
+        `Failed to upload file ${file.name} to presigned POST URL. Response: ${text}`,
       );
-      return yield* $(
-        new UploadThingError({
-          code: "UPLOAD_FAILED",
-          message: "Failed to upload file",
-          cause: text,
-        }),
-      );
+      return yield* new UploadThingError({
+        code: "UPLOAD_FAILED",
+        message: "Failed to upload file",
+        cause: text,
+      });
     }
 
-    yield* $(Effect.logDebug("File", file.name, "uploaded successfully"));
+    yield* Effect.logDebug("File", file.name, "uploaded successfully");
   });

--- a/packages/uploadthing/src/internal/presigned-post.server.ts
+++ b/packages/uploadthing/src/internal/presigned-post.server.ts
@@ -8,13 +8,14 @@ import {
 } from "@uploadthing/shared";
 
 import type { FileEsque } from "../sdk/types";
-import { logger } from "./logger";
 import { FailureCallbackResponseSchema } from "./shared-schemas";
 import type { PSPResponse } from "./types";
 
 export const uploadPresignedPost = (file: FileEsque, presigned: PSPResponse) =>
   Effect.gen(function* ($) {
-    logger.debug("Uploading file", file.name, "using presigned POST URL");
+    yield* $(
+      Effect.logDebug(`Uploading file ${file.name} using presigned POST URL`),
+    );
     const formData = new FormData();
     Object.entries(presigned.fields).forEach(([k, v]) => formData.append(k, v));
     formData.append("file", file as Blob); // File data **MUST GO LAST**
@@ -45,7 +46,11 @@ export const uploadPresignedPost = (file: FileEsque, presigned: PSPResponse) =>
 
     if (!res.ok) {
       const text = yield* $(Effect.promise(res.text));
-      logger.error("Failed to upload file:", text);
+      yield* $(
+        Effect.logError(
+          `Failed to upload file ${file.name} to presigned POST URL. Response: ${text}`,
+        ),
+      );
       return yield* $(
         new UploadThingError({
           code: "UPLOAD_FAILED",
@@ -55,5 +60,5 @@ export const uploadPresignedPost = (file: FileEsque, presigned: PSPResponse) =>
       );
     }
 
-    logger.debug("File", file.name, "uploaded successfully");
+    yield* $(Effect.logDebug("File", file.name, "uploaded successfully"));
   });

--- a/packages/uploadthing/src/internal/resolve-url.ts
+++ b/packages/uploadthing/src/internal/resolve-url.ts
@@ -9,7 +9,6 @@ export const resolveCallbackUrl = (opts: {
   config: RouteHandlerConfig | undefined;
   req: Request;
   isDev: boolean;
-  logWarning: (typeof console)["warn"];
 }) => {
   return Effect.gen(function* ($) {
     let callbackUrl = new URL(opts.req.url);
@@ -41,7 +40,7 @@ export const resolveCallbackUrl = (opts: {
 
     if (!parsedFromHeaders || parsedFromHeaders.includes("localhost")) {
       // Didn't find a valid URL in the headers, log a warning and use the original url anyway
-      opts.logWarning(
+      Effect.logWarning(
         "You are using a localhost callback url in production which is not supported.",
         "Read more and learn how to fix it here: https://docs.uploadthing.com/faq#my-callback-runs-in-development-but-not-in-production",
       );

--- a/packages/uploadthing/src/internal/resolve-url.ts
+++ b/packages/uploadthing/src/internal/resolve-url.ts
@@ -10,12 +10,12 @@ export const resolveCallbackUrl = (opts: {
   req: Request;
   isDev: boolean;
 }) => {
-  return Effect.gen(function* ($) {
+  return Effect.gen(function* () {
     let callbackUrl = new URL(opts.req.url);
     if (opts.config?.callbackUrl) {
-      callbackUrl = yield* $(getFullApiUrl(opts.config.callbackUrl));
+      callbackUrl = yield* getFullApiUrl(opts.config.callbackUrl);
     } else if (process.env.UPLOADTHING_URL) {
-      callbackUrl = yield* $(getFullApiUrl(process.env.UPLOADTHING_URL));
+      callbackUrl = yield* getFullApiUrl(process.env.UPLOADTHING_URL);
     }
 
     if (opts.isDev || !callbackUrl.host.includes("localhost")) {
@@ -47,6 +47,6 @@ export const resolveCallbackUrl = (opts: {
       return callbackUrl;
     }
 
-    return yield* $(getFullApiUrl(parsedFromHeaders));
+    return yield* getFullApiUrl(parsedFromHeaders);
   });
 };

--- a/packages/uploadthing/src/internal/to-web-request.ts
+++ b/packages/uploadthing/src/internal/to-web-request.ts
@@ -4,8 +4,6 @@ import { process } from "std-env";
 
 import { filterObjectValues, UploadThingError } from "@uploadthing/shared";
 
-import { logger } from "./logger";
-
 type IncomingMessageLike = {
   method?: string | undefined;
   url?: string | undefined;
@@ -17,8 +15,10 @@ class InvalidURL extends TaggedError("InvalidURL")<{
   reason: string;
 }> {
   constructor(attemptedUrl: string, base?: string) {
-    logger.error(
-      `Failed to parse URL from request. '${attemptedUrl}' is not a valid URL with base '${base}'.`,
+    Effect.runSync(
+      Effect.logError(
+        `Failed to parse URL from request. '${attemptedUrl}' is not a valid URL with base '${base}'.`,
+      ),
     );
     super({
       reason: `Failed to parse URL from request. '${attemptedUrl}' is not a valid URL with base '${base}'.`,
@@ -60,7 +60,9 @@ export const getPostBody = <TBody = unknown>(opts: {
 
     if ("body" in req) {
       if (contentType !== "application/json") {
-        logger.error("Expected JSON content type, got:", contentType);
+        Effect.runSync(
+          Effect.logError("Expected JSON content type, got:", contentType),
+        );
         return resume(
           Effect.fail(
             new UploadThingError({
@@ -72,9 +74,11 @@ export const getPostBody = <TBody = unknown>(opts: {
       }
 
       if (typeof req.body !== "object") {
-        logger.error(
-          "Expected body to be of type 'object', got:",
-          typeof req.body,
+        Effect.runSync(
+          Effect.logError(
+            "Expected body to be of type 'object', got:",
+            typeof req.body,
+          ),
         );
         return resume(
           Effect.fail(
@@ -86,7 +90,7 @@ export const getPostBody = <TBody = unknown>(opts: {
         );
       }
 
-      logger.debug("Body parsed successfully.", req.body);
+      Effect.runSync(Effect.logDebug("Body parsed successfully.", req.body));
       return resume(Effect.succeed(req.body as TBody));
     }
 

--- a/packages/uploadthing/src/internal/types.ts
+++ b/packages/uploadthing/src/internal/types.ts
@@ -210,7 +210,7 @@ export type RequestHandlerOutput = Effect.Effect<
       body: UTEvents[keyof UTEvents]["out"];
       cleanup?: Promise<unknown> | undefined;
     }
-  | UploadThingError<any>,
+  | UploadThingError,
   never,
   FetchContextTag
 >;

--- a/packages/uploadthing/src/internal/types.ts
+++ b/packages/uploadthing/src/internal/types.ts
@@ -210,7 +210,7 @@ export type RequestHandlerOutput = Effect.Effect<
       body: UTEvents[keyof UTEvents]["out"];
       cleanup?: Promise<unknown> | undefined;
     }
-  | UploadThingError,
+  | UploadThingError<any>,
   never,
   FetchContextTag
 >;

--- a/packages/uploadthing/src/internal/validate-request-input.ts
+++ b/packages/uploadthing/src/internal/validate-request-input.ts
@@ -79,51 +79,50 @@ export const assertFilesMeetConfig = (
   | InvalidFileTypeError
   | InvalidFileSizeError
 > =>
-  Effect.gen(function* ($) {
+  Effect.gen(function* () {
     const counts: Record<string, number> = {};
 
     for (const file of files) {
-      const type = yield* $(
-        getTypeFromFileName(file.name, objectKeys(routeConfig)),
+      const type = yield* getTypeFromFileName(
+        file.name,
+        objectKeys(routeConfig),
       );
       counts[type] = (counts[type] ?? 0) + 1;
 
       const sizeLimit = routeConfig[type]?.maxFileSize;
       if (!sizeLimit) {
-        return yield* $(new InvalidRouteConfigError(type, "maxFileSize"));
+        return yield* new InvalidRouteConfigError(type, "maxFileSize");
       }
-      const sizeLimitBytes = yield* $(fileSizeToBytes(sizeLimit));
+      const sizeLimitBytes = yield* fileSizeToBytes(sizeLimit);
 
       if (file.size > sizeLimitBytes) {
-        return yield* $(new FileSizeMismatch(type, sizeLimit, file.size));
+        return yield* new FileSizeMismatch(type, sizeLimit, file.size);
       }
     }
 
     for (const _key in counts) {
       const key = _key as FileRouterInputKey;
       const config = routeConfig[key];
-      if (!config) return yield* $(new InvalidRouteConfigError(key));
+      if (!config) return yield* new InvalidRouteConfigError(key);
 
       const count = counts[key];
       const min = config.minFileCount;
       const max = config.maxFileCount;
 
       if (min > max) {
-        return yield* $(
-          new UploadThingError({
-            code: "BAD_REQUEST",
-            message:
-              "Invalid config during file count - minFileCount > maxFileCount",
-            cause: `minFileCount must be less than maxFileCount for key ${key}. got: ${min} > ${max}`,
-          }),
-        );
+        return yield* new UploadThingError({
+          code: "BAD_REQUEST",
+          message:
+            "Invalid config during file count - minFileCount > maxFileCount",
+          cause: `minFileCount must be less than maxFileCount for key ${key}. got: ${min} > ${max}`,
+        });
       }
 
       if (count < min) {
-        return yield* $(new FileCountMismatch(key, "minimum", min, count));
+        return yield* new FileCountMismatch(key, "minimum", min, count);
       }
       if (count > max) {
-        return yield* $(new FileCountMismatch(key, "maximum", max, count));
+        return yield* new FileCountMismatch(key, "maximum", max, count);
       }
     }
 
@@ -152,7 +151,7 @@ export const parseAndValidateRequest = (opts: {
   UploadThingError,
   FetchContextTag
 > =>
-  Effect.gen(function* ($) {
+  Effect.gen(function* () {
     // Get inputs from query and params
     const url = new URL(opts.req.url);
     const headers = opts.req.headers;
@@ -165,142 +164,118 @@ export const parseAndValidateRequest = (opts: {
     const apiKey = getApiKey(opts.opts.config?.uploadthingSecret);
 
     if (clientVersion != null && clientVersion !== UPLOADTHING_VERSION) {
-      yield* $(
-        Effect.logError(
-          `Client version mismatch. Server version: ${UPLOADTHING_VERSION}, Client version: ${clientVersion}`,
-        ),
+      yield* Effect.logError(
+        `Client version mismatch. Server version: ${UPLOADTHING_VERSION}, Client version: ${clientVersion}`,
       );
-      return yield* $(
-        new UploadThingError({
-          code: "BAD_REQUEST",
-          message: "Client version mismatch",
-          cause: `Server version: ${UPLOADTHING_VERSION}, Client version: ${clientVersion}`,
-        }),
-      );
+      return yield* new UploadThingError({
+        code: "BAD_REQUEST",
+        message: "Client version mismatch",
+        cause: `Server version: ${UPLOADTHING_VERSION}, Client version: ${clientVersion}`,
+      });
     }
 
     if (!slug) {
-      yield* $(Effect.logError("No slug provided in params:", params));
-      return yield* $(
-        new UploadThingError({
-          code: "BAD_REQUEST",
-          message: "No slug provided in params",
-        }),
-      );
+      yield* Effect.logError("No slug provided in params:", params);
+      return yield* new UploadThingError({
+        code: "BAD_REQUEST",
+        message: "No slug provided in params",
+      });
     }
 
     if (slug && typeof slug !== "string") {
       const msg = `Expected slug to be of type 'string', got '${typeof slug}'`;
-      yield* $(Effect.logError(msg));
-      return yield* $(
-        new UploadThingError({
-          code: "BAD_REQUEST",
-          message: "`slug` must be a string",
-          cause: msg,
-        }),
-      );
+      yield* Effect.logError(msg);
+      return yield* new UploadThingError({
+        code: "BAD_REQUEST",
+        message: "`slug` must be a string",
+        cause: msg,
+      });
     }
 
     if (!apiKey) {
       const msg = `No secret provided, please set UPLOADTHING_SECRET in your env file or in the config`;
-      yield* $(Effect.logError(msg));
-      return yield* $(
-        new UploadThingError({
-          code: "MISSING_ENV",
-          message: `No secret provided`,
-          cause: msg,
-        }),
-      );
+      yield* Effect.logError(msg);
+      return yield* new UploadThingError({
+        code: "MISSING_ENV",
+        message: `No secret provided`,
+        cause: msg,
+      });
     }
 
     if (!apiKey.startsWith("sk_")) {
       const msg = `Invalid secret provided, UPLOADTHING_SECRET must start with 'sk_'`;
-      yield* $(Effect.logError(msg));
-      return yield* $(
-        new UploadThingError({
-          code: "MISSING_ENV",
-          message: "Invalid API key. API keys must start with 'sk_'.",
-          cause: msg,
-        }),
-      );
+      yield* Effect.logError(msg);
+      return yield* new UploadThingError({
+        code: "MISSING_ENV",
+        message: "Invalid API key. API keys must start with 'sk_'.",
+        cause: msg,
+      });
     }
 
     if (utFrontendPackage && typeof utFrontendPackage !== "string") {
       const msg = `Expected x-uploadthing-package to be of type 'string', got '${typeof utFrontendPackage}'`;
-      yield* $(Effect.logError(msg));
-      return yield* $(
-        new UploadThingError({
-          code: "BAD_REQUEST",
-          message:
-            "`x-uploadthing-package` must be a string. eg. '@uploadthing/react'",
-          cause: msg,
-        }),
-      );
+      yield* Effect.logError(msg);
+      return yield* new UploadThingError({
+        code: "BAD_REQUEST",
+        message:
+          "`x-uploadthing-package` must be a string. eg. '@uploadthing/react'",
+        cause: msg,
+      });
     }
 
     const uploadable = opts.opts.router[slug];
     if (!uploadable) {
       const msg = `No file route found for slug ${slug}`;
-      yield* $(Effect.logError(msg));
-      return yield* $(
-        new UploadThingError({
-          code: "NOT_FOUND",
-          message: msg,
-        }),
-      );
+      yield* Effect.logError(msg);
+      return yield* new UploadThingError({
+        code: "NOT_FOUND",
+        message: msg,
+      });
     }
 
     if (actionType && !isActionType(actionType)) {
       const msg = `Expected ${VALID_ACTION_TYPES.map((x) => `"${x}"`)
         .join(", ")
         .replace(/,(?!.*,)/, " or")} but got "${actionType}"`;
-      yield* $(Effect.logError("Invalid action type", msg));
-      return yield* $(
-        new UploadThingError({
-          code: "BAD_REQUEST",
-          cause: `Invalid action type ${actionType}`,
-          message: msg,
-        }),
-      );
+      yield* Effect.logError("Invalid action type", msg);
+      return yield* new UploadThingError({
+        code: "BAD_REQUEST",
+        cause: `Invalid action type ${actionType}`,
+        message: msg,
+      });
     }
 
     if (uploadthingHook && !isUploadThingHook(uploadthingHook)) {
       const msg = `Expected ${VALID_UT_HOOKS.map((x) => `"${x}"`)
         .join(", ")
         .replace(/,(?!.*,)/, " or")} but got "${uploadthingHook}"`;
-      yield* $(Effect.logError("Invalid uploadthing hook", msg));
-      return yield* $(
-        new UploadThingError({
-          code: "BAD_REQUEST",
-          cause: `Invalid uploadthing hook ${uploadthingHook}`,
-          message: msg,
-        }),
-      );
+      yield* Effect.logError("Invalid uploadthing hook", msg);
+      return yield* new UploadThingError({
+        code: "BAD_REQUEST",
+        cause: `Invalid uploadthing hook ${uploadthingHook}`,
+        message: msg,
+      });
     }
 
     if ((!actionType && !uploadthingHook) || (actionType && uploadthingHook)) {
       const msg = `Exactly one of 'actionType' or 'uploadthing-hook' must be provided`;
-      yield* $(Effect.logError(msg));
-      return yield* $(
-        new UploadThingError({
-          code: "BAD_REQUEST",
-          message: msg,
-        }),
-      );
+      yield* Effect.logError(msg);
+      return yield* new UploadThingError({
+        code: "BAD_REQUEST",
+        message: msg,
+      });
     }
 
-    yield* $(
-      Effect.logDebug("All request input is valid", {
-        slug,
-        actionType,
-        uploadthingHook,
-      }),
-    );
+    yield* Effect.logDebug("All request input is valid", {
+      slug,
+      actionType,
+      uploadthingHook,
+    });
 
     // FIXME: This should probably provide the full context at once instead of
     // partially in the `runRequestHandlerAsync` and partially in here...
     // Ref: https://discord.com/channels/@me/1201977154577891369/1207441839972548669
-    const contextValue = yield* $(fetchContext);
+    const contextValue = yield* fetchContext;
     contextValue.baseHeaders["x-uploadthing-api-key"] = apiKey;
     contextValue.baseHeaders["x-uploadthing-fe-package"] = utFrontendPackage;
     contextValue.baseHeaders["x-uploadthing-be-adapter"] = opts.adapter;

--- a/packages/uploadthing/src/next-legacy.ts
+++ b/packages/uploadthing/src/next-legacy.ts
@@ -13,7 +13,6 @@ import {
   runRequestHandlerAsync,
 } from "./internal/handler";
 import { incompatibleNodeGuard } from "./internal/incompat-node-guard";
-import { initLogger } from "./internal/logger";
 import { toWebRequest } from "./internal/to-web-request";
 import type { FileRouter, RouteHandlerOptions } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
@@ -35,7 +34,6 @@ export const createUploadthing = <TErrorShape extends Json>(
 export const createRouteHandler = <TRouter extends FileRouter>(
   opts: RouteHandlerOptions<TRouter>,
 ) => {
-  initLogger(opts.config?.logLevel);
   incompatibleNodeGuard();
 
   const requestHandler = buildRequestHandler<TRouter, MiddlewareArgs>(

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -22,7 +22,7 @@ import { UPLOADTHING_VERSION } from "../internal/constants";
 import { getApiKeyOrThrow } from "../internal/get-api-key";
 import { incompatibleNodeGuard } from "../internal/incompat-node-guard";
 import type { LogLevel } from "../internal/logger";
-import { withLogger } from "../internal/logger";
+import { ConsolaLogger, withMinimalLogLevel } from "../internal/logger";
 import type {
   ACLUpdateOptions,
   DeleteFilesOptions,
@@ -112,7 +112,8 @@ export class UTApi {
     program: Effect.Effect<A, E, FetchContextTag>,
   ) =>
     program.pipe(
-      Effect.provide(withLogger(this.logLevel)),
+      withMinimalLogLevel(this.logLevel),
+      Effect.provide(ConsolaLogger),
       Effect.provide(
         Layer.succeed(fetchContext, {
           fetch: this.fetch,

--- a/packages/uploadthing/src/sdk/utils.ts
+++ b/packages/uploadthing/src/sdk/utils.ts
@@ -86,7 +86,7 @@ export const downloadFiles = (
   Effect.forEach(
     urls,
     (_url, idx) =>
-      Effect.gen(function* ($) {
+      Effect.gen(function* () {
         let url = isObject(_url) ? _url.url : _url;
         if (typeof url === "string") {
           // since dataurls will result in name being too long, tell the user
@@ -109,7 +109,7 @@ export const downloadFiles = (
           customId = undefined,
         } = isObject(_url) ? _url : {};
 
-        const response = yield* $(fetchEff(url));
+        const response = yield* fetchEff(url);
         if (!response.ok) {
           downloadErrors[idx] = UploadThingError.toObject(
             new UploadThingError({
@@ -121,8 +121,7 @@ export const downloadFiles = (
           return undefined;
         }
 
-        return yield* $(
-          Effect.promise(() => response.blob()),
+        return yield* Effect.promise(() => response.blob()).pipe(
           Effect.andThen((blob) => new UTFile([blob], name, { customId })),
         );
       }),
@@ -130,7 +129,7 @@ export const downloadFiles = (
   );
 
 const getPresignedUrls = (input: UploadFilesInternalOptions) =>
-  Effect.gen(function* ($) {
+  Effect.gen(function* () {
     const { files, metadata, contentDisposition, acl } = input;
 
     const fileData = files.map((file) => ({
@@ -139,14 +138,16 @@ const getPresignedUrls = (input: UploadFilesInternalOptions) =>
       size: file.size,
       ...("customId" in file ? { customId: file.customId } : {}),
     }));
-    yield* $(Effect.logDebug("Getting presigned URLs for files", fileData));
+    yield* Effect.logDebug("Getting presigned URLs for files", fileData);
 
     const responseSchema = S.Struct({
       data: PresignedURLResponseSchema,
     });
 
-    const presigneds = yield* $(
-      fetchEffJson(generateUploadThingURL("/api/uploadFiles"), responseSchema, {
+    const presigneds = yield* fetchEffJson(
+      generateUploadThingURL("/api/uploadFiles"),
+      responseSchema,
+      {
         method: "POST",
         cache: "no-store",
         body: JSON.stringify({
@@ -156,11 +157,12 @@ const getPresignedUrls = (input: UploadFilesInternalOptions) =>
           acl,
         }),
         headers: { "Content-Type": "application/json" },
-      }),
+      },
+    ).pipe(
       Effect.catchTag("ParseError", (e) => Effect.die(e)),
       Effect.catchTag("FetchError", (e) => Effect.die(e)),
     );
-    yield* $(Effect.logDebug("Got presigned URLs:", presigneds.data));
+    yield* Effect.logDebug("Got presigned URLs:", presigneds.data);
 
     return files.map((file, i) => ({
       file,
@@ -171,20 +173,19 @@ const getPresignedUrls = (input: UploadFilesInternalOptions) =>
 const uploadFile = (
   input: Effect.Effect.Success<ReturnType<typeof getPresignedUrls>>[number],
 ) =>
-  Effect.gen(function* ($) {
+  Effect.gen(function* () {
     const { file, presigned } = input;
 
     if ("urls" in presigned) {
-      yield* $(uploadMultipart(file, presigned));
+      yield* uploadMultipart(file, presigned);
     } else {
-      yield* $(uploadPresignedPost(file, presigned));
+      yield* uploadPresignedPost(file, presigned);
     }
 
-    yield* $(
-      fetchEffJson(
-        generateUploadThingURL(`/api/pollUpload/${presigned.key}`),
-        PollUploadResponseSchema,
-      ),
+    yield* fetchEffJson(
+      generateUploadThingURL(`/api/pollUpload/${presigned.key}`),
+      PollUploadResponseSchema,
+    ).pipe(
       Effect.tap(Effect.logDebug("Polled upload", presigned.key)),
       Effect.andThen((res) =>
         res.status === "done"

--- a/packages/uploadthing/src/sdk/utils.ts
+++ b/packages/uploadthing/src/sdk/utils.ts
@@ -20,7 +20,6 @@ import type {
   TimeShort,
 } from "@uploadthing/shared";
 
-import { logger } from "../internal/logger";
 import { uploadMultipart } from "../internal/multi-part.server";
 import { uploadPresignedPost } from "../internal/presigned-post.server";
 import {
@@ -140,7 +139,7 @@ const getPresignedUrls = (input: UploadFilesInternalOptions) =>
       size: file.size,
       ...("customId" in file ? { customId: file.customId } : {}),
     }));
-    logger.debug("Getting presigned URLs for files", fileData);
+    yield* $(Effect.logDebug("Getting presigned URLs for files", fileData));
 
     const responseSchema = S.Struct({
       data: PresignedURLResponseSchema,
@@ -161,7 +160,7 @@ const getPresignedUrls = (input: UploadFilesInternalOptions) =>
       Effect.catchTag("ParseError", (e) => Effect.die(e)),
       Effect.catchTag("FetchError", (e) => Effect.die(e)),
     );
-    logger.debug("Got presigned URLs:", presigneds.data);
+    yield* $(Effect.logDebug("Got presigned URLs:", presigneds.data));
 
     return files.map((file, i) => ({
       file,
@@ -186,7 +185,7 @@ const uploadFile = (
         generateUploadThingURL(`/api/pollUpload/${presigned.key}`),
         PollUploadResponseSchema,
       ),
-      Effect.tap(() => logger.debug("Polled upload", presigned.key)),
+      Effect.tap(Effect.logDebug("Polled upload", presigned.key)),
       Effect.andThen((res) =>
         res.status === "done"
           ? Effect.succeed(undefined)

--- a/packages/uploadthing/src/server.ts
+++ b/packages/uploadthing/src/server.ts
@@ -9,7 +9,6 @@ import {
   runRequestHandlerAsync,
 } from "./internal/handler";
 import { incompatibleNodeGuard } from "./internal/incompat-node-guard";
-import { initLogger } from "./internal/logger";
 import type { FileRouter, RouteHandlerOptions } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
@@ -37,7 +36,6 @@ export const INTERNAL_DO_NOT_USE_createRouteHandlerCore = <
   opts: RouteHandlerOptions<TRouter>,
   adapter: string,
 ) => {
-  initLogger(opts.config?.logLevel);
   incompatibleNodeGuard();
 
   const requestHandler = buildRequestHandler<TRouter, MiddlewareArgs>(

--- a/packages/uploadthing/test/__test-helpers.ts
+++ b/packages/uploadthing/test/__test-helpers.ts
@@ -279,6 +279,13 @@ export const useBadS3 = () =>
     }),
   );
 
+export const useBadUTApi = () =>
+  msw.use(
+    http.post("https://uploadthing.com/api/*", async () => {
+      return HttpResponse.json({ error: "Not found" }, { status: 404 });
+    }),
+  );
+
 /**
  * Call this in your test to make the S3 requests fail a couple times before succeeding
  */

--- a/packages/uploadthing/test/request-handler.test.ts
+++ b/packages/uploadthing/test/request-handler.test.ts
@@ -12,6 +12,7 @@ import {
   middlewareMock,
   requestSpy,
   uploadCompleteMock,
+  useBadUTApi,
 } from "./__test-helpers";
 
 const f = createUploadthing({
@@ -69,8 +70,8 @@ const handlers = createRouteHandler({
   router,
   config: {
     uploadthingSecret: "sk_live_test123",
-    // @ts-expect-error - annoying to see error logs
-    logLevel: "silent",
+    logLevel: "debug",
+    // logLevel: "silent",
   },
 });
 
@@ -428,5 +429,31 @@ describe(".onUploadComplete()", () => {
       message: "Invalid signature",
     });
     expect(uploadCompleteMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("bad request handling", () => {
+  it("throws a more descriptive error instead of ParseError for bad request", async ({
+    db,
+  }) => {
+    useBadUTApi();
+
+    const res = await handlers.POST(
+      new Request(createApiUrl("imageUploader", "upload"), {
+        method: "POST",
+        headers: baseHeaders,
+        body: JSON.stringify({
+          files: [{ name: "foo.png", size: 48, type: "image/png" }],
+        }),
+      }),
+    );
+
+    console.log(res.status, await res.json());
+    expect(res.status).toBe(400);
+
+    // await expect(res.json()).resolves.toEqual({
+    //   message: "Invalid request",
+    //   cause: "Error: Not found",
+    // });
   });
 });

--- a/packages/uploadthing/test/request-handler.test.ts
+++ b/packages/uploadthing/test/request-handler.test.ts
@@ -18,6 +18,7 @@ import {
 const f = createUploadthing({
   errorFormatter: (e) => ({
     message: e.message,
+    data: e.data,
     cause:
       e.cause instanceof z.ZodError
         ? e.cause.flatten()
@@ -450,7 +451,8 @@ describe("bad request handling", () => {
     expect(res.status).toBe(500);
     await expect(res.json()).resolves.toEqual({
       message:
-        'Request to https://uploadthing.com/api/prepareUpload failed with status 404: {"error":"Not found"}',
+        "Request to https://uploadthing.com/api/prepareUpload failed with status 404",
+      data: { error: "Not found" },
       cause: "FetchError",
     });
   });

--- a/packages/uploadthing/test/request-handler.test.ts
+++ b/packages/uploadthing/test/request-handler.test.ts
@@ -71,8 +71,8 @@ const handlers = createRouteHandler({
   router,
   config: {
     uploadthingSecret: "sk_live_test123",
-    logLevel: "debug",
-    // logLevel: "silent",
+    // @ts-expect-error - annoying to see error logs
+    logLevel: "silent",
   },
 });
 

--- a/packages/uploadthing/test/request-handler.test.ts
+++ b/packages/uploadthing/test/request-handler.test.ts
@@ -447,13 +447,11 @@ describe("bad request handling", () => {
         }),
       }),
     );
-
-    console.log(res.status, await res.json());
-    expect(res.status).toBe(400);
-
-    // await expect(res.json()).resolves.toEqual({
-    //   message: "Invalid request",
-    //   cause: "Error: Not found",
-    // });
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toEqual({
+      message:
+        'Request to https://uploadthing.com/api/prepareUpload failed with status 404: {"error":"Not found"}',
+      cause: "FetchError",
+    });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -928,14 +928,14 @@ importers:
   packages/shared:
     dependencies:
       '@effect/schema':
-        specifier: ^0.66.9
-        version: 0.66.9(effect@3.0.6)(fast-check@3.17.2)
+        specifier: ^0.66.10
+        version: 0.66.10(effect@3.0.7)(fast-check@3.18.0)
       effect:
-        specifier: ^3.0.6
-        version: 3.0.6
+        specifier: ^3.0.7
+        version: 3.0.7
       fast-check:
-        specifier: ^3.17.2
-        version: 3.17.2
+        specifier: ^3.18.0
+        version: 3.18.0
       std-env:
         specifier: ^3.7.0
         version: 3.7.0
@@ -1069,8 +1069,8 @@ importers:
   packages/uploadthing:
     dependencies:
       '@effect/schema':
-        specifier: ^0.66.9
-        version: 0.66.9(effect@3.0.6)(fast-check@3.17.2)
+        specifier: ^0.66.10
+        version: 0.66.10(effect@3.0.7)(fast-check@3.18.0)
       '@uploadthing/mime-types':
         specifier: workspace:*
         version: link:../mime-types
@@ -1081,11 +1081,11 @@ importers:
         specifier: ^3.2.3
         version: 3.2.3
       effect:
-        specifier: ^3.0.6
-        version: 3.0.6
+        specifier: ^3.0.7
+        version: 3.0.7
       fast-check:
-        specifier: ^3.17.2
-        version: 3.17.2
+        specifier: ^3.18.0
+        version: 3.18.0
       std-env:
         specifier: ^3.7.0
         version: 3.7.0
@@ -2584,14 +2584,14 @@ packages:
       which: 4.0.0
     dev: false
 
-  /@effect/schema@0.66.9(effect@3.0.6)(fast-check@3.17.2):
-    resolution: {integrity: sha512-52sB+G4GqbUur8tDmiQnwcrqTU2XeZQiVr78SLOvsK3KwLcqHRxQpiHso7zVUbpXHEH/yTa3shbYTz0JNmD9Pg==}
+  /@effect/schema@0.66.10(effect@3.0.7)(fast-check@3.18.0):
+    resolution: {integrity: sha512-5lZTPRbncsqAhqQx3cCd3emR/q/CtvFFJZNvwNF66sUD1SjbMsLPbRkEzIaG9k2X8M71YD9GDbUE0lRWG1J+mA==}
     peerDependencies:
-      effect: ^3.0.6
+      effect: ^3.0.7
       fast-check: ^3.13.2
     dependencies:
-      effect: 3.0.6
-      fast-check: 3.17.2
+      effect: 3.0.7
+      fast-check: 3.18.0
     dev: false
 
   /@elysiajs/cors@0.8.0(elysia@0.8.17):
@@ -10749,8 +10749,8 @@ packages:
   /ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  /effect@3.0.6:
-    resolution: {integrity: sha512-mm83ZhJnSH1BRnnWnVxk0w+gMN1WPaxq2LEoxATv2esCtd8bSq9BFLuWysWWmnEO3Q8wkGIcjmeIxZymHo2qZw==}
+  /effect@3.0.7:
+    resolution: {integrity: sha512-VlEpWUc3IBc7k9NUdsdbh7cnGFNIdMpIoUFbbiVkt304d40pSr6Zadnr5Tk8m1cniqOLo4SXSZLw0M6f7N17Hg==}
     dev: false
 
   /electron-to-chromium@1.4.746:
@@ -11872,8 +11872,8 @@ packages:
     engines: {node: '>=18'}
     dev: true
 
-  /fast-check@3.17.2:
-    resolution: {integrity: sha512-+3DPTxtxABLgmmVpYxrash3DHoq0cMa1jjLYNp3qqokKKhqVEaS4lbnaDKqWU5Dd6C2pEudPPBAEEQ9nUou9OQ==}
+  /fast-check@3.18.0:
+    resolution: {integrity: sha512-/951xaT0kA40w0GXRsZXEwSTE7LugjZtSA/8vPgFkiPQ8wNp8tRvqWuNDHBgLxJYXtsK11e/7Q4ObkKW5BdTFQ==}
     engines: {node: '>=8.0.0'}
     dependencies:
       pure-rand: 6.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -928,11 +928,11 @@ importers:
   packages/shared:
     dependencies:
       '@effect/schema':
-        specifier: ^0.66.0
-        version: 0.66.0(effect@3.0.0)(fast-check@3.17.2)
+        specifier: ^0.66.9
+        version: 0.66.9(effect@3.0.6)(fast-check@3.17.2)
       effect:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.6
+        version: 3.0.6
       fast-check:
         specifier: ^3.17.2
         version: 3.17.2
@@ -1069,8 +1069,8 @@ importers:
   packages/uploadthing:
     dependencies:
       '@effect/schema':
-        specifier: ^0.66.0
-        version: 0.66.0(effect@3.0.0)(fast-check@3.17.2)
+        specifier: ^0.66.9
+        version: 0.66.9(effect@3.0.6)(fast-check@3.17.2)
       '@uploadthing/mime-types':
         specifier: workspace:*
         version: link:../mime-types
@@ -1081,8 +1081,11 @@ importers:
         specifier: ^3.2.3
         version: 3.2.3
       effect:
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.6
+        version: 3.0.6
+      fast-check:
+        specifier: ^3.17.2
+        version: 3.17.2
       std-env:
         specifier: ^3.7.0
         version: 3.7.0
@@ -2581,13 +2584,13 @@ packages:
       which: 4.0.0
     dev: false
 
-  /@effect/schema@0.66.0(effect@3.0.0)(fast-check@3.17.2):
-    resolution: {integrity: sha512-wbmA4vQ0OswEwBt+vWn4oEgw2QdEDchPiNNisPCHvSy5e5qH0usfppJ3fNX9cwrCz6jEQTCE42Q/7Was2BhVHg==}
+  /@effect/schema@0.66.9(effect@3.0.6)(fast-check@3.17.2):
+    resolution: {integrity: sha512-52sB+G4GqbUur8tDmiQnwcrqTU2XeZQiVr78SLOvsK3KwLcqHRxQpiHso7zVUbpXHEH/yTa3shbYTz0JNmD9Pg==}
     peerDependencies:
-      effect: ^3.0.0
+      effect: ^3.0.6
       fast-check: ^3.13.2
     dependencies:
-      effect: 3.0.0
+      effect: 3.0.6
       fast-check: 3.17.2
     dev: false
 
@@ -10746,8 +10749,8 @@ packages:
   /ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  /effect@3.0.0:
-    resolution: {integrity: sha512-8yVxuahojpD8Y6ynrvIlSWD2xsea/PyGnjA4V5c7v0fOMJafgsKUNUHErBAr6YoPikmtOfR9zqNWRd9u5QaWEQ==}
+  /effect@3.0.6:
+    resolution: {integrity: sha512-mm83ZhJnSH1BRnnWnVxk0w+gMN1WPaxq2LEoxATv2esCtd8bSq9BFLuWysWWmnEO3Q8wkGIcjmeIxZymHo2qZw==}
     dev: false
 
   /electron-to-chromium@1.4.746:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -929,10 +929,13 @@ importers:
     dependencies:
       '@effect/schema':
         specifier: ^0.66.0
-        version: 0.66.0(effect@3.0.0)(fast-check@3.17.1)
+        version: 0.66.0(effect@3.0.0)(fast-check@3.17.2)
       effect:
         specifier: ^3.0.0
         version: 3.0.0
+      fast-check:
+        specifier: ^3.17.2
+        version: 3.17.2
       std-env:
         specifier: ^3.7.0
         version: 3.7.0
@@ -1067,7 +1070,7 @@ importers:
     dependencies:
       '@effect/schema':
         specifier: ^0.66.0
-        version: 0.66.0(effect@3.0.0)(fast-check@3.17.1)
+        version: 0.66.0(effect@3.0.0)(fast-check@3.17.2)
       '@uploadthing/mime-types':
         specifier: workspace:*
         version: link:../mime-types
@@ -2578,14 +2581,14 @@ packages:
       which: 4.0.0
     dev: false
 
-  /@effect/schema@0.66.0(effect@3.0.0)(fast-check@3.17.1):
+  /@effect/schema@0.66.0(effect@3.0.0)(fast-check@3.17.2):
     resolution: {integrity: sha512-wbmA4vQ0OswEwBt+vWn4oEgw2QdEDchPiNNisPCHvSy5e5qH0usfppJ3fNX9cwrCz6jEQTCE42Q/7Was2BhVHg==}
     peerDependencies:
       effect: ^3.0.0
       fast-check: ^3.13.2
     dependencies:
       effect: 3.0.0
-      fast-check: 3.17.1
+      fast-check: 3.17.2
     dev: false
 
   /@elysiajs/cors@0.8.0(elysia@0.8.17):
@@ -11866,8 +11869,8 @@ packages:
     engines: {node: '>=18'}
     dev: true
 
-  /fast-check@3.17.1:
-    resolution: {integrity: sha512-jIKXJVe6ZO0SpwEgVtEVujTf8TwjI9wMXFJCjsDHUB3RroUbXBgF4kOSz3A7MW0UR26aqsoB8i9O2mjtjERAiA==}
+  /fast-check@3.17.2:
+    resolution: {integrity: sha512-+3DPTxtxABLgmmVpYxrash3DHoq0cMa1jjLYNp3qqokKKhqVEaS4lbnaDKqWU5Dd6C2pEudPPBAEEQ9nUou9OQ==}
     engines: {node: '>=8.0.0'}
     dependencies:
       pure-rand: 6.1.0


### PR DESCRIPTION
this causes some confusion errors since if the requests failed the schema wont match and it's better to show an error with the response message

updates effect, we can now drop the $-adapter thing to make yielding much nicer 👍🏼 