### PR TITLE
fix(docs): add x-robots-tag header on non-production environments

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -37,6 +37,21 @@ const withNextra = nextra({
       },
     ];
   },
+  async headers() {
+    if (process.env.VERCEL_ENV !== "production") {
+      return [
+        {
+          source: "/(.*)",
+          headers: [
+            {
+              key: "X-Robots-Tag",
+              value: "noindex",
+            },
+          ],
+        },
+      ];
+    }
+  },
 });
 
 export default withNextra({


### PR DESCRIPTION
Attempts to fix: https://x.com/t3dotgg/status/1798132183670141285

This PR adds the X-Robots-Tag header to try to prevent indexing of Vercel environments that aren't production. 

More info:
* https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag
* https://www.bing.com/webmasters/help/which-robots-metatags-does-bing-support-5198d240 