### PR TITLE
fix: squash fiberfailures, introduce "bad request error"

### DIFF
--- a/.changeset/flat-zoos-compete.md
+++ b/.changeset/flat-zoos-compete.md
@@ -1,0 +1,6 @@
+---
+"uploadthing": patch
+"@uploadthing/shared": patch
+---
+
+fix: catch FiberFailure's and squash them to the original error

--- a/packages/shared/src/error.ts
+++ b/packages/shared/src/error.ts
@@ -104,6 +104,15 @@ export class UploadThingError<
   }
 }
 
+export function getErrorTypeFromStatusCode(statusCode: number): ErrorCode {
+  for (const [code, status] of Object.entries(ERROR_CODES)) {
+    if (status === statusCode) {
+      return code as ErrorCode;
+    }
+  }
+  return "INTERNAL_SERVER_ERROR";
+}
+
 export function getStatusCodeFromError(error: UploadThingError<any>) {
   return ERROR_CODES[error.code] ?? 500;
 }

--- a/packages/shared/src/tagged-errors.ts
+++ b/packages/shared/src/tagged-errors.ts
@@ -76,7 +76,6 @@ export class BadRequestError<T = unknown> extends TaggedError(
   getMessage() {
     if (isObject(this.error)) {
       if (typeof this.error.message === "string") return this.error.message;
-      if (typeof this.error.error === "string") return this.error.error;
     }
     return this.message;
   }

--- a/packages/shared/src/tagged-errors.ts
+++ b/packages/shared/src/tagged-errors.ts
@@ -1,5 +1,7 @@
 import { TaggedError } from "effect/Data";
 
+import { isObject } from "./utils";
+
 export class InvalidRouteConfigError extends TaggedError("InvalidRouteConfig")<{
   reason: string;
 }> {
@@ -70,4 +72,12 @@ export class BadRequestError<T = unknown> extends TaggedError(
   readonly input: RequestInfo | URL;
   readonly status: number;
   readonly error: T;
-}> {}
+}> {
+  getMessage() {
+    if (isObject(this.error)) {
+      if (typeof this.error.message === "string") return this.error.message;
+      if (typeof this.error.error === "string") return this.error.error;
+    }
+    return this.message;
+  }
+}

--- a/packages/shared/src/tagged-errors.ts
+++ b/packages/shared/src/tagged-errors.ts
@@ -58,8 +58,16 @@ export const getRequestUrl = (input: RequestInfo | URL) => {
   return input.toString();
 };
 
-export class FetchError<T = unknown> extends TaggedError("FetchError")<{
+export class FetchError extends TaggedError("FetchError")<{
   readonly input: RequestInfo | URL;
   readonly error: unknown;
-  readonly data?: T;
+}> {}
+
+export class BadRequestError<T = unknown> extends TaggedError(
+  "BadRequestError",
+)<{
+  readonly message: string;
+  readonly input: RequestInfo | URL;
+  readonly status: number;
+  readonly error: T;
 }> {}

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -107,12 +107,21 @@ export const buildRequestHandler =
         parseAndValidateRequest(input, opts, adapter),
       ),
       Effect.catchTags({
+        BadRequestError: (e) =>
+          Effect.fail(
+            new UploadThingError({
+              code: "INTERNAL_SERVER_ERROR",
+              message: e.getMessage(),
+              cause: e,
+              data: e.error as never,
+            }),
+          ),
         FetchError: (e) =>
           new UploadThingError({
             code: "INTERNAL_SERVER_ERROR",
             message: typeof e.error === "string" ? e.error : e.message,
             cause: e,
-            data: e.data as never,
+            data: e.error as never,
           }),
         ParseError: (e) =>
           new UploadThingError({

--- a/packages/uploadthing/src/internal/ut-reporter.ts
+++ b/packages/uploadthing/src/internal/ut-reporter.ts
@@ -2,7 +2,12 @@ import type * as S from "@effect/schema/Schema";
 import * as Effect from "effect/Effect";
 
 import type { FetchContext, MaybePromise } from "@uploadthing/shared";
-import { fetchEffJson, UploadThingError } from "@uploadthing/shared";
+import {
+  fetchEffJson,
+  getErrorTypeFromStatusCode,
+  isObject,
+  UploadThingError,
+} from "@uploadthing/shared";
 
 import { UPLOADTHING_VERSION } from "./constants";
 import { maybeParseResponseXML } from "./s3-error-parser";
@@ -68,6 +73,18 @@ export const createUTReporter =
           ...headers,
         },
       }).pipe(
+        Effect.catchTag("BadRequestError", (e) =>
+          Effect.fail(
+            new UploadThingError({
+              code: getErrorTypeFromStatusCode(e.status),
+              message:
+                isObject(e.error) && typeof e.error.message === "string"
+                  ? e.error.message
+                  : e.message,
+              cause: e.error,
+            }),
+          ),
+        ),
         Effect.catchTag("FetchError", (e) =>
           Effect.fail(
             new UploadThingError({

--- a/packages/uploadthing/src/internal/ut-reporter.ts
+++ b/packages/uploadthing/src/internal/ut-reporter.ts
@@ -5,7 +5,6 @@ import type { FetchContext, MaybePromise } from "@uploadthing/shared";
 import {
   fetchEffJson,
   getErrorTypeFromStatusCode,
-  isObject,
   UploadThingError,
 } from "@uploadthing/shared";
 
@@ -77,10 +76,7 @@ export const createUTReporter =
           Effect.fail(
             new UploadThingError({
               code: getErrorTypeFromStatusCode(e.status),
-              message:
-                isObject(e.error) && typeof e.error.message === "string"
-                  ? e.error.message
-                  : e.message,
+              message: e.getMessage(),
               cause: e.error,
             }),
           ),

--- a/packages/uploadthing/test/client.test.ts
+++ b/packages/uploadthing/test/client.test.ts
@@ -369,17 +369,11 @@ describe("uploadFiles", () => {
   it("handles invalid file type errors", async ({ db, task }) => {
     const { uploadFiles, close } = setupUTServer(task);
 
-    const tooBigFile = new File(
-      [new ArrayBuffer(10 * 1024 * 1024)],
-      "foo.png",
-      {
-        type: "image/png",
-      },
-    );
+    const file = new File(["foo"], "foo.png", { type: "image/png" });
 
     await expect(
       uploadFiles("foo", {
-        files: [tooBigFile],
+        files: [file],
         skipPolling: true,
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(

--- a/packages/uploadthing/test/client.test.ts
+++ b/packages/uploadthing/test/client.test.ts
@@ -285,7 +285,7 @@ describe("uploadFiles", () => {
         skipPolling: true,
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[(FiberFailure) UploadThingError: Failed to upload file foo.txt to S3]`,
+      `[UploadThingError: Failed to upload file foo.txt to S3]`,
     );
 
     expect(requestsToDomain("amazonaws.com")).toHaveLength(1);
@@ -322,7 +322,7 @@ describe("uploadFiles", () => {
         skipPolling: true,
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `[(FiberFailure) UploadThingError: Failed to upload file foo.txt to S3]`,
+      `[UploadThingError: Failed to upload file foo.txt to S3]`,
     );
 
     expect(requestsToDomain("amazonaws.com")).toHaveLength(7);
@@ -343,5 +343,47 @@ describe("uploadFiles", () => {
     );
 
     close();
+  });
+
+  it("handles too big file size errors", async ({ db, task }) => {
+    const { uploadFiles, close } = setupUTServer(task);
+
+    const tooBigFile = new File(
+      [new ArrayBuffer(20 * 1024 * 1024)],
+      "foo.txt",
+      {
+        type: "text/plain",
+      },
+    );
+
+    await expect(
+      uploadFiles("foo", {
+        files: [tooBigFile],
+        skipPolling: true,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[UploadThingError: Invalid config: FileSizeMismatch]`,
+    );
+  });
+
+  it("handles invalid file type errors", async ({ db, task }) => {
+    const { uploadFiles, close } = setupUTServer(task);
+
+    const tooBigFile = new File(
+      [new ArrayBuffer(10 * 1024 * 1024)],
+      "foo.png",
+      {
+        type: "image/png",
+      },
+    );
+
+    await expect(
+      uploadFiles("foo", {
+        files: [tooBigFile],
+        skipPolling: true,
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[UploadThingError: Invalid config: InvalidFileType]`,
+    );
   });
 });

--- a/packages/uploadthing/test/request-handler.test.ts
+++ b/packages/uploadthing/test/request-handler.test.ts
@@ -453,7 +453,8 @@ describe("bad request handling", () => {
       message:
         "Request to https://uploadthing.com/api/prepareUpload failed with status 404",
       data: { error: "Not found" },
-      cause: "FetchError",
+      cause:
+        "BadRequestError: Request to https://uploadthing.com/api/prepareUpload failed with status 404",
     });
   });
 });


### PR DESCRIPTION
Closes #777 

- Squashes the FiberFailure to its original cause using `Cause.squash`
- Separates `FetchError` (where a part of the fetch failed) and `BadRequestError` for successful requests with "bad statuscode"