### PR TITLE
chore!: don't bundle tailwind-merge by default

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -63,9 +63,7 @@
   },
   "dependencies": {
     "@uploadthing/dropzone": "workspace:*",
-    "@uploadthing/shared": "workspace:*",
-    "file-selector": "^0.6.0",
-    "tailwind-merge": "^2.2.1"
+    "@uploadthing/shared": "workspace:*"
   },
   "peerDependencies": {
     "next": "*",

--- a/packages/react/src/components/button.tsx
+++ b/packages/react/src/components/button.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useCallback, useMemo, useRef, useState } from "react";
-import { twMerge } from "tailwind-merge";
 
 import {
   allowedContentTextLabelGenerator,
   contentFieldToContent,
+  defaultClassListMerger,
   generateMimeTypes,
   generatePermittedFileTypes,
   getFilesFromClipboardEvent,
@@ -96,7 +96,11 @@ export function UploadButton<
     UploadThingInternalProps;
   const fileRouteInput = "input" in $props ? $props.input : undefined;
 
-  const { mode = "auto", appendOnPaste = false } = $props.config ?? {};
+  const {
+    mode = "auto",
+    appendOnPaste = false,
+    cn = defaultClassListMerger,
+  } = $props.config ?? {};
   const acRef = useRef(new AbortController());
 
   const useUploadThing = INTERNAL_uploadthingHookGen<TRouter>({
@@ -225,7 +229,7 @@ export function UploadButton<
     return (
       <span className="z-50">
         <span className="block group-hover:hidden">{uploadProgress}%</span>
-        <Cancel className="hidden size-4 group-hover:block" />
+        <Cancel className="hidden size-4 group-hover:block" cn={cn} />
       </span>
     );
   };
@@ -239,7 +243,7 @@ export function UploadButton<
           fileInputRef.current.value = "";
         }
       }}
-      className={twMerge(
+      className={cn(
         "h-[1.25rem] cursor-pointer rounded border-none bg-transparent text-gray-500 transition-colors hover:bg-slate-200 hover:text-gray-600",
         styleFieldToClassName($props.appearance?.clearBtn, styleFieldArg),
       )}
@@ -254,7 +258,7 @@ export function UploadButton<
 
   const renderAllowedContent = () => (
     <div
-      className={twMerge(
+      className={cn(
         "h-[1.25rem] text-xs leading-5 text-gray-600",
         styleFieldToClassName($props.appearance?.allowedContent, styleFieldArg),
       )}
@@ -272,7 +276,7 @@ export function UploadButton<
 
   return (
     <div
-      className={twMerge(
+      className={cn(
         "flex flex-col items-center justify-center gap-1",
         $props.className,
         styleFieldToClassName($props.appearance?.container, styleFieldArg),
@@ -281,7 +285,7 @@ export function UploadButton<
       data-state={state}
     >
       <label
-        className={twMerge(
+        className={cn(
           "group relative flex h-10 w-36 cursor-pointer items-center justify-center overflow-hidden rounded-md text-white after:transition-[width] after:duration-500 focus-within:ring-2 focus-within:ring-blue-600 focus-within:ring-offset-2",
           state === "readying" && "cursor-not-allowed bg-blue-400",
           state === "uploading" &&

--- a/packages/react/src/components/dropzone.tsx
+++ b/packages/react/src/components/dropzone.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { twMerge } from "tailwind-merge";
 
 import { useDropzone } from "@uploadthing/dropzone/react";
 import {
   allowedContentTextLabelGenerator,
   contentFieldToContent,
+  defaultClassListMerger,
   generateClientDropzoneAccept,
   generatePermittedFileTypes,
   getFilesFromClipboardEvent,
@@ -104,7 +104,11 @@ export function UploadDropzone<
     UploadThingInternalProps;
   const fileRouteInput = "input" in $props ? $props.input : undefined;
 
-  const { mode = "manual", appendOnPaste = false } = $props.config ?? {};
+  const {
+    mode = "manual",
+    appendOnPaste = false,
+    cn = defaultClassListMerger,
+  } = $props.config ?? {};
   const acRef = useRef(new AbortController());
 
   const useUploadThing = INTERNAL_uploadthingHookGen<TRouter>({
@@ -243,7 +247,7 @@ export function UploadDropzone<
     return (
       <span className="z-50">
         <span className="block group-hover:hidden">{uploadProgress}%</span>
-        <Cancel className="hidden size-4 group-hover:block" />
+        <Cancel className="hidden size-4 group-hover:block" cn={cn} />
       </span>
     );
   };
@@ -266,7 +270,7 @@ export function UploadDropzone<
 
   return (
     <div
-      className={twMerge(
+      className={cn(
         "mt-2 flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-900/25 px-6 py-10 text-center",
         isDragActive && "bg-blue-600/10",
         $props.className,
@@ -280,7 +284,7 @@ export function UploadDropzone<
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
-          className={twMerge(
+          className={cn(
             "mx-auto block h-12 w-12 align-middle text-gray-400",
             styleFieldToClassName($props.appearance?.uploadIcon, styleFieldArg),
           )}
@@ -300,7 +304,7 @@ export function UploadDropzone<
         </svg>
       )}
       <label
-        className={twMerge(
+        className={cn(
           "relative mt-4 flex w-64 cursor-pointer items-center justify-center text-sm font-semibold leading-6 text-gray-600 focus-within:outline-none focus-within:ring-2 focus-within:ring-blue-600 focus-within:ring-offset-2 hover:text-blue-500",
           ready ? "text-blue-600" : "text-gray-500",
           styleFieldToClassName($props.appearance?.label, styleFieldArg),
@@ -314,7 +318,7 @@ export function UploadDropzone<
           (ready ? `Choose files or drag and drop` : `Loading...`)}
       </label>
       <div
-        className={twMerge(
+        className={cn(
           "m-0 h-[1.25rem] text-xs leading-5 text-gray-600",
           styleFieldToClassName(
             $props.appearance?.allowedContent,
@@ -333,7 +337,7 @@ export function UploadDropzone<
       </div>
 
       <button
-        className={twMerge(
+        className={cn(
           "group relative mt-4 flex h-10 w-36 cursor-pointer items-center justify-center overflow-hidden rounded-md border-none text-base text-white after:transition-[width] after:duration-500 focus-within:ring-2 focus-within:ring-blue-600 focus-within:ring-offset-2",
           state === "readying" && "cursor-not-allowed bg-blue-400",
           state === "uploading" &&

--- a/packages/react/src/components/shared.tsx
+++ b/packages/react/src/components/shared.tsx
@@ -1,4 +1,4 @@
-import { twMerge } from "tailwind-merge";
+import type { ClassListMerger } from "@uploadthing/shared";
 
 export function Spinner() {
   return (
@@ -16,14 +16,18 @@ export function Spinner() {
   );
 }
 
-export function Cancel({ className, ...props }: React.SVGProps<SVGSVGElement>) {
+export function Cancel({
+  className,
+  cn,
+  ...props
+}: React.SVGProps<SVGSVGElement> & { cn: ClassListMerger }) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 24 24"
       strokeLinecap="round"
       strokeLinejoin="round"
-      className={twMerge("fill-none stroke-current stroke-2", className)}
+      className={cn("fill-none stroke-current stroke-2", className)}
       {...props}
     >
       <circle cx="12" cy="12" r="10" />

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,4 +1,5 @@
 import type {
+  ClassListMerger,
   ErrorMessage,
   ExtendObjectIf,
   MaybePromise,
@@ -123,6 +124,13 @@ export type UploadthingComponentProps<
   config?: {
     mode?: "auto" | "manual";
     appendOnPaste?: boolean;
+    /**
+     * Override the default class name merger, with e.g. tailwind-merge
+     * This may be required if you're customizing the component
+     * appearance with additional TailwindCSS classes to ensure
+     * classes are sorted and applied in the correct order
+     */
+    cn?: ClassListMerger;
   };
 } & ExtendObjectIf<
     inferEndpointInput<TRouter[TEndpoint]>,

--- a/packages/shared/src/component-utils.ts
+++ b/packages/shared/src/component-utils.ts
@@ -194,3 +194,10 @@ export const contentFieldToContent = <T extends MinCallbackArg>(
     return result;
   }
 };
+
+export type ClassListMerger = (
+  ...classes: (string | null | undefined | false)[]
+) => string;
+export const defaultClassListMerger: ClassListMerger = (...classes) => {
+  return classes.filter(Boolean).join(" ");
+};

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -111,8 +111,7 @@
   },
   "dependencies": {
     "@uploadthing/dropzone": "workspace:*",
-    "@uploadthing/shared": "workspace:*",
-    "tailwind-merge": "^2.2.1"
+    "@uploadthing/shared": "workspace:*"
   },
   "devDependencies": {
     "postcss": "8.4.38",

--- a/packages/solid/src/components/button.tsx
+++ b/packages/solid/src/components/button.tsx
@@ -1,9 +1,9 @@
 import { createSignal } from "solid-js";
-import { twMerge } from "tailwind-merge";
 
 import {
   allowedContentTextLabelGenerator,
   contentFieldToContent,
+  defaultClassListMerger,
   generateMimeTypes,
   generatePermittedFileTypes,
   resolveMaybeUrlArg,
@@ -79,6 +79,8 @@ export function UploadButton<
   let inputRef: HTMLInputElement;
   const $props = props as UploadButtonProps<TRouter, TEndpoint>;
 
+  const { cn = defaultClassListMerger } = $props.config ?? {};
+
   const useUploadThing = INTERNAL_uploadthingHookGen<TRouter>({
     url: resolveMaybeUrlArg($props.url),
   });
@@ -127,7 +129,7 @@ export function UploadButton<
 
   return (
     <div
-      class={twMerge(
+      class={cn(
         "flex flex-col items-center justify-center gap-1",
         $props.class,
         styleFieldToClassName($props.appearance?.container, styleFieldArg),
@@ -136,7 +138,7 @@ export function UploadButton<
       data-state={state()}
     >
       <label
-        class={twMerge(
+        class={cn(
           "relative flex h-10 w-36 cursor-pointer items-center justify-center overflow-hidden rounded-md text-white after:transition-[width] after:duration-500",
           state() === "readying" && "cursor-not-allowed bg-blue-400",
           state() === "uploading" &&
@@ -171,7 +173,7 @@ export function UploadButton<
           ))}
       </label>
       <div
-        class={twMerge(
+        class={cn(
           "h-[1.25rem] text-xs leading-5 text-gray-600",
           styleFieldToClassName(
             $props.appearance?.allowedContent,

--- a/packages/solid/src/components/dropzone.tsx
+++ b/packages/solid/src/components/dropzone.tsx
@@ -1,10 +1,10 @@
 import { createSignal } from "solid-js";
-import { twMerge } from "tailwind-merge";
 
 import { createDropzone } from "@uploadthing/dropzone/solid";
 import {
   allowedContentTextLabelGenerator,
   contentFieldToContent,
+  defaultClassListMerger,
   generateClientDropzoneAccept,
   generatePermittedFileTypes,
   resolveMaybeUrlArg,
@@ -68,9 +68,6 @@ export type UploadDropzoneProps<
    * @param acceptedFiles - The files that were accepted.
    */
   onDrop?: (acceptedFiles: File[]) => void;
-  config?: {
-    mode?: "manual" | "auto";
-  };
 };
 
 export const UploadDropzone = <
@@ -84,7 +81,7 @@ export const UploadDropzone = <
   const [uploadProgress, setUploadProgress] = createSignal(0);
   const $props = props as UploadDropzoneProps<TRouter, TEndpoint>;
 
-  const { mode = "manual" } = $props.config ?? {};
+  const { mode = "manual", cn = defaultClassListMerger } = $props.config ?? {};
 
   const useUploadThing = INTERNAL_uploadthingHookGen<TRouter>({
     url: resolveMaybeUrlArg($props.url),
@@ -150,7 +147,7 @@ export const UploadDropzone = <
 
   return (
     <div
-      class={twMerge(
+      class={cn(
         "mt-2 flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-900/25 px-6 py-10 text-center",
         isDragActive && "bg-blue-600/10",
         $props.class,
@@ -164,7 +161,7 @@ export const UploadDropzone = <
         <svg
           xmlns="http://www.w3.org/2000/svg"
           viewBox="0 0 20 20"
-          class={twMerge(
+          class={cn(
             "mx-auto block h-12 w-12 align-middle text-gray-400",
             styleFieldToClassName($props.appearance?.uploadIcon, styleFieldArg),
           )}
@@ -184,7 +181,7 @@ export const UploadDropzone = <
         </svg>
       )}
       <label
-        class={twMerge(
+        class={cn(
           "relative mt-4 flex w-64 cursor-pointer items-center justify-center text-sm font-semibold leading-6 text-gray-600 focus-within:outline-none focus-within:ring-2 focus-within:ring-blue-600 focus-within:ring-offset-2 hover:text-blue-500",
           ready() ? "text-blue-600" : "text-gray-500",
           styleFieldToClassName($props.appearance?.label, styleFieldArg),
@@ -198,7 +195,7 @@ export const UploadDropzone = <
           (ready() ? `Choose files or drag and drop` : `Loading...`)}
       </label>
       <div
-        class={twMerge(
+        class={cn(
           "m-0 h-[1.25rem] text-xs leading-5 text-gray-600",
           styleFieldToClassName(
             $props.appearance?.allowedContent,
@@ -219,7 +216,7 @@ export const UploadDropzone = <
       </div>
       {files().length > 0 && (
         <button
-          class={twMerge(
+          class={cn(
             "relative mt-4 flex h-10 w-36 items-center justify-center overflow-hidden rounded-md text-white after:transition-[width] after:duration-500",
             state() === "uploading"
               ? `bg-blue-400 after:absolute after:left-0 after:h-full after:bg-blue-600 ${

--- a/packages/solid/src/types.ts
+++ b/packages/solid/src/types.ts
@@ -1,4 +1,5 @@
 import type {
+  ClassListMerger,
   ErrorMessage,
   ExtendObjectIf,
   MaybePromise,
@@ -99,6 +100,17 @@ export type UploadthingComponentProps<
    * @default (VERCEL_URL ?? window.location.origin) + "/api/uploadthing"
    */
   url?: string | URL;
+  config?: {
+    mode?: "manual" | "auto";
+    appendOnPaste?: never; // FIXME
+    /**
+     * Override the default class name merger, with e.g. tailwind-merge
+     * This may be required if you're customizing the component
+     * appearance with additional TailwindCSS classes to ensure
+     * classes are sorted and applied in the correct order
+     */
+    cn?: ClassListMerger;
+  };
 } & ExtendObjectIf<
     inferEndpointInput<TRouter[TEndpoint]>,
     {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -34,8 +34,7 @@
   },
   "dependencies": {
     "@uploadthing/dropzone": "workspace:*",
-    "@uploadthing/shared": "workspace:*",
-    "tailwind-merge": "^2.2.1"
+    "@uploadthing/shared": "workspace:*"
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^3.1.1",

--- a/packages/svelte/src/lib/component/UploadButton.svelte
+++ b/packages/svelte/src/lib/component/UploadButton.svelte
@@ -12,14 +12,14 @@
   generics="TRouter extends FileRouter , TEndpoint extends keyof TRouter"
 >
   import { onMount } from "svelte";
-  import { twMerge } from "tailwind-merge";
 
   import {
     allowedContentTextLabelGenerator,
+    defaultClassListMerger,
     resolveMaybeUrlArg,
     styleFieldToClassName,
+    type StyleField,
   } from "@uploadthing/shared";
-  import type { StyleField } from "@uploadthing/shared";
   import {
     generateMimeTypes,
     generatePermittedFileTypes,
@@ -88,7 +88,11 @@
     },
   );
 
-  $: ({ mode = "auto", appendOnPaste = false } = uploader.config ?? {});
+  $: ({
+    mode = "auto",
+    appendOnPaste = false,
+    cn = defaultClassListMerger,
+  } = uploader.config ?? {});
   $: uploadProgress = __internal_upload_progress ?? uploadProgress;
   $: ({ fileTypes, multiple } = generatePermittedFileTypes(
     $permittedFileInfo?.config,
@@ -154,7 +158,7 @@ Example:
 ```
 -->
 <div
-  class={twMerge(
+  class={cn(
     "flex flex-col items-center justify-center gap-1",
     className,
     styleFieldToClassName(appearance?.container, styleFieldArg),
@@ -166,7 +170,7 @@ Example:
   <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
   <label
     bind:this={labelRef}
-    class={twMerge(
+    class={cn(
       "relative flex h-10 w-36 cursor-pointer items-center justify-center overflow-hidden rounded-md text-white after:transition-[width] after:duration-500",
       state === "readying" && "cursor-not-allowed bg-blue-400",
       state === "uploading" &&
@@ -227,7 +231,7 @@ Example:
           fileInputRef.value = "";
         }
       }}
-      class={twMerge(
+      class={cn(
         "h-[1.25rem] cursor-pointer rounded border-none bg-transparent text-gray-500 transition-colors hover:bg-slate-200 hover:text-gray-600",
         styleFieldToClassName(appearance?.clearBtn, styleFieldArg),
       )}
@@ -239,7 +243,7 @@ Example:
     </button>
   {:else}
     <div
-      class={twMerge(
+      class={cn(
         "h-[1.25rem]  text-xs leading-5 text-gray-600",
         styleFieldToClassName(appearance?.allowedContent, styleFieldArg),
       )}

--- a/packages/svelte/src/lib/component/UploadButton.svelte
+++ b/packages/svelte/src/lib/component/UploadButton.svelte
@@ -18,8 +18,8 @@
     defaultClassListMerger,
     resolveMaybeUrlArg,
     styleFieldToClassName,
-    type StyleField,
   } from "@uploadthing/shared";
+  import type { StyleField } from "@uploadthing/shared";
   import {
     generateMimeTypes,
     generatePermittedFileTypes,

--- a/packages/svelte/src/lib/component/UploadDropzone.svelte
+++ b/packages/svelte/src/lib/component/UploadDropzone.svelte
@@ -12,11 +12,12 @@
   generics="TRouter extends FileRouter, TEndpoint extends keyof TRouter"
 >
   import { onMount } from "svelte";
-  import { twMerge } from "tailwind-merge";
+
 
   import { createDropzone } from "@uploadthing/dropzone/svelte";
   import {
     allowedContentTextLabelGenerator,
+    defaultClassListMerger,
     resolveMaybeUrlArg,
     styleFieldToClassName,
   } from "@uploadthing/shared";
@@ -96,7 +97,7 @@
     },
   );
 
-  $: ({ mode = "auto", appendOnPaste = false } = uploader.config ?? {});
+  $: ({ mode = "auto", appendOnPaste = false, cn = defaultClassListMerger } = uploader.config ?? {});
   $: uploadProgress = __internal_upload_progress ?? uploadProgress;
   $: ({ fileTypes, multiple } = generatePermittedFileTypes(
     $permittedFileInfo?.config,
@@ -184,7 +185,7 @@
 
 <div
   use:dropzoneRoot
-  class={twMerge(
+  class={cn(
     "mt-2 flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-900/25 px-6 py-10 text-center",
     $dropzoneState.isDragActive && "bg-blue-600/10",
     className,
@@ -197,7 +198,7 @@
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 20 20"
-      class={twMerge(
+      class={cn(
         "mx-auto block h-12 w-12 align-middle text-gray-400",
         styleFieldToClassName(appearance?.uploadIcon, styleFieldArg),
       )}
@@ -214,7 +215,7 @@
     </svg>
   </slot>
   <label
-    class={twMerge(
+    class={cn(
       "relative mt-4 flex w-64 cursor-pointer items-center justify-center text-sm font-semibold leading-6 text-gray-600 focus-within:outline-none focus-within:ring-2 focus-within:ring-blue-600 focus-within:ring-offset-2 hover:text-blue-500",
       ready ? "text-blue-600" : "text-gray-500",
       styleFieldToClassName(appearance?.label, styleFieldArg),
@@ -229,7 +230,7 @@
     </slot>
   </label>
   <div
-    class={twMerge(
+    class={cn(
       "m-0 h-[1.25rem] text-xs leading-5 text-gray-600",
       styleFieldToClassName(appearance?.allowedContent, styleFieldArg),
     )}
@@ -242,7 +243,7 @@
     </slot>
   </div>
   <button
-    class={twMerge(
+    class={cn(
       "relative mt-4 flex h-10 w-36 items-center justify-center overflow-hidden rounded-md text-white after:transition-[width] after:duration-500",
       state === "readying" && "cursor-not-allowed bg-blue-400",
       state === "uploading" &&

--- a/packages/svelte/src/lib/types.ts
+++ b/packages/svelte/src/lib/types.ts
@@ -1,4 +1,5 @@
 import type {
+  ClassListMerger,
   ErrorMessage,
   ExtendObjectIf,
   UploadThingError,
@@ -92,6 +93,13 @@ export type UploadthingComponentProps<
   config?: {
     mode?: "auto" | "manual";
     appendOnPaste?: boolean;
+    /**
+     * Override the default class name merger, with e.g. tailwind-merge
+     * This may be required if you're customizing the component
+     * appearance with additional TailwindCSS classes to ensure
+     * classes are sorted and applied in the correct order
+     */
+    cn?: ClassListMerger;
   };
 } & ExtendObjectIf<
     inferEndpointInput<TRouter[TEndpoint]>,

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -42,9 +42,7 @@
   "dependencies": {
     "@uploadthing/dropzone": "workspace:*",
     "@uploadthing/shared": "workspace:*",
-    "@vueuse/core": "^10.9.0",
-    "file-selector": "^0.6.0",
-    "tailwind-merge": "^2.2.1"
+    "@vueuse/core": "^10.9.0"
   },
   "devDependencies": {
     "@uploadthing/eslint-config": "workspace:*",

--- a/packages/vue/src/components/button.tsx
+++ b/packages/vue/src/components/button.tsx
@@ -1,11 +1,10 @@
-import { twMerge } from "tailwind-merge";
 import * as Vue from "vue";
 import { computed, reactive, ref } from "vue";
 
-import type { ContentField, StyleField } from "@uploadthing/shared";
 import {
   allowedContentTextLabelGenerator,
   contentFieldToContent,
+  defaultClassListMerger,
   generateMimeTypes,
   generatePermittedFileTypes,
   getFilesFromClipboardEvent,
@@ -13,6 +12,7 @@ import {
   styleFieldToClassName,
   styleFieldToCssObject,
 } from "@uploadthing/shared";
+import type { ContentField, StyleField } from "@uploadthing/shared";
 import type { FileRouter } from "uploadthing/server";
 
 import type {
@@ -75,7 +75,11 @@ export const generateUploadButton = <TRouter extends FileRouter>(
     }) => {
       const $props = props.config;
 
-      const { mode = "auto", appendOnPaste = false } = $props.config ?? {};
+      const {
+        mode = "auto",
+        appendOnPaste = false,
+        cn = defaultClassListMerger,
+      } = $props.config ?? {};
 
       const fileInputRef = ref<HTMLInputElement | null>(null);
       const uploadProgress = ref(0);
@@ -201,7 +205,7 @@ export const generateUploadButton = <TRouter extends FileRouter>(
               fileInputRef.value.value = "";
             }
           }}
-          class={twMerge(
+          class={cn(
             "h-[1.25rem] cursor-pointer rounded border-none bg-transparent text-gray-500 transition-colors hover:bg-slate-200 hover:text-gray-600",
             styleFieldToClassName(
               $props.appearance?.clearBtn,
@@ -224,7 +228,7 @@ export const generateUploadButton = <TRouter extends FileRouter>(
 
       const renderAllowedContent = () => (
         <div
-          class={twMerge(
+          class={cn(
             "h-[1.25rem] text-xs leading-5 text-gray-600",
             styleFieldToClassName(
               $props.appearance?.allowedContent,
@@ -247,7 +251,7 @@ export const generateUploadButton = <TRouter extends FileRouter>(
       );
 
       const labelClass = computed(() =>
-        twMerge(
+        cn(
           "relative flex h-10 w-36 cursor-pointer items-center justify-center overflow-hidden rounded-md text-white after:transition-[width] after:duration-500 focus-within:ring-2 focus-within:ring-blue-600 focus-within:ring-offset-2",
           state.value === "readying" && "cursor-not-allowed bg-blue-400",
           state.value === "uploading" &&
@@ -259,7 +263,7 @@ export const generateUploadButton = <TRouter extends FileRouter>(
         ),
       );
       const containerClass = computed(() =>
-        twMerge(
+        cn(
           "flex flex-col items-center justify-center gap-1",
           $props.class,
           styleFieldToClassName(

--- a/packages/vue/src/components/dropzone.tsx
+++ b/packages/vue/src/components/dropzone.tsx
@@ -1,4 +1,3 @@
-import { twMerge } from "tailwind-merge";
 import * as Vue from "vue";
 import { computed, reactive, ref, watch } from "vue";
 
@@ -8,6 +7,7 @@ import type { ContentField, StyleField } from "@uploadthing/shared";
 import {
   allowedContentTextLabelGenerator,
   contentFieldToContent,
+  defaultClassListMerger,
   generateClientDropzoneAccept,
   generatePermittedFileTypes,
   getFilesFromClipboardEvent,
@@ -86,7 +86,11 @@ export const generateUploadDropzone = <TRouter extends FileRouter>(
     }) => {
       const $props = props.config;
 
-      const { mode = "auto", appendOnPaste = false } = $props.config ?? {};
+      const {
+        mode = "auto",
+        appendOnPaste = false,
+        cn = defaultClassListMerger,
+      } = $props.config ?? {};
 
       const files = ref<File[]>([]);
       const uploadProgress = ref(0);
@@ -197,7 +201,7 @@ export const generateUploadDropzone = <TRouter extends FileRouter>(
           <svg
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 20 20"
-            class={twMerge(
+            class={cn(
               "mx-auto block h-12 w-12 align-middle text-gray-400",
               styleFieldToClassName(
                 $props.appearance?.uploadIcon,
@@ -273,7 +277,7 @@ export const generateUploadDropzone = <TRouter extends FileRouter>(
       });
 
       const containerClass = computed(() =>
-        twMerge(
+        cn(
           "mt-2 flex flex-col items-center justify-center rounded-lg border border-dashed border-gray-900/25 px-6 py-10 text-center",
           isDragActive.value && "bg-blue-600/10",
           $props.class,
@@ -284,14 +288,14 @@ export const generateUploadDropzone = <TRouter extends FileRouter>(
         ),
       );
       const labelClass = computed(() =>
-        twMerge(
+        cn(
           "relative mt-4 flex w-64 cursor-pointer items-center justify-center text-sm font-semibold leading-6 text-gray-600 focus-within:outline-none focus-within:ring-2 focus-within:ring-blue-600 focus-within:ring-offset-2 hover:text-blue-500",
           state.value === "ready" ? "text-blue-600" : "text-gray-500",
           styleFieldToClassName($props.appearance?.label, styleFieldArg.value),
         ),
       );
       const allowedContentClass = computed(() =>
-        twMerge(
+        cn(
           "m-0 h-[1.25rem] text-xs leading-5 text-gray-600",
           styleFieldToClassName(
             $props.appearance?.allowedContent,
@@ -300,7 +304,7 @@ export const generateUploadDropzone = <TRouter extends FileRouter>(
         ),
       );
       const buttonClass = computed(() =>
-        twMerge(
+        cn(
           "relative mt-4 flex h-10 w-36 cursor-pointer items-center justify-center overflow-hidden rounded-md border-none text-base text-white after:transition-[width] after:duration-500 focus-within:ring-2 focus-within:ring-blue-600 focus-within:ring-offset-2",
           state.value === "readying" && "cursor-not-allowed bg-blue-400",
           state.value === "uploading" &&

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -1,4 +1,5 @@
 import type {
+  ClassListMerger,
   ErrorMessage,
   ExtendObjectIf,
   MaybePromise,
@@ -92,6 +93,13 @@ export type UploadthingComponentProps<
   config?: {
     mode?: "auto" | "manual";
     appendOnPaste?: boolean;
+    /**
+     * Override the default class name merger, with e.g. tailwind-merge
+     * This may be required if you're customizing the component
+     * appearance with additional TailwindCSS classes to ensure
+     * classes are sorted and applied in the correct order
+     */
+    cn?: ClassListMerger;
   };
 } & ExtendObjectIf<
     inferEndpointInput<TRouter[TEndpoint]>,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,7 +397,7 @@ importers:
         version: 6.3.1(expo@51.0.9(@babel/core@7.24.4)(@babel/preset-env@7.24.6(@babel/core@7.24.4))(encoding@0.1.13))
       expo-router:
         specifier: ~3.5.9
-        version: 3.5.14(encoding@0.1.13)(expo-constants@16.0.2(expo@51.0.9(@babel/core@7.24.4)(@babel/preset-env@7.24.6(@babel/core@7.24.4))(encoding@0.1.13)))(expo-linking@6.3.1(expo@51.0.9(@babel/core@7.24.4)(@babel/preset-env@7.24.6(@babel/core@7.24.4))(encoding@0.1.13)))(expo-modules-autolinking@1.11.1)(expo-status-bar@1.12.1)(expo@51.0.9(@babel/core@7.24.4)(@babel/preset-env@7.24.6(@babel/core@7.24.4))(encoding@0.1.13))(react-native-reanimated@3.10.1(@babel/core@7.24.4)(react-native@0.74.1(@babel/core@7.24.4)(@babel/preset-env@7.24.6(@babel/core@7.24.4))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.4)(@babel/preset-env@7.24.6(@babel/core@7.24.4))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.4)(@babel/preset-env@7.24.6(@babel/core@7.24.4))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.74.1(@babel/core@7.24.4)(@babel/preset-env@7.24.6(@babel/core@7.24.4))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)(typescript@5.5.2)
+        version: 3.5.14(ykzuma3rk5zuqux2u6h3kzlmui)
       expo-splash-screen:
         specifier: ~0.27.4
         version: 0.27.4(encoding@0.1.13)(expo-modules-autolinking@1.11.1)(expo@51.0.9(@babel/core@7.24.4)(@babel/preset-env@7.24.6(@babel/core@7.24.4))(encoding@0.1.13))
@@ -1239,12 +1239,6 @@ importers:
       '@uploadthing/shared':
         specifier: workspace:*
         version: link:../shared
-      file-selector:
-        specifier: ^0.6.0
-        version: 0.6.0
-      tailwind-merge:
-        specifier: ^2.2.1
-        version: 2.3.0
     devDependencies:
       '@types/node':
         specifier: ^20.14.0
@@ -1340,9 +1334,6 @@ importers:
       '@uploadthing/shared':
         specifier: workspace:*
         version: link:../shared
-      tailwind-merge:
-        specifier: ^2.2.1
-        version: 2.3.0
     devDependencies:
       postcss:
         specifier: 8.4.38
@@ -1377,9 +1368,6 @@ importers:
       '@uploadthing/shared':
         specifier: workspace:*
         version: link:../shared
-      tailwind-merge:
-        specifier: ^2.2.1
-        version: 2.3.0
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^3.1.1
@@ -1523,12 +1511,6 @@ importers:
       '@vueuse/core':
         specifier: ^10.9.0
         version: 10.9.0(vue@3.4.25(typescript@5.5.2))
-      file-selector:
-        specifier: ^0.6.0
-        version: 0.6.0
-      tailwind-merge:
-        specifier: ^2.2.1
-        version: 2.3.0
     devDependencies:
       '@uploadthing/eslint-config':
         specifier: workspace:*
@@ -20102,7 +20084,7 @@ snapshots:
       lodash: 4.17.21
       prettier: 3.3.2
       recast: 0.23.9
-      tiny-invariant: 1.3.1
+      tiny-invariant: 1.3.3
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -24266,8 +24248,8 @@ snapshots:
     dependencies:
       invariant: 2.2.4
 
-  ? expo-router@3.5.14(encoding@0.1.13)(expo-constants@16.0.2(expo@51.0.9(@babel/core@7.24.4)(@babel/preset-env@7.24.6(@babel/core@7.24.4))(encoding@0.1.13)))(expo-linking@6.3.1(expo@51.0.9(@babel/core@7.24.4)(@babel/preset-env@7.24.6(@babel/core@7.24.4))(encoding@0.1.13)))(expo-modules-autolinking@1.11.1)(expo-status-bar@1.12.1)(expo@51.0.9(@babel/core@7.24.4)(@babel/preset-env@7.24.6(@babel/core@7.24.4))(encoding@0.1.13))(react-native-reanimated@3.10.1(@babel/core@7.24.4)(react-native@0.74.1(@babel/core@7.24.4)(@babel/preset-env@7.24.6(@babel/core@7.24.4))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@4.10.1(react-native@0.74.1(@babel/core@7.24.4)(@babel/preset-env@7.24.6(@babel/core@7.24.4))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native-screens@3.31.1(react-native@0.74.1(@babel/core@7.24.4)(@babel/preset-env@7.24.6(@babel/core@7.24.4))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))(react@18.3.1))(react-native@0.74.1(@babel/core@7.24.4)(@babel/preset-env@7.24.6(@babel/core@7.24.4))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)(typescript@5.5.2)
-  : dependencies:
+  expo-router@3.5.14(ykzuma3rk5zuqux2u6h3kzlmui):
+    dependencies:
       '@expo/metro-runtime': 3.2.1(react-native@0.74.1(@babel/core@7.24.4)(@babel/preset-env@7.24.6(@babel/core@7.24.4))(@types/react@18.3.3)(encoding@0.1.13)(react@18.3.1))
       '@expo/server': 0.4.2(typescript@5.5.2)
       '@radix-ui/react-slot': 1.0.1(react@18.3.1)
@@ -25853,7 +25835,7 @@ snapshots:
       micromatch: 4.0.5
       neo-async: 2.6.2
       node-dir: 0.1.17
-      recast: 0.23.4
+      recast: 0.23.9
       temp: 0.8.4
       write-file-atomic: 2.4.3
     optionalDependencies:
@@ -30524,7 +30506,7 @@ snapshots:
       semver: 7.6.2
       strip-json-comments: 3.1.1
       tempy: 3.1.0
-      tiny-invariant: 1.3.1
+      tiny-invariant: 1.3.3
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@babel/preset-env'


### PR DESCRIPTION
tailwind-merge is [20kb (7kB gzipped)](https://bundlejs.com/?q=tailwind-merge&treeshake=%5B%7B+twMerge+%7D%5D) that not everyone benefits from. It is only useful for folks applying additional tailwind classes when [theming using TailwindCSS](https://uploadthing-docs-twui.vercel.app/concepts/theming#theming-with-tailwind-css). They can thus provide us the merge function themselves.

This will:
- reduce client bundle by 7kB by default for everyone not using tailwind customizations
- reduce risk of duplicating tailwind-merge in projects already using it, in the case of a version range mismatch
- reduce package dependencies (if that counts as something positive :))

```tsx
import { twMerge } from "tailwind-merge"

<UploadButton 
  classList="bg-red-500"
  cn={twMerge}
/>
```