### PR TITLE
fix: Node 20.13 compat

### DIFF
--- a/.changeset/tame-brooms-end.md
+++ b/.changeset/tame-brooms-end.md
@@ -1,0 +1,6 @@
+---
+"uploadthing": patch
+"@uploadthing/shared": patch
+---
+
+refactor header parsring to support breaking change in Node 20.13

--- a/.changeset/tame-brooms-end.md
+++ b/.changeset/tame-brooms-end.md
@@ -3,4 +3,4 @@
 "@uploadthing/shared": patch
 ---
 
-refactor header parsing to support breaking change in Node 20.13
+refactor header parsing to support breaking change in Node.js 20.13

--- a/.changeset/tame-brooms-end.md
+++ b/.changeset/tame-brooms-end.md
@@ -3,4 +3,4 @@
 "@uploadthing/shared": patch
 ---
 
-refactor header parsring to support breaking change in Node 20.13
+refactor header parsing to support breaking change in Node 20.13

--- a/packages/shared/src/effect.ts
+++ b/packages/shared/src/effect.ts
@@ -6,7 +6,6 @@ import * as Schedule from "effect/Schedule";
 
 import { BadRequestError, FetchError, InvalidJsonError } from "./tagged-errors";
 import type { FetchEsque, ResponseEsque } from "./types";
-import { filterObjectValues } from "./utils";
 
 export type FetchContextService = {
   fetch: FetchEsque;
@@ -34,17 +33,20 @@ export const fetchEff = (
   init?: RequestInit,
 ): Effect.Effect<ResponseWithURL, FetchError, FetchContext> =>
   Effect.flatMap(FetchContext, ({ fetch, baseHeaders }) => {
+    const headers = new Headers(init?.headers ?? {});
+    for (const [key, value] of Object.entries(baseHeaders)) {
+      if (typeof value === "string") headers.set(key, value);
+    }
+
     const reqInfo = {
       url: input.toString(),
       method: init?.method,
       body: init?.body,
-      headers: {
-        ...filterObjectValues(baseHeaders, (v): v is string => v != null),
-        ...init?.headers,
-      },
+      headers: Object.fromEntries(headers.entries()),
     };
+
     return Effect.tryPromise({
-      try: () => fetch(input, { ...init, headers: reqInfo.headers }),
+      try: () => fetch(input, { ...init, headers }),
       catch: (error) =>
         new FetchError({
           error:

--- a/packages/shared/src/effect.ts
+++ b/packages/shared/src/effect.ts
@@ -42,7 +42,7 @@ export const fetchEff = (
       url: input.toString(),
       method: init?.method,
       body: init?.body,
-      headers: Object.fromEntries(headers.entries()),
+      headers: Object.fromEntries(headers),
     };
 
     return Effect.tryPromise({

--- a/packages/shared/src/effect.ts
+++ b/packages/shared/src/effect.ts
@@ -33,7 +33,7 @@ export const fetchEff = (
   init?: RequestInit,
 ): Effect.Effect<ResponseWithURL, FetchError, FetchContext> =>
   Effect.flatMap(FetchContext, ({ fetch, baseHeaders }) => {
-    const headers = new Headers(init?.headers ?? {});
+    const headers = new Headers(init?.headers ?? []);
     for (const [key, value] of Object.entries(baseHeaders)) {
       if (typeof value === "string") headers.set(key, value);
     }

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -199,21 +199,6 @@ export function asArray<T>(val: T | T[]): T[] {
   return Array.isArray(val) ? val : [val];
 }
 
-/**
- * Filters an object's values based on a predicate
- * @example
- * filterObjectValues({ a: "a", b: null }, (v): v is string => v != null)
- * // ^? Record<string, string> { a: "a" }
- */
-export const filterObjectValues = <V, T extends Record<string, V>, D extends V>(
-  obj: T,
-  predicate: (val: V) => val is D,
-) => {
-  return Object.fromEntries(
-    Object.entries(obj).filter(([_, v]) => predicate(v)),
-  ) as Record<string, D>;
-};
-
 /** construct content-disposition header */
 export function contentDisposition(
   contentDisposition: ContentDisposition,

--- a/packages/uploadthing/src/internal/to-web-request.ts
+++ b/packages/uploadthing/src/internal/to-web-request.ts
@@ -120,7 +120,7 @@ export const toWebRequest = (
   const allowsBody = ["POST", "PUT", "PATCH"].includes(method);
 
   const headers = new Headers();
-  for (const [key, value] of Object.entries(req.headers ?? {})) {
+  for (const [key, value] of Object.entries(req.headers ?? [])) {
     if (typeof value === "string") headers.set(key, value);
     if (Array.isArray(value)) headers.set(key, value.join(","));
   }

--- a/packages/uploadthing/src/internal/to-web-request.ts
+++ b/packages/uploadthing/src/internal/to-web-request.ts
@@ -2,7 +2,7 @@ import { TaggedError } from "effect/Data";
 import * as Effect from "effect/Effect";
 import { process } from "std-env";
 
-import { filterObjectValues, UploadThingError } from "@uploadthing/shared";
+import { UploadThingError } from "@uploadthing/shared";
 
 type IncomingMessageLike = {
   method?: string | undefined;
@@ -119,16 +119,19 @@ export const toWebRequest = (
   const method = req.method ?? "GET";
   const allowsBody = ["POST", "PUT", "PATCH"].includes(method);
 
+  const headers = new Headers();
+  for (const [key, value] of Object.entries(req.headers ?? {})) {
+    if (typeof value === "string") headers.set(key, value);
+    if (Array.isArray(value)) headers.set(key, value.join(","));
+  }
+
   return parseURL(req).pipe(
     Effect.catchTag("InvalidURL", (e) => Effect.die(e)),
     Effect.andThen(
       (url) =>
         new Request(url, {
           method,
-          headers: filterObjectValues(
-            req.headers ?? {},
-            (v): v is string => typeof v === "string",
-          ),
+          headers,
           ...(allowsBody ? { body: bodyStr } : {}),
         }),
     ),

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -81,7 +81,7 @@ export class UTApi {
       }),
     );
 
-    const headers = new Headers([["Content-Type", "application/json"]]);
+    const headers = new Headers([["Content-Type", "application/jso"]]);
     for (const [key, value] of Object.entries(this.defaultHeaders)) {
       if (typeof value === "string") headers.set(key, value);
     }

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -81,7 +81,7 @@ export class UTApi {
       }),
     );
 
-    const headers = new Headers({ "Content-Type": "application/json" });
+    const headers = new Headers([["Content-Type", "application/json"]]);
     for (const [key, value] of Object.entries(this.defaultHeaders)) {
       if (typeof value === "string") headers.set(key, value);
     }

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -81,7 +81,7 @@ export class UTApi {
       }),
     );
 
-    const headers = new Headers([["Content-Type", "application/jso"]]);
+    const headers = new Headers([["Content-Type", "application/json"]]);
     for (const [key, value] of Object.entries(this.defaultHeaders)) {
       if (typeof value === "string") headers.set(key, value);
     }

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -12,7 +12,6 @@ import {
   asArray,
   FetchContext,
   fetchEff,
-  filterObjectValues,
   generateUploadThingURL,
   parseResponseJson,
   UploadThingError,
@@ -82,17 +81,16 @@ export class UTApi {
       }),
     );
 
+    const headers = new Headers({ "Content-Type": "application/json" });
+    for (const [key, value] of Object.entries(this.defaultHeaders)) {
+      if (typeof value === "string") headers.set(key, value);
+    }
+
     return fetchEff(url, {
       method: "POST",
       cache: "no-store",
       body: JSON.stringify(body),
-      headers: {
-        ...filterObjectValues(
-          this.defaultHeaders,
-          (v): v is string => typeof v === "string",
-        ),
-        "Content-Type": "application/json",
-      },
+      headers,
     }).pipe(
       Effect.andThen(parseResponseJson),
       Effect.andThen(S.decodeUnknown(responseSchema)),

--- a/packages/uploadthing/test/__test-helpers.ts
+++ b/packages/uploadthing/test/__test-helpers.ts
@@ -85,7 +85,7 @@ const mockPresigned = (file: {
 const callRequestSpy = async (request: StrictRequest<any>) =>
   requestSpy(new URL(request.url).toString(), {
     method: request.method,
-    headers: Object.fromEntries(request.headers.entries()),
+    headers: Object.fromEntries(request.headers),
     body: await (() => {
       if (request.method === "GET") return null;
       const ct = request.headers.get("content-type");

--- a/tooling/gh-actions/setup/action.yml
+++ b/tooling/gh-actions/setup/action.yml
@@ -10,7 +10,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: 20.12
+        node-version: 20
         cache: pnpm
 
     - name: Setup bun


### PR DESCRIPTION
Seems like something in Node 20.13 is broken with the spread operator on `Headers`:

![image](https://github.com/pingdotgg/uploadthing/assets/51714798/e8d1c654-6c69-4c57-b6fd-99bef29c5cb3)

Symbols aren't enumerable so they shouldn't show up after a spread, yet they are...

Anyways, this refactor makes it compat with this new behavior, be it intentional or unintentional from their side...