### PR TITLE
docs: Fix link to dashboard

### DIFF
--- a/docs/src/app/(docs)/v7/page.mdx
+++ b/docs/src/app/(docs)/v7/page.mdx
@@ -39,7 +39,7 @@ required information into a single `UPLOADTHING_TOKEN` environment variable.
 
 The token is a base64 encoded JSON object that contains information such as your
 app id, the app region as well as the API key. The token is available in the
-[UploadThing Dashboard](https://dashboard.uploadthing.com) under `API Keys` and
+[UploadThing Dashboard](https://uploadthing.com/dashboard) under `API Keys` and
 selecting the `V7` tab:
 
 ![Token](./token.png)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the URL for the UploadThing Dashboard to the correct location: `https://uploadthing.com/dashboard`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->