### PR TITLE
docs: `Working with Files`

### DIFF
--- a/docs/src/pages/_meta.json
+++ b/docs/src/pages/_meta.json
@@ -12,6 +12,7 @@
     "type": "separator"
   },
   "backend-adapters": "Backend Adapters",
+  "working-with-files": "Working with Files",
   "auth-security": "Authentication & Security",
   "theming": "Theming",
   "regions-and-acl": "Regions and Access Controls",

--- a/docs/src/pages/working-with-files.mdx
+++ b/docs/src/pages/working-with-files.mdx
@@ -1,0 +1,67 @@
+import { Callout } from "nextra-theme-docs";
+
+# Working with Files
+
+After your files have been uploaded, you will most likely want to do something
+with them. This page shows how to work with your uploaded files.
+
+## Accessing Files
+
+<Callout type="warning">
+    Do not use the raw file URL from the storage provider, e.g. `https://bucket.s3.region.amazonaws.com/<FILE_KEY>`. We preserve the right to move objects between different storage providers and/or buckets, so this URL may not be valid over time.
+</Callout>
+
+There are multiple ways to access your files. The most generic way is to
+construct the URL from the `fileKey` you get back after the file has been
+uploaded:
+
+`https://utfs.io/f/<FILE_KEY>`
+
+This URL will always work and is the default URL returned by the API and from
+any SDK method. However, sometimes you may want a URL that's scoped to your
+application, for example when doing image optimizations and want to filter what
+URLs are allowed to be optimized on your server. For this, the following URL can
+be used:
+
+`https://utfs.io/a/<APP_ID>/<FILE_KEY>`
+
+By using this URL pattern, you have more granular control over what URLs are
+allowed to be optimized. Below is an example of how to setup image optimization
+allow filtering in Next.js:
+
+```js
+/** @type {import('next').NextConfig} */
+export default {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "utfs.io",
+        pathname: "/a/<APP_ID>/*",
+      },
+    ],
+  },
+};
+```
+
+<Callout type="info">
+    If you set a `customId` when uploading the file, you can also use `https://utfs.io/a/<APP_ID>/<CUSTOM_ID>`.
+</Callout>
+
+### Accessing Private Files
+
+If your files are protected with
+[access controls](/regions-and-acl#access-controls), you will need to request a
+short-lived presigned URL from the API to access the file. You can request one
+using [`UTApi.getSignedUrl`](/api-reference/ut-api#getsignedurl), or from the
+`/requestFileAccess` API endpoint (see
+[OpenAPI Specification](/api-reference/openapi-spec)).
+
+Presigned URL follows the same patterns as above, with additional query
+parameters to authenticate the request.
+
+## Other File Operations
+
+Please refer to our server SDK, [UTApi](/api-reference/ut-api) for more
+information on how to work with files. You can also access the API directly
+using the [OpenAPI Specification](/api-reference/openapi-spec).

--- a/docs/src/pages/working-with-files.mdx
+++ b/docs/src/pages/working-with-files.mdx
@@ -8,7 +8,7 @@ with them. This page shows how to work with your uploaded files.
 ## Accessing Files
 
 <Callout type="warning">
-    Do not use the raw file URL from the storage provider, e.g. `https://bucket.s3.region.amazonaws.com/<FILE_KEY>`. We preserve the right to move objects between different storage providers and/or buckets, so this URL may not be valid over time.
+    Do not use the raw file URL from the storage provider, e.g. `https://bucket.s3.region.amazonaws.com/<FILE_KEY>`. We reserve the right to move objects between different storage providers and/or buckets, so this URL is not guaranteed to remain valid.
 </Callout>
 
 There are multiple ways to access your files. The most generic way is to

--- a/docs/src/pages/working-with-files.mdx
+++ b/docs/src/pages/working-with-files.mdx
@@ -17,7 +17,7 @@ uploaded:
 
 `https://utfs.io/f/<FILE_KEY>`
 
-This URL will always work and is the default URL returned by the API and from
+This URL will always work for public files and is the default URL returned by the API and from
 any SDK method. However, sometimes you may want a URL that's scoped to your
 application, for example when doing image optimizations and want to filter what
 URLs are allowed to be optimized on your server. For this, the following URL can

--- a/docs/src/pages/working-with-files.mdx
+++ b/docs/src/pages/working-with-files.mdx
@@ -17,11 +17,11 @@ uploaded:
 
 `https://utfs.io/f/<FILE_KEY>`
 
-This URL will always work for public files and is the default URL returned by the API and from
-any SDK method. However, sometimes you may want a URL that's scoped to your
-application, for example when doing image optimizations and want to filter what
-URLs are allowed to be optimized on your server. For this, the following URL can
-be used:
+This URL will always work for public files and is the default URL returned by
+the API and from any SDK method. However, sometimes you may want a URL that's
+scoped to your application, for example when doing image optimizations and want
+to filter what URLs are allowed to be optimized on your server. For this, the
+following URL can be used:
 
 `https://utfs.io/a/<APP_ID>/<FILE_KEY>`
 


### PR DESCRIPTION
https://docs-uploadthing-git-working-with-files-pinglabs.vercel.app/working-with-files

I think we should have more generic text-based docs (examples and docs that gets straight to the code are great in their way, but I think we should also explain the concepts)

Pages I think could be useful

- `Uploading Files`
  - Explain what different ways there are
    - [ ] Client uploads
      - Setup an api route on your server using an adapter
      - Use `uploadthing/client.genUploader`, client-lib hooks etc
      - File never touches your server
    - [ ] Server uploads
      - Submit file to your server, then upload from there
    - _might be easier to explain once/if we merge prepareUpload and uploadFiles API endpoints and there's only one way to retrieve the presigned URLs_
    - Pre-upload operations? Where can you crop, compress images? Optimize files before upload? Verify file data? Blur hashes? Etc etc.
  - 
- Working with files
  - [x] This PR mostly goes over accessing your files
  - [ ] Streaming files?
  - [ ] Do some operation need more concept-type-docs than just a link to the UTApi method on the API reference page?
  - [ ] Replacing files? Right now we recommend just deleting the old file in `onUploadComplete`. Should this be documented? Or just implement the override functionality on infra side?

By having more concept type-thing, it'd be easier to make 3rd party SDKs for different langauges (Python, Go etc) and help adoption of non-JS devs to use UploadThing