### PR TITLE
docs: Fixed component exports for tanstack/start

### DIFF
--- a/docs/src/app/(docs)/getting-started/tanstack-start/page.mdx
+++ b/docs/src/app/(docs)/getting-started/tanstack-start/page.mdx
@@ -159,7 +159,7 @@ export const UploadDropzone = generateUploadDropzone<OurFileRouter>();
 ```tsx {{ title: "app/routes/index.tsx" }}
 import { createFileRoute } from "@tanstack/react-router";
 
-import { UploadButton } from "~/utils/uploadThing";
+import { UploadButton } from "~/utils/uploadthing";
 
 export const Route = createFileRoute("/")({
   component: Home,

--- a/docs/src/app/(docs)/getting-started/tanstack-start/page.mdx
+++ b/docs/src/app/(docs)/getting-started/tanstack-start/page.mdx
@@ -159,7 +159,7 @@ export const UploadDropzone = generateUploadDropzone<OurFileRouter>();
 ```tsx {{ title: "app/routes/index.tsx" }}
 import { createFileRoute } from "@tanstack/react-router";
 
-import UploadButton from "~/utils/uploadThing";
+import { UploadButton } from "~/utils/uploadThing";
 
 export const Route = createFileRoute("/")({
   component: Home,

--- a/docs/src/app/(docs)/getting-started/tanstack-start/page.mdx
+++ b/docs/src/app/(docs)/getting-started/tanstack-start/page.mdx
@@ -122,10 +122,8 @@ import {
 
 import type { OurFileRouter } from "~/api/uploadthing";
 
-const UploadButton = generateUploadButton<OurFileRouter>();
-const UploadDropzone = generateUploadDropzone<OurFileRouter>();
-
-export default UploadButton;
+export const UploadButton = generateUploadButton<OurFileRouter>();
+export const UploadDropzone = generateUploadDropzone<OurFileRouter>();
 ```
 
 ### Add UploadThing's Styles


### PR DESCRIPTION
Follow up for https://github.com/pingdotgg/uploadthing/pull/973.

Exports for `UploadButton` and `UploadDropzone` were incorrect in getting started for `@tanstack/start`. Noticed it only after the original PR was merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced accessibility of the `UploadButton` and `UploadDropzone` components through named exports, allowing for more flexible imports in other modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->