### PR TITLE
chore: Fix wrong dropzone label

### DIFF
--- a/packages/react/src/components/dropzone.tsx
+++ b/packages/react/src/components/dropzone.tsx
@@ -330,7 +330,9 @@ export function UploadDropzone<
       >
         <input className="sr-only" {...getInputProps()} />
         {contentFieldToContent($props.content?.label, styleFieldArg) ??
-          (ready ? `Choose files or drag and drop` : `Loading...`)}
+          (ready
+            ? `Choose ${multiple ? "file(s)" : "a file"} or drag and drop`
+            : `Loading...`)}
       </label>
       <div
         className={cn(


### PR DESCRIPTION
When mode is set to single the dropzone label says "Choose files ..." instead of "Choose a file" even though the button is correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved user interface for the file upload component with dynamic messaging indicating the number of files that can be selected.
  
This enhancement clarifies whether users can upload a single file or multiple files, improving the overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->