### PR TITLE
chore: update api paths

### DIFF
--- a/.changeset/mighty-kiwis-enjoy.md
+++ b/.changeset/mighty-kiwis-enjoy.md
@@ -1,0 +1,6 @@
+---
+"uploadthing": patch
+"@uploadthing/shared": patch
+---
+
+chore: update api paths to skip rewrites

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -124,7 +124,7 @@ export const getTypeFromFileName = (
 };
 
 export function generateUploadThingURL(path: `/${string}`) {
-  let host = "https://uploadthing.com";
+  let host = "https://api.uploadthing.com";
   if (process.env.CUSTOM_INFRA_URL) {
     host = process.env.CUSTOM_INFRA_URL;
   }

--- a/packages/uploadthing/src/internal/dev-hook.ts
+++ b/packages/uploadthing/src/internal/dev-hook.ts
@@ -26,7 +26,7 @@ const isValidResponse = (response: ResponseEsque) => {
 export const conditionalDevServer = (fileKey: string, apiKey: string) => {
   return Effect.gen(function* () {
     const file = yield* fetchEff(
-      generateUploadThingURL(`/api/pollUpload/${fileKey}`),
+      generateUploadThingURL(`/v6/pollUpload/${fileKey}`),
     ).pipe(
       Effect.andThen(parseResponseJson),
       Effect.andThen(S.decodeUnknown(PollUploadResponse)),

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -203,7 +203,7 @@ const handleCallbackRequest = Effect.gen(function* () {
     payload,
   );
 
-  yield* fetchEff(generateUploadThingURL("/api/serverCallback"), {
+  yield* fetchEff(generateUploadThingURL("/v6/serverCallback"), {
     method: "POST",
     body: JSON.stringify(payload),
     headers: { "Content-Type": "application/json" },
@@ -354,7 +354,7 @@ const handleUploadAction = Effect.gen(function* () {
   );
 
   const presignedUrls = yield* fetchEff(
-    generateUploadThingURL("/api/prepareUpload"),
+    generateUploadThingURL("/v6/prepareUpload"),
     {
       method: "POST",
       body: JSON.stringify({

--- a/packages/uploadthing/src/internal/multi-part.server.ts
+++ b/packages/uploadthing/src/internal/multi-part.server.ts
@@ -111,7 +111,7 @@ export const completeMultipartUpload = (
   presigned: { key: string; uploadId: string },
   etags: readonly { tag: string; partNumber: number }[],
 ) =>
-  fetchEff(generateUploadThingURL("/api/completeMultipart"), {
+  fetchEff(generateUploadThingURL("/v6/completeMultipart"), {
     method: "POST",
     body: JSON.stringify({
       fileKey: presigned.key,
@@ -136,7 +136,7 @@ export const abortMultipartUpload = (presigned: {
   uploadId: string | null;
 }) =>
   fetchEff(
-    generateUploadThingURL("/api/failureCallback"),
+    generateUploadThingURL("/v6/failureCallback"),
 
     {
       method: "POST",

--- a/packages/uploadthing/src/internal/presigned-post.server.ts
+++ b/packages/uploadthing/src/internal/presigned-post.server.ts
@@ -29,7 +29,7 @@ export const uploadPresignedPost = (file: FileEsque, presigned: PSPResponse) =>
       }),
     }).pipe(
       Effect.tapErrorCause(() =>
-        fetchEff(generateUploadThingURL("/api/failureCallback"), {
+        fetchEff(generateUploadThingURL("/v6/failureCallback"), {
           method: "POST",
           body: JSON.stringify({
             fileKey: presigned.key,

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -343,7 +343,7 @@ export class UTApi {
 
     return await this.executeAsync(
       this.requestUploadThing(
-        "/api/renameFiles",
+        "/v6/renameFiles",
         { updates: asArray(updates) },
         RenameFileResponse,
       ),

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -248,7 +248,7 @@ export class UTApi {
 
     return await this.executeAsync(
       this.requestUploadThing(
-        "/api/deleteFiles",
+        "/v6/deleteFiles",
         keyType === "fileKey"
           ? { fileKeys: asArray(keys) }
           : { customIds: asArray(keys) },
@@ -287,7 +287,7 @@ export class UTApi {
 
     return await this.executeAsync(
       this.requestUploadThing(
-        "/api/getFileUrl",
+        "/v6/getFileUrl",
         keyType === "fileKey" ? { fileKeys: keys } : { customIds: keys },
         GetFileUrlResponse,
       ),
@@ -328,7 +328,7 @@ export class UTApi {
     }) {}
 
     return await this.executeAsync(
-      this.requestUploadThing("/api/listFiles", { ...opts }, ListFileResponse),
+      this.requestUploadThing("/v6/listFiles", { ...opts }, ListFileResponse),
     );
   };
 
@@ -366,7 +366,7 @@ export class UTApi {
     }) {}
 
     return await this.executeAsync(
-      this.requestUploadThing("/api/getUsageInfo", {}, GetUsageInfoResponse),
+      this.requestUploadThing("/v6/getUsageInfo", {}, GetUsageInfoResponse),
     );
   };
 
@@ -401,7 +401,7 @@ export class UTApi {
 
     return await this.executeAsync(
       this.requestUploadThing(
-        "/api/requestFileAccess",
+        "/v6/requestFileAccess",
         keyType === "fileKey"
           ? { fileKey: key, expiresIn }
           : { customId: key, expiresIn },
@@ -445,7 +445,7 @@ export class UTApi {
     });
 
     return await this.executeAsync(
-      this.requestUploadThing("/api/updateACL", { updates }, responseSchema),
+      this.requestUploadThing("/v6/updateACL", { updates }, responseSchema),
     );
   };
 }

--- a/packages/uploadthing/src/sdk/utils.ts
+++ b/packages/uploadthing/src/sdk/utils.ts
@@ -149,7 +149,7 @@ const getPresignedUrls = (input: UploadFilesInternalOptions) =>
     });
 
     const presigneds = yield* fetchEff(
-      generateUploadThingURL("/api/uploadFiles"),
+      generateUploadThingURL("/v6/uploadFiles"),
       {
         method: "POST",
         cache: "no-store",
@@ -188,7 +188,7 @@ const uploadFile = (
     }
 
     yield* fetchEff(
-      generateUploadThingURL(`/api/pollUpload/${presigned.key}`),
+      generateUploadThingURL(`/v6/pollUpload/${presigned.key}`),
     ).pipe(
       Effect.andThen(parseResponseJson),
       Effect.andThen(S.decodeUnknown(PollUploadResponse)),

--- a/packages/uploadthing/test/__test-helpers.ts
+++ b/packages/uploadthing/test/__test-helpers.ts
@@ -47,7 +47,7 @@ const mockPresigned = (file: {
     fileUrl: "https://utfs.io/f/abc-123.txt",
     key: "abc-123.txt",
     pollingJwt: "random-jwt",
-    pollingUrl: generateUploadThingURL("/api/serverCallback"),
+    pollingUrl: generateUploadThingURL("/v6/serverCallback"),
   };
   if (file.size > 5 * 1024 * 1024) {
     return {
@@ -140,7 +140,7 @@ export const it = itBase.extend({
        * UploadThing API
        */
       http.post<never, { files: any[] } & Record<string, string>>(
-        "https://uploadthing.com/api/prepareUpload",
+        "https://api.uploadthing.com/v6/prepareUpload",
         async ({ request }) => {
           await callRequestSpy(request);
           const body = await request.json();
@@ -162,7 +162,7 @@ export const it = itBase.extend({
         },
       ),
       http.post<never, { files: any[]; metadata: unknown }>(
-        "https://uploadthing.com/api/uploadFiles",
+        "https://api.uploadthing.com/v6/uploadFiles",
         async ({ request }) => {
           await callRequestSpy(request);
           const body = await request.json();
@@ -181,21 +181,21 @@ export const it = itBase.extend({
         },
       ),
       http.post(
-        "https://uploadthing.com/api/completeMultipart",
+        "https://api.uploadthing.com/v6/completeMultipart",
         async ({ request }) => {
           await callRequestSpy(request);
           return HttpResponse.json({ success: true });
         },
       ),
       http.post(
-        "https://uploadthing.com/api/failureCallback",
+        "https://api.uploadthing.com/v6/failureCallback",
         async ({ request }) => {
           await callRequestSpy(request);
           return HttpResponse.json({ success: true });
         },
       ),
       http.get<{ key: string }>(
-        "https://uploadthing.com/api/pollUpload/:key",
+        "https://api.uploadthing.com/v6/pollUpload/:key",
         // @ts-expect-error - https://github.com/mswjs/msw/pull/2108
         async function* ({ request, params }) {
           await callRequestSpy(request);
@@ -222,7 +222,7 @@ export const it = itBase.extend({
         },
       ),
       http.post(
-        "https://uploadthing.com/api/requestFileAccess",
+        "https://api.uploadthing.com/v6/requestFileAccess",
         async ({ request }) => {
           await callRequestSpy(request);
           return HttpResponse.json({
@@ -231,14 +231,14 @@ export const it = itBase.extend({
         },
       ),
       http.post(
-        "https://uploadthing.com/api/serverCallback",
+        "https://api.uploadthing.com/v6/serverCallback",
         async ({ request }) => {
           await callRequestSpy(request);
           return HttpResponse.json({ status: "ok" });
         },
       ),
       http.get(
-        "https://uploadthing.com/api/serverCallback",
+        "https://api.uploadthing.com/v6/serverCallback",
         // @ts-expect-error - https://github.com/mswjs/msw/pull/2108
         async function* ({ request }) {
           await callRequestSpy(request);
@@ -248,7 +248,7 @@ export const it = itBase.extend({
         },
       ),
       http.post(
-        "https://uploadthing.com/api/updateACL",
+        "https://api.uploadthing.com/v6/updateACL",
         async ({ request }) => {
           await callRequestSpy(request);
           return HttpResponse.json({ success: true });
@@ -277,7 +277,7 @@ export const useBadS3 = () =>
 
 export const useBadUTApi = () =>
   msw.use(
-    http.post("https://uploadthing.com/api/*", async () => {
+    http.post("https://api.uploadthing.com/*", async () => {
       return HttpResponse.json({ error: "Not found" }, { status: 404 });
     }),
   );

--- a/packages/uploadthing/test/adapters.test.ts
+++ b/packages/uploadthing/test/adapters.test.ts
@@ -67,7 +67,7 @@ describe("adapters:h3", async () => {
     // Should proceed to have requested URLs
     expect(requestSpy).toHaveBeenCalledOnce();
     expect(requestSpy).toHaveBeenCalledWith(
-      "https://uploadthing.com/api/prepareUpload",
+      "https://api.uploadthing.com/v6/prepareUpload",
       {
         body: {
           files: [{ name: "foo.txt", size: 48 }],
@@ -142,7 +142,7 @@ describe("adapters:server", async () => {
     // Should proceed to have requested URLs
     expect(requestSpy).toHaveBeenCalledOnce();
     expect(requestSpy).toHaveBeenCalledWith(
-      "https://uploadthing.com/api/prepareUpload",
+      "https://api.uploadthing.com/v6/prepareUpload",
       {
         body: {
           files: [{ name: "foo.txt", size: 48 }],
@@ -214,7 +214,7 @@ describe("adapters:next", async () => {
     // Should proceed to have requested URLs
     expect(requestSpy).toHaveBeenCalledOnce();
     expect(requestSpy).toHaveBeenCalledWith(
-      "https://uploadthing.com/api/prepareUpload",
+      "https://api.uploadthing.com/v6/prepareUpload",
       {
         body: {
           files: [{ name: "foo.txt", size: 48 }],
@@ -328,7 +328,7 @@ describe("adapters:next-legacy", async () => {
     // Should proceed to have requested URLs
     expect(requestSpy).toHaveBeenCalledOnce();
     expect(requestSpy).toHaveBeenCalledWith(
-      "https://uploadthing.com/api/prepareUpload",
+      "https://api.uploadthing.com/v6/prepareUpload",
       {
         body: {
           files: [{ name: "foo.txt", size: 48 }],
@@ -426,7 +426,7 @@ describe("adapters:express", async () => {
     // Should proceed to have requested URLs
     expect(requestSpy).toHaveBeenCalledOnce();
     expect(requestSpy).toHaveBeenCalledWith(
-      "https://uploadthing.com/api/prepareUpload",
+      "https://api.uploadthing.com/v6/prepareUpload",
       {
         body: {
           files: [{ name: "foo.txt", size: 48 }],
@@ -564,7 +564,7 @@ describe("adapters:fastify", async () => {
     // Should proceed to have requested URLs
     expect(requestSpy).toHaveBeenCalledOnce();
     expect(requestSpy).toHaveBeenCalledWith(
-      "https://uploadthing.com/api/prepareUpload",
+      "https://api.uploadthing.com/v6/prepareUpload",
       {
         body: {
           files: [{ name: "foo.txt", size: 48 }],

--- a/packages/uploadthing/test/client.test.ts
+++ b/packages/uploadthing/test/client.test.ts
@@ -43,7 +43,6 @@ export const setupUTServer = async () => {
       config: {
         uploadthingSecret: "sk_test_123",
         isDev: true,
-        logLevel: "debug",
       },
     }),
   );

--- a/packages/uploadthing/test/client.test.ts
+++ b/packages/uploadthing/test/client.test.ts
@@ -43,6 +43,7 @@ export const setupUTServer = async () => {
       config: {
         uploadthingSecret: "sk_test_123",
         isDev: true,
+        logLevel: "debug",
       },
     }),
   );
@@ -290,7 +291,7 @@ describe("uploadFiles", () => {
     expect(requestsToDomain("amazonaws.com")).toHaveLength(1);
     expect(onErrorMock).toHaveBeenCalledOnce();
     expect(requestSpy).toHaveBeenCalledWith(
-      generateUploadThingURL("/api/failureCallback"),
+      generateUploadThingURL("/v6/failureCallback"),
       {
         body: { fileKey: "abc-123.txt", uploadId: null },
         headers: {
@@ -327,7 +328,7 @@ describe("uploadFiles", () => {
     expect(requestsToDomain("amazonaws.com")).toHaveLength(7);
     expect(onErrorMock).toHaveBeenCalledOnce();
     expect(requestSpy).toHaveBeenCalledWith(
-      generateUploadThingURL("/api/failureCallback"),
+      generateUploadThingURL("/v6/failureCallback"),
       {
         body: { fileKey: "abc-123.txt", uploadId: "random-upload-id" },
         headers: {

--- a/packages/uploadthing/test/request-handler.test.ts
+++ b/packages/uploadthing/test/request-handler.test.ts
@@ -451,10 +451,10 @@ describe("bad request handling", () => {
     expect(res.status).toBe(500);
     await expect(res.json()).resolves.toEqual({
       message:
-        "Request to https://uploadthing.com/api/prepareUpload failed with status 404",
+        "Request to https://api.uploadthing.com/v6/prepareUpload failed with status 404",
       data: { error: "Not found" },
       cause:
-        "BadRequestError: Request to https://uploadthing.com/api/prepareUpload failed with status 404",
+        "BadRequestError: Request to https://api.uploadthing.com/v6/prepareUpload failed with status 404",
     });
   });
 });

--- a/packages/uploadthing/test/sdk.test.ts
+++ b/packages/uploadthing/test/sdk.test.ts
@@ -23,7 +23,7 @@ describe("uploadFiles", () => {
     expect(requestSpy).toHaveBeenCalledTimes(3);
     expect(requestSpy).toHaveBeenNthCalledWith(
       1,
-      "https://uploadthing.com/api/uploadFiles",
+      "https://api.uploadthing.com/v6/uploadFiles",
       {
         body: {
           files: [{ name: "foo.txt", type: "text/plain", size: 3 }],
@@ -49,7 +49,7 @@ describe("uploadFiles", () => {
     );
     expect(requestSpy).toHaveBeenNthCalledWith(
       3,
-      "https://uploadthing.com/api/pollUpload/abc-123.txt",
+      "https://api.uploadthing.com/v6/pollUpload/abc-123.txt",
       {
         body: null,
         headers: {
@@ -95,7 +95,7 @@ describe("uploadFiles", () => {
     expect(file.type).toBe("text/plain");
 
     expect(requestSpy).toHaveBeenCalledWith(
-      "https://uploadthing.com/api/uploadFiles",
+      "https://api.uploadthing.com/v6/uploadFiles",
       expect.objectContaining({}),
     );
   });
@@ -114,7 +114,7 @@ describe("uploadFiles", () => {
     expect(fileWithId.customId).toBe("foo");
 
     expect(requestSpy).toHaveBeenCalledWith(
-      "https://uploadthing.com/api/uploadFiles",
+      "https://api.uploadthing.com/v6/uploadFiles",
       {
         body: {
           files: [
@@ -145,7 +145,7 @@ describe("uploadFilesFromUrl", () => {
     expect(requestSpy).toHaveBeenCalledTimes(4); // download, request url, upload, poll
     expect(requestSpy).toHaveBeenNthCalledWith(
       2,
-      "https://uploadthing.com/api/uploadFiles",
+      "https://api.uploadthing.com/v6/uploadFiles",
       {
         body: {
           files: [{ name: "foo.txt", type: "text/plain", size: 26 }],
@@ -170,7 +170,7 @@ describe("uploadFilesFromUrl", () => {
     );
     expect(requestSpy).toHaveBeenNthCalledWith(
       4,
-      "https://uploadthing.com/api/pollUpload/abc-123.txt",
+      "https://api.uploadthing.com/v6/pollUpload/abc-123.txt",
       expect.objectContaining({}),
     );
 
@@ -214,7 +214,7 @@ describe("uploadFilesFromUrl", () => {
     });
 
     expect(requestSpy).toHaveBeenCalledWith(
-      "https://uploadthing.com/api/uploadFiles",
+      "https://api.uploadthing.com/v6/uploadFiles",
       {
         body: {
           files: [{ name: "bar.txt", type: "text/plain", size: 26 }],
@@ -240,7 +240,7 @@ describe("uploadFilesFromUrl", () => {
     });
 
     expect(requestSpy).toHaveBeenCalledWith(
-      "https://uploadthing.com/api/uploadFiles",
+      "https://api.uploadthing.com/v6/uploadFiles",
       {
         body: {
           files: [
@@ -349,7 +349,7 @@ describe("getSignedURL", () => {
 
     expect(requestSpy).toHaveBeenCalledOnce();
     expect(requestSpy).toHaveBeenCalledWith(
-      "https://uploadthing.com/api/requestFileAccess",
+      "https://api.uploadthing.com/v6/requestFileAccess",
       {
         body: { fileKey: "foo" },
         headers: {
@@ -369,7 +369,7 @@ describe("getSignedURL", () => {
 
     expect(requestSpy).toHaveBeenCalledOnce();
     expect(requestSpy).toHaveBeenCalledWith(
-      "https://uploadthing.com/api/requestFileAccess",
+      "https://api.uploadthing.com/v6/requestFileAccess",
       {
         body: { fileKey: "foo", expiresIn: 86400 },
         headers: {
@@ -389,7 +389,7 @@ describe("getSignedURL", () => {
 
     expect(requestSpy).toHaveBeenCalledOnce();
     expect(requestSpy).toHaveBeenCalledWith(
-      "https://uploadthing.com/api/requestFileAccess",
+      "https://api.uploadthing.com/v6/requestFileAccess",
       {
         body: { fileKey: "foo", expiresIn: 180 },
         headers: {
@@ -434,7 +434,7 @@ describe("updateACL", () => {
     });
 
     expect(requestSpy).toHaveBeenCalledWith(
-      "https://uploadthing.com/api/updateACL",
+      "https://api.uploadthing.com/v6/updateACL",
       {
         body: { updates: [{ fileKey: "ut-key", acl: "public-read" }] },
         headers: {
@@ -456,7 +456,7 @@ describe("updateACL", () => {
     ).resolves.toEqual({ success: true });
 
     expect(requestSpy).toHaveBeenCalledWith(
-      "https://uploadthing.com/api/updateACL",
+      "https://api.uploadthing.com/v6/updateACL",
       {
         body: {
           updates: [
@@ -485,7 +485,7 @@ describe("updateACL", () => {
     ).resolves.toEqual({ success: true });
 
     expect(requestSpy).toHaveBeenCalledWith(
-      "https://uploadthing.com/api/updateACL",
+      "https://api.uploadthing.com/v6/updateACL",
       {
         body: {
           updates: [


### PR DESCRIPTION
go straight to cf dist. instead of being rewritten from vercel first