### PR TITLE
fix: `onUploadProgress` events out of order

### DIFF
--- a/.changeset/wild-terms-know.md
+++ b/.changeset/wild-terms-know.md
@@ -1,0 +1,8 @@
+---
+"@uploadthing/react": patch
+"@uploadthing/solid": patch
+"@uploadthing/svelte": patch
+"@uploadthing/vue": patch
+---
+
+fix: `onUploadProgress` events out of order when uploading many files

--- a/examples/minimal-appdir/src/app/page.tsx
+++ b/examples/minimal-appdir/src/app/page.tsx
@@ -11,8 +11,19 @@ export default function Home() {
     /**
      * @see https://docs.uploadthing.com/api-reference/react#useuploadthing
      */
-    onClientUploadComplete: () => {
-      alert("Upload Completed");
+    skipPolling: true,
+    onBeforeUploadBegin: (files) => {
+      console.log("Uploading", files.length, "files");
+      return files;
+    },
+    onUploadBegin: (name) => {
+      console.log("Beginning upload of", name);
+    },
+    onClientUploadComplete: (res) => {
+      console.log("Upload Completed.", res.length, "files uploaded");
+    },
+    onUploadProgress(p) {
+      console.log("onUploadProgress", p);
     },
   });
 
@@ -50,14 +61,14 @@ export default function Home() {
       />
       <input
         type="file"
+        multiple
         onChange={async (e) => {
-          const file = e.target.files?.[0];
-          if (!file) return;
+          const files = Array.from(e.target.files ?? []);
 
           // Do something with files
 
           // Then start the upload
-          await startUpload([file]);
+          await startUpload(files);
         }}
       />
     </main>

--- a/examples/minimal-appdir/src/server/uploadthing.ts
+++ b/examples/minimal-appdir/src/server/uploadthing.ts
@@ -23,8 +23,8 @@ const f = createUploadthing({
 export const uploadRouter = {
   videoAndImage: f({
     image: {
-      maxFileSize: "4MB",
-      maxFileCount: 4,
+      maxFileSize: "16MB",
+      maxFileCount: 10,
       acl: "public-read",
     },
     video: {

--- a/examples/minimal-appdir/src/server/uploadthing.ts
+++ b/examples/minimal-appdir/src/server/uploadthing.ts
@@ -23,8 +23,8 @@ const f = createUploadthing({
 export const uploadRouter = {
   videoAndImage: f({
     image: {
-      maxFileSize: "16MB",
-      maxFileCount: 10,
+      maxFileSize: "4MB",
+      maxFileCount: 4,
       acl: "public-read",
     },
     video: {

--- a/packages/react/src/useUploadThing.ts
+++ b/packages/react/src/useUploadThing.ts
@@ -83,6 +83,7 @@ export const INTERNAL_uploadthingHookGen = <
       const input = args[1];
 
       setUploading(true);
+      files.forEach((f) => fileProgress.current.set(f.name, 0));
       opts?.onUploadProgress?.(0);
       try {
         const res = await uploadFiles<TEndpoint, TSkipPolling>(endpoint, {
@@ -91,6 +92,7 @@ export const INTERNAL_uploadthingHookGen = <
           files,
           skipPolling: opts?.skipPolling,
           onUploadProgress: (progress) => {
+            console.log("[ut]: got progress event", progress);
             if (!opts?.onUploadProgress) return;
             fileProgress.current.set(progress.file, progress.progress);
             let sum = 0;
@@ -100,6 +102,11 @@ export const INTERNAL_uploadthingHookGen = <
             const averageProgress =
               Math.floor(sum / fileProgress.current.size / 10) * 10;
             if (averageProgress !== uploadProgress.current) {
+              console.log(
+                "[ut]: running user callback",
+                fileProgress.current,
+                averageProgress,
+              );
               opts?.onUploadProgress?.(averageProgress);
               uploadProgress.current = averageProgress;
             }

--- a/packages/react/src/useUploadThing.ts
+++ b/packages/react/src/useUploadThing.ts
@@ -92,7 +92,6 @@ export const INTERNAL_uploadthingHookGen = <
           files,
           skipPolling: opts?.skipPolling,
           onUploadProgress: (progress) => {
-            console.log("[ut]: got progress event", progress);
             if (!opts?.onUploadProgress) return;
             fileProgress.current.set(progress.file, progress.progress);
             let sum = 0;
@@ -102,11 +101,6 @@ export const INTERNAL_uploadthingHookGen = <
             const averageProgress =
               Math.floor(sum / fileProgress.current.size / 10) * 10;
             if (averageProgress !== uploadProgress.current) {
-              console.log(
-                "[ut]: running user callback",
-                fileProgress.current,
-                averageProgress,
-              );
               opts?.onUploadProgress?.(averageProgress);
               uploadProgress.current = averageProgress;
             }

--- a/packages/solid/src/useUploadThing.ts
+++ b/packages/solid/src/useUploadThing.ts
@@ -62,6 +62,7 @@ export const INTERNAL_uploadthingHookGen = <
 
       setUploading(true);
       opts?.onUploadProgress?.(0);
+      files.forEach((f) => fileProgress.set(f.name, 0));
       try {
         const res = await uploadFiles<TEndpoint, TSkipPolling>(endpoint, {
           headers: opts?.headers,

--- a/packages/svelte/src/lib/create-uploadthing.ts
+++ b/packages/svelte/src/lib/create-uploadthing.ts
@@ -63,6 +63,7 @@ export const INTERNAL_createUploadThingGen = <
       const input = args[1];
       isUploading.set(true);
       opts?.onUploadProgress?.(0);
+      files.forEach((f) => fileProgress.set(f.name, 0));
       try {
         const res = await uploadFiles(endpoint, {
           files,

--- a/packages/vue/src/useUploadThing.ts
+++ b/packages/vue/src/useUploadThing.ts
@@ -77,6 +77,7 @@ export const INTERNAL_uploadthingHookGen = <
 
       isUploading.value = true;
       opts?.onUploadProgress?.(0);
+      files.forEach((f) => fileProgress.value.set(f.name, 0));
       try {
         const res = await uploadFiles(endpoint, {
           headers: opts?.headers,


### PR DESCRIPTION
Closes #859

prefilling the map fixes the average calculation as some items might not be uplaoding from the start

![CleanShot 2024-06-16 at 11 24 08@2x](https://github.com/pingdotgg/uploadthing/assets/51714798/1ded1fff-cd08-4f5b-97fb-0eb9c8f29f6c)
