### PR TITLE
fix(docs): force path resolution

### DIFF
--- a/docs/tailwind.config.ts
+++ b/docs/tailwind.config.ts
@@ -8,6 +8,9 @@ import typographyStyles from "./typography";
 export default withUt({
   content: [
     "./src/**/*.{js,mjs,jsx,ts,tsx,mdx}",
+    // TODO: Investigate why resolution doesn't work in workspace.
+    // It works fine in other monorepos (e.g. create-t3-turbo) so appears
+    // to be some local workspace issue, making pnpm fail to resolve `@uploadthing/react`
     "./node_modules/@uploadthing/react/dist/**/*.js",
   ],
   darkMode: "selector",

--- a/docs/tailwind.config.ts
+++ b/docs/tailwind.config.ts
@@ -6,7 +6,10 @@ import { withUt } from "uploadthing/tw";
 import typographyStyles from "./typography";
 
 export default withUt({
-  content: ["./src/**/*.{js,mjs,jsx,ts,tsx,mdx}"],
+  content: [
+    "./src/**/*.{js,mjs,jsx,ts,tsx,mdx}",
+    "./node_modules/@uploadthing/react/dist/**/*.js",
+  ],
   darkMode: "selector",
   theme: {
     fontSize: {


### PR DESCRIPTION
tw plugin refuses to work in monorepo?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced Tailwind CSS configuration to include additional paths for content scanning, improving style processing from the Uploadthing React library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->