### PR TITLE
docs: Cleanup: Fix typo in Libraries

### DIFF
--- a/docs/src/components/Libraries.tsx
+++ b/docs/src/components/Libraries.tsx
@@ -129,7 +129,7 @@ export function Frameworks() {
       </Heading>
       <Prose as="p">
         Using a fullstack framework makes integrating UploadThing a breeze. No
-        matter what framework you use, there's a good change we have a first
+        matter what framework you use, there's a good chance we have a first
         party adapter for it.
       </Prose>
       <div className="not-prose mt-4 grid grid-cols-1 gap-x-6 gap-y-10 border-t border-zinc-900/5 pt-10 sm:grid-cols-2 xl:max-w-none xl:grid-cols-3 dark:border-white/5">


### PR DESCRIPTION
Typo: change -> chance

![image](https://github.com/user-attachments/assets/382d6c4f-5530-4d1d-8929-35b64d59f8d6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a textual error for improved clarity in the Frameworks section of the Libraries documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->