### PR TITLE
docs: document button config.mode

### DIFF
--- a/docs/src/pages/api-reference/react.mdx
+++ b/docs/src/pages/api-reference/react.mdx
@@ -145,9 +145,10 @@ export const OurUploadButton = () => (
 
 Config object
 
-| Attribute     | Type    | Required | Notes           | Description                                   |
-| :------------ | :------ | :------- | :-------------- | :-------------------------------------------- |
-| appendOnPaste | boolean | No       | Added in `v5.7` | enables ability to paste files from clipboard |
+| Attribute     | Type               | Required | Notes           | Description                                                                                                                                |
+| :------------ | :----------------- | :------- | :-------------- | :----------------------------------------------------------------------------------------------------------------------------------------- |
+| mode          | 'auto' \| 'manual' | No       | Added in `v5.4` | mode of button. 'auto' is default one and triggers upload right after selection. 'manual' requires an additional click to start the upload |
+| appendOnPaste | boolean            | No       | Added in `v5.7` | enables ability to paste files from clipboard                                                                                              |
 
 <Callout type="info">
   If you want to disable the button based on when your `input` is not satisfied,


### PR DESCRIPTION
# Note to self that we should probably unify the defaults to be the same for both components in #866 - auto or manual though??

![CleanShot 2024-07-12 at 23 37 56@2x](https://github.com/user-attachments/assets/92225baa-ed6f-4510-9ec3-88d40df8e680)

