### PR TITLE
fix: enforce JSONObject return in `onUploadComplete`

### DIFF
--- a/.changeset/ten-pillows-smile.md
+++ b/.changeset/ten-pillows-smile.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+fix: enforce JSONObject return in `onUploadComplete` callback

--- a/packages/uploadthing/src/internal/types.ts
+++ b/packages/uploadthing/src/internal/types.ts
@@ -6,6 +6,7 @@ import type {
   FetchEsque,
   FileRouterInputConfig,
   Json,
+  JsonObject,
   MaybePromise,
   RouteOptions,
   Simplify,
@@ -86,9 +87,10 @@ type MiddlewareFn<
   },
 ) => MaybePromise<TOutput>;
 
-type ResolverFn<TOutput extends Json | void, TParams extends AnyParams> = (
-  opts: ResolverOptions<TParams>,
-) => MaybePromise<TOutput>;
+type ResolverFn<
+  TOutput extends JsonObject | void,
+  TParams extends AnyParams,
+> = (opts: ResolverOptions<TParams>) => MaybePromise<TOutput>;
 
 type UploadErrorFn = (input: {
   error: UploadThingError;
@@ -122,7 +124,7 @@ export interface UploadBuilder<TParams extends AnyParams> {
     _errorFn: TParams["_errorFn"];
     _output: UnsetMarker;
   }>;
-  onUploadComplete: <TOutput extends Json | void>(
+  onUploadComplete: <TOutput extends JsonObject | void>(
     fn: ResolverFn<TOutput, TParams>,
   ) => Uploader<{
     _routeOptions: TParams["_routeOptions"];

--- a/packages/uploadthing/test/upload-builder.test.ts
+++ b/packages/uploadthing/test/upload-builder.test.ts
@@ -64,6 +64,14 @@ it("typeerrors for invalid input", () => {
     })
     // @ts-expect-error - cannot set multiple middlewares
     .middleware(() => {});
+
+  f(["image"])
+    // @ts-expect-error - callback data must be a JSON object
+    .onUploadComplete(() => "foo");
+
+  f(["image"])
+    // @ts-expect-error - callback data must be a JSON object
+    .onUploadComplete(() => 1);
 });
 
 it("uses defaults for not-chained", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `onUploadComplete` callback to ensure it returns a consistent JSON object for better data processing.
  
- **Bug Fixes**
	- Improved type safety in the `uploadthing` module with updated method signatures.

- **Tests**
	- Added new test cases for handling invalid input scenarios in the `onUploadComplete` method, ensuring robust type error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->