### PR TITLE
feat: added onDrop prop for UploadDropzone component

### DIFF
--- a/.changeset/fuzzy-toys-smell.md
+++ b/.changeset/fuzzy-toys-smell.md
@@ -1,0 +1,5 @@
+---
+"@uploadthing/react": minor
+---
+
+added onDrop prop for UploadDropzone component

--- a/docs/src/pages/api-reference/react.mdx
+++ b/docs/src/pages/api-reference/react.mdx
@@ -201,6 +201,10 @@ export const OurUploadDropzone = () => (
       // Do something once upload begins
       console.log("Uploading: ", name);
     }}
+    onDrop={(acceptedFiles) => {
+      // Do something with the accepted files
+      console.log("Accepted files: ", acceptedFiles);
+    }}
   />
 );
 ```
@@ -221,6 +225,7 @@ export const OurUploadDropzone = () => (
 | onBeforeUploadBegin    | `(files: File[]) => File[]`                          | No                      | Added in `v6.0` | callback function called before uploading starts. The files returned are the files that will be uploaded                    |
 | onUploadBegin          | function                                             | No                      | Added in `v5.4` | callback function for upload begin                                                                                          |
 | config                 | object                                               | No                      | Added in `v5.4` | object to pass additional configuration for dropzone                                                                        |
+| onDrop                 | (acceptedFiles: File[]) => void                      | No                      | Added in `v6.5` | Callback called when files are dropped or pasted.                                                                           |
 
 Config object
 

--- a/packages/react/src/components/dropzone.tsx
+++ b/packages/react/src/components/dropzone.tsx
@@ -66,6 +66,8 @@ export type UploadDropzoneProps<
    * @see https://docs.uploadthing.com/theming#content-customisation
    */
   content?: DropzoneContent;
+
+  onDrop?: (acceptedFiles: File[]) => void;
 };
 
 export function UploadDropzone<
@@ -137,6 +139,8 @@ export function UploadDropzone<
 
   const onDrop = useCallback(
     (acceptedFiles: File[]) => {
+      $props.onDrop?.(acceptedFiles);
+
       setFiles(acceptedFiles);
 
       // If mode is auto, start upload immediately
@@ -303,7 +307,7 @@ export function UploadDropzone<
           "relative mt-4 flex h-10 w-36 cursor-pointer items-center justify-center overflow-hidden rounded-md border-none text-base text-white after:transition-[width] after:duration-500 focus-within:ring-2 focus-within:ring-blue-600 focus-within:ring-offset-2",
           state === "readying" && "cursor-not-allowed bg-blue-400",
           state === "uploading" &&
-            `bg-blue-400 after:absolute after:left-0 after:h-full after:bg-blue-600 after:content-[''] ${progressWidths[uploadProgress]}`,
+          `bg-blue-400 after:absolute after:left-0 after:h-full after:bg-blue-600 after:content-[''] ${progressWidths[uploadProgress]}`,
           state === "ready" && "bg-blue-600",
           "disabled:pointer-events-none",
           styleFieldToClassName($props.appearance?.button, styleFieldArg),

--- a/packages/react/src/components/dropzone.tsx
+++ b/packages/react/src/components/dropzone.tsx
@@ -311,7 +311,7 @@ export function UploadDropzone<
           "relative mt-4 flex h-10 w-36 cursor-pointer items-center justify-center overflow-hidden rounded-md border-none text-base text-white after:transition-[width] after:duration-500 focus-within:ring-2 focus-within:ring-blue-600 focus-within:ring-offset-2",
           state === "readying" && "cursor-not-allowed bg-blue-400",
           state === "uploading" &&
-          `bg-blue-400 after:absolute after:left-0 after:h-full after:bg-blue-600 after:content-[''] ${progressWidths[uploadProgress]}`,
+            `bg-blue-400 after:absolute after:left-0 after:h-full after:bg-blue-600 after:content-[''] ${progressWidths[uploadProgress]}`,
           state === "ready" && "bg-blue-600",
           "disabled:pointer-events-none",
           styleFieldToClassName($props.appearance?.button, styleFieldArg),

--- a/packages/react/src/components/dropzone.tsx
+++ b/packages/react/src/components/dropzone.tsx
@@ -66,7 +66,11 @@ export type UploadDropzoneProps<
    * @see https://docs.uploadthing.com/theming#content-customisation
    */
   content?: DropzoneContent;
-
+  /**
+   * Callback called when files are dropped or pasted.
+   *
+   * @param acceptedFiles - The files that were accepted.
+   */
   onDrop?: (acceptedFiles: File[]) => void;
 };
 


### PR DESCRIPTION
Added a prop `onDrop` for the `<UploadDropzone />` component. Whenever the user selects or drops the file it will call the passed `onDrop` callback function.

Closes #805