### PR TITLE
fix: nextjs pages adapter response body

### DIFF
--- a/.changeset/cuddly-pets-jog.md
+++ b/.changeset/cuddly-pets-jog.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+fix: nextjs pages adapter response body regression

--- a/packages/uploadthing/src/next-legacy.ts
+++ b/packages/uploadthing/src/next-legacy.ts
@@ -34,6 +34,7 @@ export const createRouteHandler = <TRouter extends FileRouter>(
 
   return async (req: NextApiRequest, res: NextApiResponse) => {
     const response = await handler(req, res);
+    res.status(response.status);
     for (const [name, value] of response.headers) {
       res.setHeader(name, value);
     }

--- a/packages/uploadthing/src/next-legacy.ts
+++ b/packages/uploadthing/src/next-legacy.ts
@@ -34,10 +34,9 @@ export const createRouteHandler = <TRouter extends FileRouter>(
 
   return async (req: NextApiRequest, res: NextApiResponse) => {
     const response = await handler(req, res);
-    res.status(response.status);
     for (const [name, value] of response.headers) {
       res.setHeader(name, value);
     }
-    return res.json(response.body);
+    return res.json(await response.json());
   };
 };

--- a/packages/uploadthing/src/next-legacy.ts
+++ b/packages/uploadthing/src/next-legacy.ts
@@ -37,6 +37,7 @@ export const createRouteHandler = <TRouter extends FileRouter>(
     for (const [name, value] of response.headers) {
       res.setHeader(name, value);
     }
+    // FIXME: Should be able to just forward it instead of consuming it first
     return res.json(await response.json());
   };
 };

--- a/packages/uploadthing/test/adapters.test.ts
+++ b/packages/uploadthing/test/adapters.test.ts
@@ -356,18 +356,7 @@ describe("adapters:next-legacy", async () => {
 
     // Should proceed to generate a signed URL
     const resJson = (json.mock.calls[0] as any[])[0];
-    const reader = (resJson as ReadableStream).getReader();
-    let data = "";
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
-        break;
-      }
-      data += new TextDecoder().decode(value);
-    }
-    const jsonData = JSON.parse(data);
-    expect(jsonData).toEqual([
+    expect(resJson).toEqual([
       {
         customId: null,
         key: expect.stringMatching(/.+/),
@@ -382,7 +371,7 @@ describe("adapters:next-legacy", async () => {
       body: {
         isDev: false,
         awaitServerData: true,
-        fileKeys: [jsonData[0]?.key],
+        fileKeys: [resJson[0]?.key],
         metadata: {},
         callbackUrl: "http://localhost:3000/",
         callbackSlug: "middleware",


### PR DESCRIPTION
`res.json(response.body)` resulted in `{}`.

couldn't find a way to forward the stream as-is, so consuming it and sending it down as JSON as a temporary workaround