### PR TITLE
docs: Improvements for getting-started/tanstack-start

### DIFF
--- a/docs/src/app/(docs)/getting-started/tanstack-start/page.mdx
+++ b/docs/src/app/(docs)/getting-started/tanstack-start/page.mdx
@@ -96,7 +96,7 @@ import { createAPIFileRoute } from "@tanstack/start/api";
 
 import { createRouteHandler } from "uploadthing/server";
 
-import { ourFileRouter } from "~/api/uploadthing";
+import { ourFileRouter } from "../../server/uploadthing";
 
 const handlers = createRouteHandler({ router: ourFileRouter });
 
@@ -120,7 +120,7 @@ import {
   generateUploadDropzone,
 } from "@uploadthing/react";
 
-import type { OurFileRouter } from "~/api/uploadthing";
+import type { OurFileRouter } from "../server/uploadthing";
 
 export const UploadButton = generateUploadButton<OurFileRouter>();
 export const UploadDropzone = generateUploadDropzone<OurFileRouter>();
@@ -130,25 +130,31 @@ export const UploadDropzone = generateUploadDropzone<OurFileRouter>();
 
 <Tabs tabs={["Tailwind", "Not Tailwind"]}>
   <Tab>
-      Wrap your Tailwind config with the `withUt` helper. You can learn more about our
-      Tailwind helper in the ["Theming" page](/concepts/theming#theming-with-tailwind-css)
+    Wrap your Tailwind config with the `withUt` helper. You can learn more about our
+    Tailwind helper in the ["Theming" page](/concepts/theming#theming-with-tailwind-css)
 
-      ```tsx
-      import { withUt } from "uploadthing/tw";
+    ```tsx
+    import { withUt } from "uploadthing/tw";
 
-      export default withUt({
-        // Your existing Tailwind config
-        content: ["./src/**/*.{ts,tsx,mdx}"],
-        ...
-      });
-      ```
+    export default withUt({
+      // Your existing Tailwind config
+      content: ["./src/**/*.{ts,tsx,mdx}"],
+      ...
+    });
+    ```
 
   </Tab>
   <Tab>
-    Include our CSS file in the root layout to make sure the components look right!
+    Include our CSS in your root route to make sure the components look right!
 
-    ```tsx
-    import "@uploadthing/react/styles.css";
+    ```tsx {{ title: "app/routes/__root.tsx" }}
+    // @ts-expect-error
+    import uploadthingCss from "@uploadthing/react/styles.css?url";
+
+    export const Route = createRootRoute({
+      component: RootComponent,
+      links: () => [{ rel: "stylesheet", href: uploadthingCss }],
+    });
     ```
 
   </Tab>
@@ -159,7 +165,7 @@ export const UploadDropzone = generateUploadDropzone<OurFileRouter>();
 ```tsx {{ title: "app/routes/index.tsx" }}
 import { createFileRoute } from "@tanstack/react-router";
 
-import { UploadButton } from "~/utils/uploadthing";
+import { UploadButton } from "../utils/uploadthing";
 
 export const Route = createFileRoute("/")({
   component: Home,


### PR DESCRIPTION
Changes to getting started for `@tanstack/start`
- Fixed the way css for UT components is included when not using tailwind.
- Changed absolute imports to relative. `tanstack/start` doesn't include `vite-tsconfig-paths` by default, so absolute imports will not work, even if paths are configured in `tsconfig.json`. More info here: [TSS Docs: Path Aliases](https://tanstack.com/router/latest/docs/framework/react/start/path-aliases)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated import paths for clarity and accuracy.
	- Rephrased documentation content for better understanding, especially regarding Tailwind configuration and CSS inclusion.
	- Reformatted code snippets for consistency, including TypeScript error suppression comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->