### PR TITLE
fix: invalid schema

### DIFF
--- a/.changeset/twenty-parrots-knock.md
+++ b/.changeset/twenty-parrots-knock.md
@@ -1,0 +1,6 @@
+---
+"uploadthing": patch
+---
+
+fix: invalid response schema for `utapi.getUsageInfo`
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,8 @@ name: CI
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-
+  UPLOADTHING_TEST_SECRET: ${{ secrets.UPLOADTHING_TEST_SECRET }}
+  
 on:
   push:
     branches:

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -234,9 +234,12 @@ export class UTApi {
     guardServerOnly();
     const { keyType = this.defaultKeyType } = opts ?? {};
 
-    const responseSchema = S.Struct({
+    class DeleteFileResponse extends S.Class<DeleteFileResponse>(
+      "DeleteFileResponse",
+    )({
       success: S.Boolean,
-    });
+      deletedCount: S.Number,
+    }) {}
 
     return await this.executeAsync(
       this.requestUploadThing(
@@ -244,7 +247,7 @@ export class UTApi {
         keyType === "fileKey"
           ? { fileKeys: asArray(keys) }
           : { customIds: asArray(keys) },
-        responseSchema,
+        DeleteFileResponse,
       ),
     );
   };
@@ -266,20 +269,22 @@ export class UTApi {
 
     const { keyType = this.defaultKeyType } = opts ?? {};
 
-    const responseSchema = S.Struct({
+    class GetFileUrlResponse extends S.Class<GetFileUrlResponse>(
+      "GetFileUrlResponse",
+    )({
       data: S.Array(
         S.Struct({
           key: S.String,
           url: S.String,
         }),
       ),
-    });
+    }) {}
 
     return await this.executeAsync(
       this.requestUploadThing(
         "/api/getFileUrl",
         keyType === "fileKey" ? { fileKeys: keys } : { customIds: keys },
-        responseSchema,
+        GetFileUrlResponse,
       ),
     );
   };
@@ -297,13 +302,16 @@ export class UTApi {
   listFiles = async (opts?: ListFilesOptions) => {
     guardServerOnly();
 
-    const responseSchema = S.Struct({
+    class ListFileResponse extends S.Class<ListFileResponse>(
+      "ListFileResponse",
+    )({
+      hasMore: S.Boolean,
       files: S.Array(
         S.Struct({
           id: S.String,
+          customId: S.NullOr(S.String),
           key: S.String,
           name: S.String,
-          customId: S.NullOr(S.String),
           status: S.Literal(
             "Deletion Pending",
             "Failed",
@@ -312,25 +320,27 @@ export class UTApi {
           ),
         }),
       ),
-    });
+    }) {}
 
     return await this.executeAsync(
-      this.requestUploadThing("/api/listFiles", { ...opts }, responseSchema),
+      this.requestUploadThing("/api/listFiles", { ...opts }, ListFileResponse),
     );
   };
 
   renameFiles = async (updates: RenameFileUpdate | RenameFileUpdate[]) => {
     guardServerOnly();
 
-    const responseSchema = S.Struct({
+    class RenameFileResponse extends S.Class<RenameFileResponse>(
+      "RenameFileResponse",
+    )({
       success: S.Boolean,
-    });
+    }) {}
 
     return await this.executeAsync(
       this.requestUploadThing(
         "/api/renameFiles",
         { updates: asArray(updates) },
-        responseSchema,
+        RenameFileResponse,
       ),
     );
   };
@@ -341,18 +351,17 @@ export class UTApi {
   getUsageInfo = async () => {
     guardServerOnly();
 
-    const responseSchema = S.Struct({
+    class GetUsageInfoResponse extends S.Class<GetUsageInfoResponse>(
+      "GetUsageInfoResponse",
+    )({
       totalBytes: S.Number,
-      totalReadable: S.String,
       appTotalBytes: S.Number,
-      appTotalReadable: S.String,
       filesUploaded: S.Number,
       limitBytes: S.Number,
-      limitReadable: S.String,
-    });
+    }) {}
 
     return await this.executeAsync(
-      this.requestUploadThing("/api/getUsageInfo", {}, responseSchema),
+      this.requestUploadThing("/api/getUsageInfo", {}, GetUsageInfoResponse),
     );
   };
 
@@ -379,9 +388,11 @@ export class UTApi {
       });
     }
 
-    const responseSchema = S.Struct({
+    class GetSignedUrlResponse extends S.Class<GetSignedUrlResponse>(
+      "GetSignedUrlResponse",
+    )({
       url: S.String,
-    });
+    }) {}
 
     return await this.executeAsync(
       this.requestUploadThing(
@@ -389,7 +400,7 @@ export class UTApi {
         keyType === "fileKey"
           ? { fileKey: key, expiresIn }
           : { customId: key, expiresIn },
-        responseSchema,
+        GetSignedUrlResponse,
       ),
     );
   };

--- a/packages/uploadthing/test/__test-helpers.ts
+++ b/packages/uploadthing/test/__test-helpers.ts
@@ -96,35 +96,11 @@ const callRequestSpy = async (request: StrictRequest<any>) =>
     })(),
   });
 
-const msw = setupServer(
-  /**
-   * S3
-   */
-  http.post("https://bucket.s3.amazonaws.com", async ({ request }) => {
-    await callRequestSpy(request);
-    return new HttpResponse();
-  }),
-  http.put("https://bucket.s3.amazonaws.com/:key", async ({ request }) => {
-    await callRequestSpy(request);
-    return new HttpResponse(null, {
-      status: 204,
-      headers: { ETag: "abc123" },
-    });
-  }),
-  /**
-   * Static Assets
-   */
-  http.get("https://cdn.foo.com/:fileKey", async ({ request }) => {
-    await callRequestSpy(request);
-    return HttpResponse.text("Lorem ipsum doler sit amet");
-  }),
-  http.get("https://utfs.io/f/:key", async ({ request }) => {
-    await callRequestSpy(request);
-    return HttpResponse.text("Lorem ipsum doler sit amet");
-  }),
-);
+const msw = setupServer();
 beforeAll(() => msw.listen({ onUnhandledRequest: "bypass" }));
 afterAll(() => msw.close());
+
+export const resetMocks = () => msw.close();
 
 /**
  * Extend the base `it` function to provide a `db` instance to our tests
@@ -142,8 +118,35 @@ export const it = itBase.extend({
       insertFile: (file: any) => files.push(file),
       getFileByKey: (key: string) => files.find((f) => f.key === key),
     };
-    // prepend msw listeners to use db instance
     msw.use(
+      /**
+       * S3
+       */
+      http.post("https://bucket.s3.amazonaws.com", async ({ request }) => {
+        await callRequestSpy(request);
+        return new HttpResponse();
+      }),
+      http.put("https://bucket.s3.amazonaws.com/:key", async ({ request }) => {
+        await callRequestSpy(request);
+        return new HttpResponse(null, {
+          status: 204,
+          headers: { ETag: "abc123" },
+        });
+      }),
+      /**
+       * Static Assets
+       */
+      http.get("https://cdn.foo.com/:fileKey", async ({ request }) => {
+        await callRequestSpy(request);
+        return HttpResponse.text("Lorem ipsum doler sit amet");
+      }),
+      http.get("https://utfs.io/f/:key", async ({ request }) => {
+        await callRequestSpy(request);
+        return HttpResponse.text("Lorem ipsum doler sit amet");
+      }),
+      /**
+       * UploadThing API
+       */
       http.post<never, { files: any[] } & Record<string, string>>(
         "https://uploadthing.com/api/prepareUpload",
         async ({ request }) => {

--- a/packages/uploadthing/test/sdk.test.ts
+++ b/packages/uploadthing/test/sdk.test.ts
@@ -1,9 +1,17 @@
+/* eslint-disable no-restricted-globals */
 import { process } from "std-env";
-import { describe, expect, expectTypeOf } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  expectTypeOf,
+  it as rawIt,
+} from "vitest";
 
 import { UTApi, UTFile } from "../src/sdk";
 import type { UploadFileResult } from "../src/sdk/types";
-import { it, requestSpy } from "./__test-helpers";
+import { it, requestSpy, resetMocks } from "./__test-helpers";
 
 describe("uploadFiles", () => {
   const fooFile = new File(["foo"], "foo.txt", { type: "text/plain" });
@@ -496,3 +504,217 @@ describe("updateACL", () => {
     );
   });
 });
+
+describe.runIf(process.env.UPLOADTHING_TEST_SECRET)(
+  "smoke test with live api",
+  { timeout: 15_000 },
+  () => {
+    const utapi = new UTApi({
+      apiKey: process.env.UPLOADTHING_TEST_SECRET ?? "sk_foo",
+    });
+
+    const localInfo = { totalBytes: 0, filesUploaded: 0 };
+    const TEST_APP_LIMIT_BYTES = 2147483648;
+
+    // Clean up any files before and after tests
+    beforeAll(async () => {
+      resetMocks();
+      const { files } = await utapi.listFiles();
+      await utapi.deleteFiles(files.map((f) => f.key));
+    });
+    afterAll(async () => {
+      const { files } = await utapi.listFiles();
+      await utapi.deleteFiles(files.map((f) => f.key));
+    });
+
+    // These will all run in serial
+
+    rawIt("should have no files", async () => {
+      const { files, hasMore } = await utapi.listFiles();
+      expect(files).toHaveLength(0);
+      expect(hasMore).toBe(false);
+
+      const usageInfo = await utapi.getUsageInfo();
+      expect(usageInfo).toEqual({
+        totalBytes: 0,
+        appTotalBytes: 0,
+        filesUploaded: 0,
+        limitBytes: TEST_APP_LIMIT_BYTES,
+      });
+      localInfo.totalBytes = usageInfo.totalBytes;
+      localInfo.filesUploaded = usageInfo.filesUploaded;
+    });
+
+    rawIt("should upload a file", async () => {
+      const file = new File(["foo"], "foo.txt", { type: "text/plain" });
+      const result = await utapi.uploadFiles(file);
+      expect(result).toEqual({
+        data: {
+          customId: null,
+          key: expect.stringMatching(/.+/),
+          name: "foo.txt",
+          size: 3,
+          type: "text/plain",
+          url: expect.stringMatching(/https:\/\/utfs.io\/f\/.+/),
+        },
+        error: null,
+      });
+
+      const content = await fetch(result.data!.url).then((r) => r.text());
+      expect(content).toBe("foo");
+
+      const usageInfo = await utapi.getUsageInfo();
+      expect(usageInfo).toEqual({
+        totalBytes: 3,
+        appTotalBytes: 3,
+        filesUploaded: 1,
+        limitBytes: TEST_APP_LIMIT_BYTES,
+      });
+
+      localInfo.totalBytes += result.data!.size;
+      localInfo.filesUploaded++;
+    });
+
+    rawIt("should upload a private file", async () => {
+      const file = new File(["foo"], "foo.txt", { type: "text/plain" });
+      const result = await utapi.uploadFiles(file, {
+        acl: "private",
+      });
+      expect(result).toEqual({
+        data: {
+          customId: null,
+          key: expect.stringMatching(/.+/),
+          name: "foo.txt",
+          size: 3,
+          type: "text/plain",
+          url: expect.stringMatching(/https:\/\/utfs.io\/f\/.+/),
+        },
+        error: null,
+      });
+
+      const response = await fetch(result.data!.url);
+      expect(response.status).toBe(403);
+
+      const { url } = await utapi.getSignedURL(result.data!.key);
+      const content = await fetch(url).then((r) => r.text());
+      expect(content).toBe("foo");
+
+      localInfo.totalBytes += result.data!.size;
+      localInfo.filesUploaded++;
+    });
+
+    rawIt("should upload a file from a url", async () => {
+      const result = await utapi.uploadFilesFromUrl(
+        "https://uploadthing.com/favicon.ico",
+      );
+      expect(result).toEqual({
+        data: {
+          customId: null,
+          key: expect.stringMatching(/.+/),
+          name: "favicon.ico",
+          size: expect.any(Number),
+          type: "image/vnd.microsoft.icon",
+          url: expect.stringMatching(/https:\/\/utfs.io\/f\/.+/),
+        },
+        error: null,
+      });
+
+      localInfo.totalBytes += result.data!.size;
+      localInfo.filesUploaded++;
+    });
+
+    rawIt("should rename a file", async () => {
+      const customId = crypto.randomUUID();
+
+      const file = new UTFile(["foo"], "bar.txt", { customId });
+      const result = await utapi.uploadFiles(file);
+      expect(result).toEqual({
+        data: {
+          customId: customId,
+          key: expect.stringMatching(/.+/),
+          name: "bar.txt",
+          size: 3,
+          type: "text/plain",
+          url: expect.stringMatching(/https:\/\/utfs.io\/f\/.+/),
+        },
+        error: null,
+      });
+
+      const { success } = await utapi.renameFiles({
+        customId,
+        newName: "baz.txt",
+      });
+      expect(success).toBe(true);
+
+      const { files } = await utapi.listFiles();
+      expect(files.find((f) => f.customId === customId)).toHaveProperty(
+        "name",
+        "baz.txt",
+      );
+
+      // FIXME: Bug in uploadthing server
+      // const heads = await fetch(result.data!.url).then((r) => r.headers);
+      // expect(heads.get("Content-Disposition")).toEqual(
+      //   expect.stringContaining("filename=baz.txt"),
+      // );
+
+      localInfo.totalBytes += result.data!.size;
+      localInfo.filesUploaded++;
+    });
+
+    rawIt("should update ACL", async () => {
+      const file = new File(["foo"], "foo.txt", { type: "text/plain" });
+      const result = await utapi.uploadFiles(file);
+      expect(result).toEqual({
+        data: {
+          customId: null,
+          key: expect.stringMatching(/.+/),
+          name: "foo.txt",
+          size: 3,
+          type: "text/plain",
+          url: expect.stringMatching(/https:\/\/utfs.io\/f\/.+/),
+        },
+        error: null,
+      });
+      const { url, key } = result.data!;
+
+      const firstChange = await utapi.updateACL(key, "private");
+      expect(firstChange.success).toBe(true);
+      await expect(fetch(url)).resolves.toHaveProperty("status", 403);
+
+      const secondChange = await utapi.updateACL(key, "public-read");
+      expect(secondChange.success).toBe(true);
+      await expect(fetch(url)).resolves.toHaveProperty("status", 200);
+
+      localInfo.totalBytes += result.data!.size;
+      localInfo.filesUploaded++;
+    });
+
+    rawIt("should delete a file", async () => {
+      const { files } = await utapi.listFiles();
+      const someFile = files[0];
+
+      const response = await fetch(`https://utfs.io/f/${someFile.key}`);
+      const size = Number(response.headers.get("Content-Length"));
+
+      const result = await utapi.deleteFiles(someFile.key);
+      expect(result).toEqual({
+        deletedCount: 1,
+        success: true,
+      });
+
+      localInfo.totalBytes -= size;
+      localInfo.filesUploaded--;
+    });
+
+    rawIt("should have correct usage info", async () => {
+      const usageInfo = await utapi.getUsageInfo();
+      expect(usageInfo).toEqual({
+        totalBytes: localInfo.totalBytes,
+        appTotalBytes: localInfo.totalBytes,
+        filesUploaded: localInfo.filesUploaded,
+        limitBytes: TEST_APP_LIMIT_BYTES,
+      });
+    });
+  },
+);


### PR DESCRIPTION
Fixes invalid schema.

Also adds a test suite that runs against a live app (if `UPLOADTHING_TEST_SECRET` is defined) to test a good chunk of the happy paths