### PR TITLE
fix: Add x-robots-tag to next.config.mjs

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -11,7 +11,7 @@ const withNextra = nextra({
   async headers() {
     if (
       process.env.VERCEL_ENV === "production" &&
-      process.env.VERCEL_URL !== process.env.VERCEL_PROJECT_PRODUCTION_URL
+      process.env.VERCEL_PROJECT_PRODUCTION_URL !== process.env.VERCEL_URL
     ) {
       return []
     } else {

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -8,6 +8,23 @@ const withNextra = nextra({
   flexsearch: {
     codeblock: false,
   },
+  async headers() {
+    if (process.env.VERCEL_ENV === "production") {
+      return []
+    } else {
+      return [
+        {
+          source: "/:path*",
+          headers: [
+            {
+              key: "x-robots-tag",
+              value: "noindex"
+            }
+          ]
+        }
+      ]
+    }
+  },
   async redirects() {
     return [
       {

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -9,7 +9,10 @@ const withNextra = nextra({
     codeblock: false,
   },
   async headers() {
-    if (process.env.VERCEL_ENV === "production") {
+    if (
+      process.env.VERCEL_ENV === "production" &&
+      !process.env.VERCEL_URL.includes("vercel.app")
+    ) {
       return []
     } else {
       return [

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -11,7 +11,7 @@ const withNextra = nextra({
   async headers() {
     if (
       process.env.VERCEL_ENV === "production" &&
-      !process.env.VERCEL_URL.includes("vercel.app")
+      process.env.VERCEL_URL !== process.env.VERCEL_PROJECT_PRODUCTION_URL
     ) {
       return []
     } else {


### PR DESCRIPTION
Fixing https://x.com/t3dotgg/status/1798132183670141285

See: https://vercel.com/guides/are-vercel-preview-deployment-indexed-by-search-engines#x-robots-tag-header

`x-robots-tag: noindex` should exist but it doesn't, this config makes sure that it does. Sometimes,  the generated `*.vercel.app` URLs are marked as production so better to check if `VERCEL_PROJECT_PRODUCTION_URL` (uploadthing.com) is not the same as the generated URL: https://vercel.com/docs/projects/environment-variables/system-environment-variables

To be even more specific you can set a `NEXT_PUBLIC_URL` env variable and check if it contains `vercel.app`: https://github.com/vercel/next.js/discussions/16429#discussioncomment-1302156
 
![CleanShot 2024-06-04 at 18 09 29@2x](https://github.com/pingdotgg/uploadthing/assets/157987250/7583ed45-171a-4126-b791-a37c3c829d84)
