### PR TITLE
docs: uncomment used import on react example for useUploadThing hook

### DIFF
--- a/docs/src/app/(docs)/api-reference/react/page.mdx
+++ b/docs/src/app/(docs)/api-reference/react/page.mdx
@@ -547,7 +547,7 @@ and `useUploadThing` hooks. For a more complete example, take a look at
 [our prebuilt components](https://github.com/pingdotgg/uploadthing/tree/main/packages/react/src/components).
 
 ```tsx {{ title: "app/example-custom-uploader.tsx" }}
-// import { useDropzone } from "@uploadthing/react";
+import { useDropzone } from "@uploadthing/react";
 import { generateClientDropzoneAccept } from "uploadthing/client";
 
 import { useUploadThing } from "~/utils/uploadthing";


### PR DESCRIPTION
uncomment used import on react example for useUploadThing hook

Used here:
![image](https://github.com/user-attachments/assets/a7411a5c-f4fa-4f47-852f-399c997791bd)

Commented here:
![image](https://github.com/user-attachments/assets/52839377-12fb-480b-9527-6248e2ef7af2)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Activated the import of the `useDropzone` hook, enhancing the functionality of components that utilize this feature.

- **Documentation**
	- Updated API reference documentation to reflect the new import for the `useDropzone` hook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->