### PR TITLE
fix(docs): resolve broken link in `generateReactHelpers`

### DIFF
--- a/docs/src/app/(docs)/api-reference/react/page.mdx
+++ b/docs/src/app/(docs)/api-reference/react/page.mdx
@@ -104,7 +104,7 @@ export const UploadDropzone = generateUploadDropzone<OurFileRouter>();
 
 The `generateReactHelpers` function is used to generate the
 [useUploadThing](/api-reference/react#use-upload-thing) hook and the
-[uploadFiles]/api-reference/client#upload-files) functions you use to interact
+[uploadFiles](/api-reference/client#upload-files) functions you use to interact
 with UploadThing in custom components. It takes your File Router as a generic
 
 ```tsx


### PR DESCRIPTION
### About
Reading through the docs and came across a broken link:
![image](https://github.com/user-attachments/assets/83a348ca-63c9-4151-9093-da53db634a79)
> https://docs.uploadthing.com/api-reference/react#generate-react-helpers

### Changes
Added the missing `(` 
```diff
- [uploadFiles]/api-reference/client#upload-files) functions you use to interact
+ [uploadFiles](/api-reference/client#upload-files) functions you use to interact
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected the link syntax for the `uploadFiles` function in the API reference, ensuring proper navigation to the documentation section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->