### PR TITLE
fix: docsearch

### DIFF
--- a/docs/src/mdx/search.js
+++ b/docs/src/mdx/search.js
@@ -71,6 +71,11 @@ export default function withSearch(nextConfig = {}) {
                   .replaceAll(/\(.+\)/g, "")
                   // Remove `page.msx`
                   .replace(/(^|\/)page\.mdx$/, "");
+
+              // Remove double slashes that might have occured from removing route groups
+              url = url.replaceAll(/\/\/+/g, "/");
+
+              console.log("search url", { file, url });
               let mdx = fs.readFileSync(path.join(appDir, file), "utf8");
 
               let sections = [];

--- a/docs/src/mdx/search.js
+++ b/docs/src/mdx/search.js
@@ -75,7 +75,6 @@ export default function withSearch(nextConfig = {}) {
               // Remove double slashes that might have occured from removing route groups
               url = url.replaceAll(/\/\/+/g, "/");
 
-              console.log("search url", { file, url });
               let mdx = fs.readFileSync(path.join(appDir, file), "utf8");
 
               let sections = [];


### PR DESCRIPTION
remove consecutive slashes leading to invalid URLs from search results