### PR TITLE
feat: composable primitive components

### DIFF
--- a/examples/minimal-appdir/next-env.d.ts
+++ b/examples/minimal-appdir/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/examples/minimal-appdir/src/app/page.tsx
+++ b/examples/minimal-appdir/src/app/page.tsx
@@ -4,6 +4,7 @@ import {
   UploadButton,
   UploadDropzone,
   useUploadThing,
+  UT,
 } from "~/utils/uploadthing";
 
 export default function Home() {
@@ -70,6 +71,19 @@ export default function Home() {
           await startUpload(files);
         }}
       />
+      <UT.Root endpoint="videoAndImage">
+        <UT.Dropzone>
+          {({ dropzone, isUploading }) => (
+            <>
+              <UT.Button>{isUploading ? "Uploading" : "Upload file"}</UT.Button>
+              <div>
+                <UT.AllowedContent />
+              </div>
+              {dropzone?.isDragActive && <span>Dragging</span>}
+            </>
+          )}
+        </UT.Dropzone>
+      </UT.Root>
     </main>
   );
 }

--- a/examples/minimal-appdir/src/utils/uploadthing.ts
+++ b/examples/minimal-appdir/src/utils/uploadthing.ts
@@ -2,11 +2,13 @@ import {
   generateReactHelpers,
   generateUploadButton,
   generateUploadDropzone,
+  generateUploadPrimitives,
 } from "@uploadthing/react";
 
 import type { OurFileRouter } from "~/server/uploadthing";
 
 export const UploadButton = generateUploadButton<OurFileRouter>();
 export const UploadDropzone = generateUploadDropzone<OurFileRouter>();
+export const UT = generateUploadPrimitives<OurFileRouter>();
 
 export const { useUploadThing } = generateReactHelpers<OurFileRouter>();

--- a/examples/minimal-pagedir/src/pages/index.tsx
+++ b/examples/minimal-pagedir/src/pages/index.tsx
@@ -2,6 +2,7 @@ import {
   UploadButton,
   UploadDropzone,
   useUploadThing,
+  UT,
 } from "~/utils/uploadthing";
 
 export default function Home() {
@@ -54,6 +55,19 @@ export default function Home() {
           await startUpload([file]);
         }}
       />
+      <UT.Root endpoint="videoAndImage">
+        <UT.Dropzone>
+          {({ dropzone, isUploading }) => (
+            <>
+              <UT.Button>{isUploading ? "Uploading" : "Upload file"}</UT.Button>
+              <div>
+                <UT.AllowedContent />
+              </div>
+              {dropzone?.isDragActive && <span>Dragging</span>}
+            </>
+          )}
+        </UT.Dropzone>
+      </UT.Root>
     </main>
   );
 }

--- a/examples/minimal-pagedir/src/utils/uploadthing.ts
+++ b/examples/minimal-pagedir/src/utils/uploadthing.ts
@@ -2,11 +2,13 @@ import {
   generateReactHelpers,
   generateUploadButton,
   generateUploadDropzone,
+  generateUploadPrimitives,
 } from "@uploadthing/react";
 
 import type { OurFileRouter } from "~/server/uploadthing";
 
 export const UploadButton = generateUploadButton<OurFileRouter>();
 export const UploadDropzone = generateUploadDropzone<OurFileRouter>();
+export const UT = generateUploadPrimitives<OurFileRouter>();
 
 export const { useUploadThing } = generateReactHelpers<OurFileRouter>();

--- a/examples/with-clerk-appdir/src/app/page.tsx
+++ b/examples/with-clerk-appdir/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { SignIn, useAuth } from "@clerk/nextjs";
 
-import { UploadButton, UploadDropzone } from "~/utils/uploadthing";
+import { UploadButton, UploadDropzone, UT } from "~/utils/uploadthing";
 
 export default function Home() {
   const { isSignedIn } = useAuth();
@@ -35,6 +35,19 @@ export default function Home() {
           console.log("upload begin");
         }}
       />
+      <UT.Root endpoint="videoAndImage">
+        <UT.Dropzone>
+          {({ dropzone, isUploading }) => (
+            <>
+              <UT.Button>{isUploading ? "Uploading" : "Upload file"}</UT.Button>
+              <div>
+                <UT.AllowedContent />
+              </div>
+              {dropzone?.isDragActive && <span>Dragging</span>}
+            </>
+          )}
+        </UT.Dropzone>
+      </UT.Root>
       {!isSignedIn ? (
         <div
           style={{

--- a/examples/with-clerk-appdir/src/utils/uploadthing.ts
+++ b/examples/with-clerk-appdir/src/utils/uploadthing.ts
@@ -2,11 +2,13 @@ import {
   generateReactHelpers,
   generateUploadButton,
   generateUploadDropzone,
+  generateUploadPrimitives,
 } from "@uploadthing/react";
 
 import type { OurFileRouter } from "~/server/uploadthing";
 
 export const UploadButton = generateUploadButton<OurFileRouter>();
 export const UploadDropzone = generateUploadDropzone<OurFileRouter>();
+export const UT = generateUploadPrimitives<OurFileRouter>();
 
 export const { useUploadThing } = generateReactHelpers<OurFileRouter>();

--- a/examples/with-clerk-pagesdir/src/pages/index.tsx
+++ b/examples/with-clerk-pagesdir/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import { Inter } from "next/font/google";
 import { SignIn, useAuth } from "@clerk/nextjs";
 
-import { UploadButton, UploadDropzone } from "~/utils/uploadthing";
+import { UploadButton, UploadDropzone, UT } from "~/utils/uploadthing";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -36,6 +36,19 @@ export default function Home() {
           console.log("upload begin");
         }}
       />
+      <UT.Root endpoint="videoAndImage">
+        <UT.Dropzone>
+          {({ dropzone, isUploading }) => (
+            <>
+              <UT.Button>{isUploading ? "Uploading" : "Upload file"}</UT.Button>
+              <div>
+                <UT.AllowedContent />
+              </div>
+              {dropzone?.isDragActive && <span>Dragging</span>}
+            </>
+          )}
+        </UT.Dropzone>
+      </UT.Root>
       {!isSignedIn ? (
         <div
           style={{

--- a/examples/with-clerk-pagesdir/src/utils/uploadthing.ts
+++ b/examples/with-clerk-pagesdir/src/utils/uploadthing.ts
@@ -2,11 +2,13 @@ import {
   generateReactHelpers,
   generateUploadButton,
   generateUploadDropzone,
+  generateUploadPrimitives,
 } from "@uploadthing/react";
 
 import type { OurFileRouter } from "~/server/uploadthing";
 
 export const UploadButton = generateUploadButton<OurFileRouter>();
 export const UploadDropzone = generateUploadDropzone<OurFileRouter>();
+export const UT = generateUploadPrimitives<OurFileRouter>();
 
 export const { useUploadThing } = generateReactHelpers<OurFileRouter>();

--- a/packages/react/src/components/index.tsx
+++ b/packages/react/src/components/index.tsx
@@ -9,6 +9,8 @@ import type { UploadButtonProps } from "./button";
 import { UploadButton } from "./button";
 import type { UploadDropzoneProps } from "./dropzone";
 import { UploadDropzone } from "./dropzone";
+import * as primitives from "./primitive";
+import { RootPrimitiveComponentProps } from "./primitive/root";
 import { Uploader } from "./uploader";
 
 export { UploadButton, UploadDropzone, Uploader };
@@ -39,6 +41,20 @@ export const generateUploadDropzone = <TRouter extends FileRouter>(
     >,
   ) => <UploadDropzone<TRouter, TEndpoint> {...(props as any)} url={url} />;
   return TypedDropzone;
+};
+
+export const generateUploadPrimitives = <TRouter extends FileRouter>(
+  opts?: GenerateTypedHelpersOptions,
+) => {
+  const url = resolveMaybeUrlArg(opts?.url);
+
+  const TypedUploadRoot = <TEndpoint extends keyof TRouter>(
+    props: Omit<
+      RootPrimitiveComponentProps<TRouter, TEndpoint>,
+      keyof GenerateTypedHelpersOptions
+    >,
+  ) => <primitives.Root<TRouter, TEndpoint> {...(props as any)} url={url} />;
+  return { ...primitives, Root: TypedUploadRoot };
 };
 
 export const generateUploader = <TRouter extends FileRouter>(

--- a/packages/react/src/components/primitive/allowed-content.tsx
+++ b/packages/react/src/components/primitive/allowed-content.tsx
@@ -1,0 +1,18 @@
+import { allowedContentTextLabelGenerator } from "@uploadthing/shared";
+
+import {
+  PrimitiveComponentChildrenProp,
+  PrimitiveSlot,
+  usePrimitiveValues,
+} from "./root";
+
+export function AllowedContent(props: PrimitiveComponentChildrenProp) {
+  const { routeConfig } = usePrimitiveValues("AllowedContent");
+
+  return (
+    <PrimitiveSlot
+      default={allowedContentTextLabelGenerator(routeConfig)}
+      children={props.children}
+    />
+  );
+}

--- a/packages/react/src/components/primitive/button.tsx
+++ b/packages/react/src/components/primitive/button.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import {
+  PrimitiveComponentProps,
+  PrimitiveSlot,
+  usePrimitiveValues,
+} from "./root";
+
+export function Button({
+  children,
+  onClick,
+  ...props
+}: PrimitiveComponentProps<"label">) {
+  const {
+    refs,
+    disabled,
+    setFiles,
+    dropzone,
+    accept,
+    state,
+    files,
+    abortUpload,
+    options,
+    uploadFiles,
+  } = usePrimitiveValues("Button");
+
+  return (
+    <label
+      {...props}
+      data-state={state}
+      onClick={(e) => {
+        onClick?.(e);
+        if (state === "uploading") {
+          e.preventDefault();
+          e.stopPropagation();
+          abortUpload();
+          return;
+        }
+        if (options.mode === "manual" && files.length > 0) {
+          e.preventDefault();
+          e.stopPropagation();
+
+          uploadFiles();
+        }
+      }}
+    >
+      <PrimitiveSlot>{children}</PrimitiveSlot>
+      {!dropzone && (
+        <input
+          type="file"
+          ref={refs.fileInputRef}
+          multiple={options.multiple}
+          accept={accept}
+          onChange={(e) => {
+            if (!e.target.files) return;
+            setFiles(Array.from(e.target.files));
+          }}
+          disabled={disabled}
+          tabIndex={disabled ? -1 : 0}
+          className="sr-only"
+        />
+      )}
+    </label>
+  );
+}

--- a/packages/react/src/components/primitive/dropzone.tsx
+++ b/packages/react/src/components/primitive/dropzone.tsx
@@ -1,0 +1,40 @@
+import { useDropzone } from "@uploadthing/dropzone/react";
+import { generateClientDropzoneAccept } from "@uploadthing/shared";
+
+import {
+  PrimitiveComponentProps,
+  PrimitiveContextMergeProvider,
+  PrimitiveSlot,
+  usePrimitiveValues,
+} from "./root";
+
+export function Dropzone({
+  children,
+  ...props
+}: PrimitiveComponentProps<"div">) {
+  const { setFiles, options, fileTypes, disabled, state, refs } =
+    usePrimitiveValues("Dropzone");
+
+  const { getRootProps, getInputProps, isDragActive, rootRef } = useDropzone({
+    onDrop: setFiles,
+    multiple: options.multiple,
+    accept: fileTypes ? generateClientDropzoneAccept(fileTypes) : undefined,
+    disabled,
+  });
+
+  refs.focusElementRef = rootRef;
+
+  return (
+    <PrimitiveContextMergeProvider value={{ dropzone: { isDragActive } }}>
+      <div
+        {...getRootProps()}
+        data-drag-active={isDragActive || undefined}
+        data-state={state}
+        {...props}
+      >
+        <PrimitiveSlot>{children}</PrimitiveSlot>
+        <input type="hidden" {...getInputProps()} />
+      </div>
+    </PrimitiveContextMergeProvider>
+  );
+}

--- a/packages/react/src/components/primitive/index.tsx
+++ b/packages/react/src/components/primitive/index.tsx
@@ -1,0 +1,4 @@
+export { Root } from "./root";
+export { Button } from "./button";
+export { Dropzone } from "./dropzone";
+export { AllowedContent } from "./allowed-content";

--- a/packages/react/src/components/primitive/root.tsx
+++ b/packages/react/src/components/primitive/root.tsx
@@ -1,0 +1,302 @@
+import {
+  createContext,
+  ElementType,
+  ProviderProps,
+  RefObject,
+  useCallback,
+  useContext,
+  useRef,
+  useState,
+} from "react";
+
+import {
+  generateMimeTypes,
+  generatePermittedFileTypes,
+  getFilesFromClipboardEvent,
+  resolveMaybeUrlArg,
+  UploadAbortedError,
+} from "@uploadthing/shared";
+import type {
+  ErrorMessage,
+  ExpandedRouteConfig,
+  FileRouterInputKey,
+} from "@uploadthing/shared";
+import type { FileRouter } from "uploadthing/types";
+
+import type { UploadthingComponentProps } from "../../types";
+import { INTERNAL_uploadthingHookGen } from "../../useUploadThing";
+import { usePaste } from "../../utils/usePaste";
+
+type PrimitiveContextValues = {
+  state: "readying" | "ready" | "uploading" | "disabled";
+
+  disabled: boolean;
+  isUploading: boolean;
+  ready: boolean;
+
+  files: File[];
+  fileTypes: FileRouterInputKey[];
+  accept: string;
+
+  /**
+   * @remarks If the mode is set to 'auto' this function will upload the files too
+   */
+  setFiles: (_: File[]) => void;
+
+  /**
+   * Uploads the selected files
+   * @remarks If the mode is set to 'auto', there is no need to call this function
+   */
+  uploadFiles: () => void;
+
+  abortUpload: () => void;
+
+  routeConfig: ExpandedRouteConfig | undefined;
+
+  uploadProgress: number;
+
+  options: {
+    mode: "auto" | "manual";
+    multiple: boolean;
+  };
+
+  refs: {
+    focusElementRef: RefObject<HTMLElement>;
+    fileInputRef: RefObject<HTMLInputElement>;
+  };
+
+  /**
+   * @remarks This will be only defined when nested in a <Dropzone>
+   */
+  dropzone?: {
+    isDragActive: boolean;
+  };
+};
+
+const PrimitiveContext = createContext<PrimitiveContextValues | null>(null);
+
+export function PrimitiveContextMergeProvider({
+  value,
+  ...props
+}: ProviderProps<Partial<PrimitiveContextValues>>) {
+  const currentValue = useContext(PrimitiveContext);
+
+  if (currentValue === null) {
+    throw new Error(
+      "<PrimitiveContextMergeProvider> must be used within a <UT.Root>",
+    );
+  }
+
+  return (
+    <PrimitiveContext.Provider
+      value={{ ...currentValue, ...value }}
+      {...props}
+    />
+  );
+}
+
+export function usePrimitiveValues(componentName?: string) {
+  const values = useContext(PrimitiveContext);
+  if (values === null) {
+    const name = componentName ? "usePrimitiveValues" : `<UT.${componentName}>`;
+    throw new Error(`${name} must be used within a <UT.Root>`);
+  }
+  return values;
+}
+
+export function usePrimitiveChildren(
+  children: PrimitiveComponentChildren,
+  componentName: string,
+) {
+  return typeof children === "function"
+    ? children?.(usePrimitiveValues(componentName))
+    : children;
+}
+
+export function PrimitiveSlot({
+  children,
+  componentName,
+  default: defaultChildren,
+}: {
+  children: PrimitiveComponentChildren;
+  componentName?: string;
+  default?: React.ReactNode;
+}) {
+  if (!children) return defaultChildren;
+  return typeof children === "function"
+    ? children?.(usePrimitiveValues(componentName))
+    : children;
+}
+
+export type PrimitiveComponentProps<T extends ElementType = "div"> = Omit<
+  React.ComponentPropsWithRef<T>,
+  "children"
+> &
+  PrimitiveComponentChildrenProp;
+
+export type PrimitiveComponentChildrenProp = {
+  children?: PrimitiveComponentChildren;
+};
+
+export type PrimitiveComponentChildren =
+  | ((values: PrimitiveContextValues) => React.ReactNode)
+  | React.ReactNode;
+
+/** These are some internal stuff we use to test the component and for forcing a state in docs */
+type UploadThingInternalProps = {
+  __internal_state?: "readying" | "ready" | "uploading";
+  __internal_upload_progress?: number;
+  __internal_button_disabled?: boolean;
+};
+
+export type RootPrimitiveComponentProps<
+  TRouter extends FileRouter,
+  TEndpoint extends keyof TRouter,
+> = UploadthingComponentProps<TRouter, TEndpoint> & {
+  // TODO: add @see comment for docs
+  children?: PrimitiveComponentChildren;
+};
+
+export function Root<
+  TRouter extends FileRouter,
+  TEndpoint extends keyof TRouter,
+>(
+  props: FileRouter extends TRouter
+    ? ErrorMessage<"You forgot to pass the generic">
+    : RootPrimitiveComponentProps<TRouter, TEndpoint>,
+) {
+  // Cast back to UploadthingComponentProps<TRouter> to get the correct type
+  // since the ErrorMessage messes it up otherwise
+  const $props = props as unknown as RootPrimitiveComponentProps<
+    TRouter,
+    TEndpoint
+  > &
+    UploadThingInternalProps;
+
+  const fileRouteInput = "input" in $props ? $props.input : undefined;
+
+  const { mode = "auto", appendOnPaste = false } = $props.config ?? {};
+  const acRef = useRef(new AbortController());
+
+  const useUploadThing = INTERNAL_uploadthingHookGen<TRouter>({
+    url: resolveMaybeUrlArg($props.url),
+  });
+
+  const focusElementRef = useRef<HTMLElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploadProgress, setUploadProgress] = useState(
+    $props.__internal_upload_progress ?? 0,
+  );
+  const [files, setFiles] = useState<File[]>([]);
+
+  const { startUpload, isUploading, routeConfig } = useUploadThing(
+    $props.endpoint,
+    {
+      signal: acRef.current.signal,
+      headers: $props.headers,
+      onClientUploadComplete: (res) => {
+        if (fileInputRef.current) {
+          fileInputRef.current.value = "";
+        }
+        setFiles([]);
+        void $props.onClientUploadComplete?.(res);
+        setUploadProgress(0);
+      },
+      onUploadProgress: (p) => {
+        setUploadProgress(p);
+        $props.onUploadProgress?.(p);
+      },
+      onUploadError: $props.onUploadError,
+      onUploadBegin: $props.onUploadBegin,
+      onBeforeUploadBegin: $props.onBeforeUploadBegin,
+    },
+  );
+
+  const uploadFiles = useCallback(
+    (files: File[]) => {
+      startUpload(files, fileRouteInput).catch((e) => {
+        if (e instanceof UploadAbortedError) {
+          void $props.onUploadAborted?.();
+        } else {
+          throw e;
+        }
+      });
+    },
+    [$props, startUpload, fileRouteInput],
+  );
+
+  const { fileTypes, multiple } = generatePermittedFileTypes(routeConfig);
+
+  let disabled = fileTypes.length === 0;
+  if ($props.disabled) disabled = true;
+  if ($props.__internal_button_disabled) disabled = true;
+
+  const accept = generateMimeTypes(fileTypes).join(", ");
+
+  const state = (() => {
+    if ($props.__internal_state) return $props.__internal_state;
+    if (disabled) return "disabled";
+    if (!disabled && !isUploading) return "ready";
+    return "uploading";
+  })();
+
+  usePaste((event) => {
+    if (!appendOnPaste) return;
+    const ref = focusElementRef.current || fileInputRef.current;
+
+    if (document.activeElement !== ref) return;
+
+    const pastedFiles = getFilesFromClipboardEvent(event);
+    if (!pastedFiles) return;
+
+    let filesToUpload = pastedFiles;
+    setFiles((prev) => {
+      filesToUpload = [...prev, ...pastedFiles];
+
+      $props.onChange?.(filesToUpload);
+
+      return filesToUpload;
+    });
+
+    if (mode === "auto") void uploadFiles(files);
+  });
+
+  const primitiveValues: PrimitiveContextValues = {
+    files,
+    setFiles: (files) => {
+      setFiles(files);
+      $props.onChange?.(files);
+
+      if (mode === "manual") {
+        setFiles(files);
+        return;
+      }
+
+      void uploadFiles(files);
+    },
+    uploadFiles: () => void uploadFiles(files),
+    abortUpload: () => {
+      acRef.current.abort();
+      acRef.current = new AbortController();
+    },
+    uploadProgress,
+    state,
+    disabled,
+    accept,
+    fileTypes,
+    options: { mode, multiple },
+    refs: {
+      focusElementRef,
+      fileInputRef,
+    },
+    routeConfig,
+    isUploading: state === "uploading",
+    ready: state === "ready",
+  };
+
+  return (
+    <PrimitiveContext.Provider value={primitiveValues}>
+      <PrimitiveSlot>{$props.children}</PrimitiveSlot>
+    </PrimitiveContext.Provider>
+  );
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,6 +4,7 @@ export {
   Uploader,
   generateUploadButton,
   generateUploadDropzone,
+  generateUploadPrimitives,
   generateUploader,
 } from "./components";
 


### PR DESCRIPTION
This PR adds unstyled composable components through `generateUploadPrimitives` which returns:
- `<Root>`
- `<Dropzone>`
- `<Button>`
- `<AllowedContent>`

I've also added examples for `minimal-appdir`, `minimal-pagedir`, `with-clerk-appdir`, `with-clerk-pagedir`. I can add it to all the rest of the react ones if needed.

All these components accept parameters as children like `({ isUploading }) => <></>`.
There is no `asChild` or `as={YourComponent}` prop at the moment as I'm not sure which one to use.
I haven't implemented the docs either as I'm not sure if the current styling page should be split up.