### PR TITLE
feat: add `effect/Redacted`

### DIFF
--- a/.changeset/orange-roses-sip.md
+++ b/.changeset/orange-roses-sip.md
@@ -1,0 +1,6 @@
+---
+"@uploadthing/shared": patch
+"uploadthing": patch
+---
+
+chore: redact sensitive fields from logs using `effect/Redacted`

--- a/examples/backend-adapters/server/package.json
+++ b/examples/backend-adapters/server/package.json
@@ -12,14 +12,14 @@
     "dev:effect": "NODE_ENV=development PORT=3003 tsx watch src/effect-platform.ts"
   },
   "dependencies": {
-    "@effect/platform": "0.69.5",
-    "@effect/platform-node": "0.64.6",
+    "@effect/platform": "0.69.6",
+    "@effect/platform-node": "0.64.7",
     "@elysiajs/cors": "^1.1.1",
     "@fastify/cors": "^9.0.1",
     "@hono/node-server": "^1.8.2",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
-    "effect": "3.10.1",
+    "effect": "3.10.2",
     "elysia": "^1.1.16",
     "express": "^4.18.2",
     "fastify": "^4.26.1",

--- a/examples/backend-adapters/server/package.json
+++ b/examples/backend-adapters/server/package.json
@@ -12,15 +12,14 @@
     "dev:effect": "NODE_ENV=development PORT=3003 tsx watch src/effect-platform.ts"
   },
   "dependencies": {
-    "@effect/platform": "0.68.5",
-    "@effect/platform-node": "0.63.5",
-    "@effect/schema": "0.75.4",
+    "@effect/platform": "0.69.5",
+    "@effect/platform-node": "0.64.6",
     "@elysiajs/cors": "^1.1.1",
     "@fastify/cors": "^9.0.1",
     "@hono/node-server": "^1.8.2",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
-    "effect": "3.9.2",
+    "effect": "3.10.1",
     "elysia": "^1.1.16",
     "express": "^4.18.2",
     "fastify": "^4.26.1",

--- a/examples/minimal-appdir/src/server/uploadthing.ts
+++ b/examples/minimal-appdir/src/server/uploadthing.ts
@@ -36,7 +36,7 @@ export const uploadRouter = {
   })
     .middleware(({ req, files }) => {
       // Check some condition based on the incoming requrest
-      console.log("Request", req);
+      req;
       //^?
       // if (!req.headers.get("x-some-header")) {
       //   throw new Error("x-some-header is required");

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@actions/github": "^6.0.0",
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.1",
-    "@effect/vitest": "0.12.1",
+    "@effect/vitest": "0.13.1",
     "@ianvs/prettier-plugin-sort-imports": "^4.2.1",
     "@manypkg/cli": "^0.21.3",
     "@playwright/test": "1.45.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@uploadthing/mime-types": "workspace:*",
-    "effect": "3.9.2",
+    "effect": "3.10.1",
     "sqids": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@uploadthing/mime-types": "workspace:*",
-    "effect": "3.10.1",
+    "effect": "3.10.2",
     "sqids": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/shared/test/crypto.test.ts
+++ b/packages/shared/test/crypto.test.ts
@@ -1,6 +1,6 @@
 import { it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
-import * as Exit from "effect/Exit";
+import * as Redacted from "effect/Redacted";
 import { describe, expect } from "vitest";
 
 import {
@@ -14,7 +14,7 @@ import {
 describe("crypto sign / verify", () => {
   it.effect("signs and verifies a payload", () =>
     Effect.gen(function* () {
-      const secret = "foo-123";
+      const secret = Redacted.make("foo-123");
       const payload = "hello world";
 
       const sig = yield* signPayload(payload, secret);
@@ -26,7 +26,7 @@ describe("crypto sign / verify", () => {
 
   it.effect("doesn't verify a payload with a bad signature", () =>
     Effect.gen(function* () {
-      const secret = "foo-123";
+      const secret = Redacted.make("foo-123");
       const payload = "hello world";
 
       const sig = yield* signPayload(payload, secret);
@@ -38,11 +38,15 @@ describe("crypto sign / verify", () => {
 
   it.effect("doesn't verify a payload with a bad secret", () =>
     Effect.gen(function* () {
-      const secret = "foo-123";
+      const secret = Redacted.make("foo-123");
       const payload = "hello world";
 
       const sig = yield* signPayload(payload, secret);
-      const verified = yield* verifySignature(payload, sig, "bad");
+      const verified = yield* verifySignature(
+        payload,
+        sig,
+        Redacted.make("bad"),
+      );
 
       expect(verified).toBe(false);
     }),
@@ -51,7 +55,7 @@ describe("crypto sign / verify", () => {
   it.effect("generates a signed URL", () =>
     Effect.gen(function* () {
       const url = "https://example.com";
-      const secret = "foo-123";
+      const secret = Redacted.make("foo-123");
 
       const signedURL = yield* generateSignedURL(url, secret, {
         ttlInSeconds: 60 * 60,
@@ -67,7 +71,7 @@ describe("crypto sign / verify", () => {
   it.effect("generates and verifies a signed URL", () =>
     Effect.gen(function* () {
       const url = "https://example.com";
-      const secret = "foo-123";
+      const secret = Redacted.make("foo-123");
 
       const signedURL = yield* generateSignedURL(url, secret, {
         ttlInSeconds: 60 * 60,

--- a/packages/uploadthing/package.json
+++ b/packages/uploadthing/package.json
@@ -154,8 +154,7 @@
     "@effect/schema": "0.72.2",
     "@uploadthing/mime-types": "workspace:*",
     "@uploadthing/shared": "workspace:*",
-    "effect": "3.7.2",
-    "effect-log": "0.32.0"
+    "effect": "3.7.2"
   },
   "devDependencies": {
     "@remix-run/server-runtime": "^2.12.0",

--- a/packages/uploadthing/package.json
+++ b/packages/uploadthing/package.json
@@ -150,11 +150,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@effect/platform": "0.68.5",
-    "@effect/schema": "0.75.4",
+    "@effect/platform": "0.69.5",
     "@uploadthing/mime-types": "workspace:*",
     "@uploadthing/shared": "workspace:*",
-    "effect": "3.9.2"
+    "effect": "3.10.1"
   },
   "devDependencies": {
     "@remix-run/server-runtime": "^2.12.0",

--- a/packages/uploadthing/package.json
+++ b/packages/uploadthing/package.json
@@ -150,10 +150,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@effect/platform": "0.69.5",
+    "@effect/platform": "0.69.6",
     "@uploadthing/mime-types": "workspace:*",
     "@uploadthing/shared": "workspace:*",
-    "effect": "3.10.1"
+    "effect": "3.10.2"
   },
   "devDependencies": {
     "@remix-run/server-runtime": "^2.12.0",

--- a/packages/uploadthing/src/internal/config.test.ts
+++ b/packages/uploadthing/src/internal/config.test.ts
@@ -4,6 +4,7 @@ import { it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
 import { afterEach, beforeEach, describe, expect } from "vitest";
 
 import { UploadThingError } from "@uploadthing/shared";
@@ -12,12 +13,12 @@ import { configProvider, IngestUrl, IsDevelopment, UTToken } from "./config";
 import { ParsedToken, UploadThingToken } from "./shared-schemas";
 
 const app1TokenData = {
-  apiKey: "sk_foo",
+  apiKey: Redacted.make("sk_foo"),
   appId: "app-1",
   regions: ["fra1"] as const,
 };
 const app2TokenData = {
-  apiKey: "sk_bar",
+  apiKey: Redacted.make("sk_bar"),
   appId: "app-2",
   regions: ["dub1"] as const,
 };

--- a/packages/uploadthing/src/internal/config.test.ts
+++ b/packages/uploadthing/src/internal/config.test.ts
@@ -1,10 +1,10 @@
 import { after } from "node:test";
-import * as S from "@effect/schema/Schema";
 import { it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
+import * as S from "effect/Schema";
 import { afterEach, beforeEach, describe, expect } from "vitest";
 
 import { UploadThingError } from "@uploadthing/shared";

--- a/packages/uploadthing/src/internal/config.ts
+++ b/packages/uploadthing/src/internal/config.ts
@@ -1,7 +1,7 @@
-import * as S from "@effect/schema/Schema";
 import * as Config from "effect/Config";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
+import * as S from "effect/Schema";
 
 import {
   filterDefinedObjectValues,

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -13,7 +13,6 @@ import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import * as Logger from "effect/Logger";
 import * as ManagedRuntime from "effect/ManagedRuntime";
 import * as Match from "effect/Match";
 import * as Redacted from "effect/Redacted";

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -16,6 +16,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as ManagedRuntime from "effect/ManagedRuntime";
 import * as Match from "effect/Match";
+import * as Redacted from "effect/Redacted";
 
 import {
   fillInputRouteConfig,
@@ -373,7 +374,7 @@ const handleCallbackRequest = (opts: {
       yield* HttpClientRequest.post(`/callback-result`).pipe(
         HttpClientRequest.prependUrl(baseUrl),
         HttpClientRequest.setHeaders({
-          "x-uploadthing-api-key": apiKey,
+          "x-uploadthing-api-key": Redacted.value(apiKey),
           "x-uploadthing-version": pkgJson.version,
           "x-uploadthing-be-adapter": beAdapter,
           "x-uploadthing-fe-package": fePackage,
@@ -602,7 +603,7 @@ const handleUploadAction = (opts: {
     const metadataRequest = HttpClientRequest.post("/route-metadata").pipe(
       HttpClientRequest.prependUrl(ingestUrl),
       HttpClientRequest.setHeaders({
-        "x-uploadthing-api-key": apiKey,
+        "x-uploadthing-api-key": Redacted.value(apiKey),
         "x-uploadthing-version": pkgJson.version,
         "x-uploadthing-be-adapter": beAdapter,
         "x-uploadthing-fe-package": fePackage,

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -68,15 +68,13 @@ export const makeAdapterHandler = <Args extends any[]>(
   opts: RouteHandlerOptions<FileRouter>,
   beAdapter: string,
 ): ((...args: Args) => Promise<Response>) => {
-  const layer = Layer.provide(
-    Layer.mergeAll(
-      Logger.pretty,
-      withMinimalLogLevel,
-      HttpClient.layer,
-      Layer.succeed(
-        HttpClient.Fetch,
-        opts.config?.fetch as typeof globalThis.fetch,
-      ),
+  const layer = Layer.mergeAll(
+    Logger.pretty,
+    withMinimalLogLevel,
+    HttpClient.layer,
+    Layer.succeed(
+      HttpClient.Fetch,
+      opts.config?.fetch as typeof globalThis.fetch,
     ),
     Layer.setConfigProvider(configProvider(opts.config)),
   );

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -9,11 +9,11 @@ import {
   HttpServerResponse,
 } from "@effect/platform";
 import * as S from "@effect/schema/Schema";
-import { PrettyLogger } from "effect-log";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
 import * as ManagedRuntime from "effect/ManagedRuntime";
 import * as Match from "effect/Match";
 import * as Redacted from "effect/Redacted";
@@ -70,7 +70,7 @@ export const makeAdapterHandler = <Args extends any[]>(
 ): ((...args: Args) => Promise<Response>) => {
   const layer = Layer.provide(
     Layer.mergeAll(
-      PrettyLogger.layer({ showFiberId: false }),
+      Logger.pretty,
       withMinimalLogLevel,
       HttpClient.layer,
       Layer.succeed(
@@ -657,7 +657,6 @@ const handleUploadAction = (opts: {
                   HttpBody.text(payload, "application/json"),
                 ),
                 httpClient,
-
                 HttpClientResponse.arrayBuffer,
                 Effect.asVoid,
                 Effect.tapBoth({

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -8,12 +8,12 @@ import {
   HttpServerRequest,
   HttpServerResponse,
 } from "@effect/platform";
-import * as S from "@effect/schema/Schema";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Match from "effect/Match";
 import * as Redacted from "effect/Redacted";
+import * as S from "effect/Schema";
 
 import {
   fillInputRouteConfig,

--- a/packages/uploadthing/src/internal/jsonl.test.ts
+++ b/packages/uploadthing/src/internal/jsonl.test.ts
@@ -1,6 +1,7 @@
 import { it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import * as Redacted from "effect/Redacted";
 import * as Stream from "effect/Stream";
 import { beforeEach, describe, expect, vi } from "vitest";
 
@@ -13,7 +14,8 @@ const te = new TextEncoder();
 
 const createChunk = (_payload: unknown) => {
   const payload = JSON.stringify(_payload);
-  return Effect.map(signPayload(payload, "sk_123"), (signature) =>
+  const secret = Redacted.make("sk_123");
+  return Effect.map(signPayload(payload, secret), (signature) =>
     JSON.stringify(
       MetadataFetchStreamPart.make({ payload, signature, hook: "callback" }),
     ),

--- a/packages/uploadthing/src/internal/jsonl.ts
+++ b/packages/uploadthing/src/internal/jsonl.ts
@@ -1,5 +1,5 @@
-import * as S from "@effect/schema/Schema";
 import * as Effect from "effect/Effect";
+import * as S from "effect/Schema";
 import * as Stream from "effect/Stream";
 
 export const handleJsonLineStream =

--- a/packages/uploadthing/src/internal/route-config.ts
+++ b/packages/uploadthing/src/internal/route-config.ts
@@ -1,6 +1,6 @@
-import type * as S from "@effect/schema/Schema";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import type * as S from "effect/Schema";
 
 import type {
   ExpandedRouteConfig,

--- a/packages/uploadthing/src/internal/runtime.ts
+++ b/packages/uploadthing/src/internal/runtime.ts
@@ -1,4 +1,5 @@
-import { FetchHttpClient } from "@effect/platform";
+import { FetchHttpClient, Headers } from "@effect/platform";
+import * as FiberRef from "effect/FiberRef";
 import * as Layer from "effect/Layer";
 import * as ManagedRuntime from "effect/ManagedRuntime";
 
@@ -12,8 +13,20 @@ export const makeRuntime = (fetch: FetchEsque, config: unknown) => {
     FetchHttpClient.layer,
     Layer.succeed(FetchHttpClient.Fetch, fetch as typeof globalThis.fetch),
   );
+
+  const withRedactedHeaders = Layer.effectDiscard(
+    FiberRef.update(Headers.currentRedactedNames, (_) =>
+      _.concat(["x-uploadthing-api-key"]),
+    ),
+  );
+
   const layer = Layer.provide(
-    Layer.mergeAll(withLogFormat, withMinimalLogLevel, fetchHttpClient),
+    Layer.mergeAll(
+      withLogFormat,
+      withMinimalLogLevel,
+      fetchHttpClient,
+      withRedactedHeaders,
+    ),
     Layer.setConfigProvider(configProvider(config)),
   );
   return ManagedRuntime.make(layer);

--- a/packages/uploadthing/src/internal/shared-schemas.ts
+++ b/packages/uploadthing/src/internal/shared-schemas.ts
@@ -28,7 +28,7 @@ const DecodeString = S.transform(S.Uint8ArrayFromSelf, S.String, {
 });
 
 export const ParsedToken = S.Struct({
-  apiKey: S.Redacted(S.String.pipe(S.startsWith("sk_"))), 
+  apiKey: S.Redacted(S.String.pipe(S.startsWith("sk_"))),
   appId: S.String,
   regions: S.NonEmptyArray(S.String),
   ingestHost: S.String.pipe(

--- a/packages/uploadthing/src/internal/shared-schemas.ts
+++ b/packages/uploadthing/src/internal/shared-schemas.ts
@@ -28,7 +28,7 @@ const DecodeString = S.transform(S.Uint8ArrayFromSelf, S.String, {
 });
 
 export const ParsedToken = S.Struct({
-  apiKey: S.String.pipe(S.startsWith("sk_")),
+  apiKey: S.Redacted(S.String.pipe(S.startsWith("sk_"))), 
   appId: S.String,
   regions: S.NonEmptyArray(S.String),
   ingestHost: S.String.pipe(

--- a/packages/uploadthing/src/internal/shared-schemas.ts
+++ b/packages/uploadthing/src/internal/shared-schemas.ts
@@ -1,4 +1,4 @@
-import * as S from "@effect/schema/Schema";
+import * as S from "effect/Schema";
 
 import type { Json } from "@uploadthing/shared";
 import { ValidACLs, ValidContentDispositions } from "@uploadthing/shared";

--- a/packages/uploadthing/src/internal/types.ts
+++ b/packages/uploadthing/src/internal/types.ts
@@ -1,6 +1,6 @@
-import type { Schema } from "@effect/schema/Schema";
 import type * as Config from "effect/Config";
 import type * as LogLevel from "effect/LogLevel";
+import type { Schema } from "effect/Schema";
 
 import type {
   ErrorMessage,

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -9,6 +9,7 @@ import * as Arr from "effect/Array";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Predicate from "effect/Predicate";
+import * as Redacted from "effect/Redacted";
 
 import type {
   ACL,
@@ -75,7 +76,7 @@ export class UTApi {
         HttpClientRequest.setHeaders({
           "x-uploadthing-version": UPLOADTHING_VERSION,
           "x-uploadthing-be-adapter": "server-sdk",
-          "x-uploadthing-api-key": apiKey,
+          "x-uploadthing-api-key": Redacted.value(apiKey),
         }),
         HttpClient.filterStatusOk(httpClient),
         Effect.tapBoth({

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -4,10 +4,10 @@ import {
   HttpClientResponse,
 } from "@effect/platform";
 import * as S from "@effect/schema/Schema";
-import { PrettyLogger } from "effect-log";
 import * as Arr from "effect/Array";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
 import * as Predicate from "effect/Predicate";
 import * as Redacted from "effect/Redacted";
 
@@ -97,17 +97,19 @@ export class UTApi {
     program: Effect.Effect<A, E, HttpClient.HttpClient.Default>,
     signal?: AbortSignal,
   ) => {
-    return program.pipe(
-      Effect.provide(PrettyLogger.layer({ showFiberId: false })),
-      Effect.provide(withMinimalLogLevel),
-      Effect.provide(HttpClient.layer),
-      Effect.provide(
-        Layer.effect(
-          HttpClient.Fetch,
-          Effect.succeed(this.fetch as typeof globalThis.fetch),
-        ),
+    const layer = Layer.mergeAll(
+      Logger.pretty,
+      withMinimalLogLevel,
+      HttpClient.layer,
+      Layer.effect(
+        HttpClient.Fetch,
+        Effect.succeed(this.fetch as typeof globalThis.fetch),
       ),
-      Effect.provide(Layer.setConfigProvider(configProvider(this.opts))),
+      Layer.setConfigProvider(configProvider(this.opts)),
+    );
+
+    return program.pipe(
+      Effect.provide(layer),
       Effect.withLogSpan("utapi.#executeAsync"),
       (e) => Effect.runPromise(e, signal ? { signal } : undefined),
     );

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -7,7 +7,6 @@ import * as S from "@effect/schema/Schema";
 import * as Arr from "effect/Array";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import * as Logger from "effect/Logger";
 import * as Predicate from "effect/Predicate";
 import * as Redacted from "effect/Redacted";
 

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -4,12 +4,12 @@ import {
   HttpClientRequest,
   HttpClientResponse,
 } from "@effect/platform";
-import * as S from "@effect/schema/Schema";
 import * as Arr from "effect/Array";
 import * as Effect from "effect/Effect";
 import type * as ManagedRuntime from "effect/ManagedRuntime";
 import * as Predicate from "effect/Predicate";
 import * as Redacted from "effect/Redacted";
+import * as S from "effect/Schema";
 
 import type {
   ACL,

--- a/packages/uploadthing/test/__test-helpers.ts
+++ b/packages/uploadthing/test/__test-helpers.ts
@@ -1,4 +1,5 @@
 import * as S from "@effect/schema/Schema";
+import * as Redacted from "effect/Redacted";
 import type { StrictRequest } from "msw";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
@@ -17,7 +18,7 @@ export const uploadCompleteMock = vi.fn();
 export const onErrorMock = vi.fn();
 
 const tokenData = {
-  apiKey: "sk_foo",
+  apiKey: Redacted.make("sk_foo"),
   appId: "app-1",
   regions: ["fra1"] as const,
 };

--- a/packages/uploadthing/test/__test-helpers.ts
+++ b/packages/uploadthing/test/__test-helpers.ts
@@ -1,6 +1,6 @@
 import { createHash } from "crypto";
-import * as S from "@effect/schema/Schema";
 import * as Redacted from "effect/Redacted";
+import * as S from "effect/Schema";
 import type { StrictRequest } from "msw";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";

--- a/packages/uploadthing/test/request-handler.test.ts
+++ b/packages/uploadthing/test/request-handler.test.ts
@@ -1,4 +1,5 @@
 import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
 import { describe, expect } from "vitest";
 import { z } from "zod";
 
@@ -418,7 +419,7 @@ describe(".onUploadComplete()", () => {
       }),
     });
     const signature = await Effect.runPromise(
-      signPayload(payload, "sk_live_badkey"),
+      signPayload(payload, Redacted.make("sk_live_badkey")),
     );
 
     const res = await handler(

--- a/packages/uploadthing/test/sdk.test.ts
+++ b/packages/uploadthing/test/sdk.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-restricted-globals */
-import * as S from "@effect/schema/Schema";
+import * as S from "effect/Schema";
 import {
   afterAll,
   beforeAll,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1392,7 +1392,7 @@ importers:
     devDependencies:
       '@nuxt/devtools':
         specifier: latest
-        version: 1.5.1(rollup@3.29.4)(vite@5.3.1(@types/node@20.14.0)(lightningcss@1.24.1)(terser@5.32.0))(vue@3.4.25(typescript@5.5.2))(webpack-sources@3.2.3)
+        version: 1.5.2(rollup@3.29.4)(vite@5.3.1(@types/node@20.14.0)(lightningcss@1.24.1)(terser@5.32.0))(vue@3.4.25(typescript@5.5.2))(webpack-sources@3.2.3)
       '@nuxt/module-builder':
         specifier: ^0.5.5
         version: 0.5.5(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3))(nuxi@3.11.1)(typescript@5.5.2)
@@ -1622,9 +1622,6 @@ importers:
       effect:
         specifier: 3.7.2
         version: 3.7.2
-      effect-log:
-        specifier: 0.32.0
-        version: 0.32.0(effect@3.7.2)
     devDependencies:
       '@remix-run/server-runtime':
         specifier: ^2.12.0
@@ -4618,12 +4615,27 @@ packages:
     peerDependencies:
       vite: '*'
 
+  '@nuxt/devtools-kit@1.5.2':
+    resolution: {integrity: sha512-IMbwflL/JLuK1JcM5yWKa+T5JGjwnCACZJw218/8bUTt/uTVgtkMueE+1/p9rhCWxvGQiT3xnCIXKhEg7xP58Q==}
+    peerDependencies:
+      vite: '*'
+
   '@nuxt/devtools-wizard@1.5.1':
     resolution: {integrity: sha512-09VqUYnL8dh31GK85g9+L1xZCXCmieOBWsV9H5a3ZA7wNepDjbrmaRFr/KSA6fsI7AZoqzkNuRsGUzEksEDxpg==}
     hasBin: true
 
+  '@nuxt/devtools-wizard@1.5.2':
+    resolution: {integrity: sha512-wZhouI3drb7HL7KYezYb9ksK0EeSVbHDPPKdLQePVrr+7SphThqiHoWmovBB3e/D4jtO3VC07+ILZcXUnat6HQ==}
+    hasBin: true
+
   '@nuxt/devtools@1.5.1':
     resolution: {integrity: sha512-A5+TEKJURuwes/PD30hl6gksA+935UY7i8DIkDr+9a4AWnPgrVt/WsGRmz84Q/9eRBxlLjwD9/kwDpNYcMST6Q==}
+    hasBin: true
+    peerDependencies:
+      vite: '*'
+
+  '@nuxt/devtools@1.5.2':
+    resolution: {integrity: sha512-E0bqGjAEpzVu7K8soiiDOqjAQ1FaRZPqSSU0OidmRL0HNM9kIaBNr78R494OLSop0Hh0d2Uha7Yt9IEADHtgyw==}
     hasBin: true
     peerDependencies:
       vite: '*'
@@ -8794,11 +8806,6 @@ packages:
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
-
-  effect-log@0.32.0:
-    resolution: {integrity: sha512-zlh4S+zBkHeDhiV5IAAXwecqxASVJk9tYNJUb12EuJqgtRGGyhrXYNn8zz5Gk/w7PmnNLTl9Vb6bQo2BFn+J/Q==}
-    peerDependencies:
-      effect: ^3.7.0
 
   effect@3.7.2:
     resolution: {integrity: sha512-pV7l1+LSZFvVObj4zuy4nYiBaC7qZOfrKV6s/Ef4p3KueiQwZFgamazklwyZ+x7Nyj2etRDFvHE/xkThTfQD1w==}
@@ -15529,6 +15536,11 @@ packages:
       '@testing-library/jest-dom':
         optional: true
 
+  vite-plugin-vue-inspector@5.1.3:
+    resolution: {integrity: sha512-pMrseXIDP1Gb38mOevY+BvtNGNqiqmqa2pKB99lnLsADQww9w9xMbAfT4GB6RUoaOkSPrtlXqpq2Fq+Dj2AgFg==}
+    peerDependencies:
+      vite: ^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0
+
   vite-plugin-vue-inspector@5.2.0:
     resolution: {integrity: sha512-wWxyb9XAtaIvV/Lr7cqB1HIzmHZFVUJsTNm3yAxkS87dgh/Ky4qr2wDEWNxF23fdhVa3jQ8MZREpr4XyiuaRqA==}
     peerDependencies:
@@ -16379,7 +16391,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.4
       '@babel/helper-compilation-targets': 7.24.6
-      '@babel/helper-plugin-utils': 7.24.6
+      '@babel/helper-plugin-utils': 7.24.8
       debug: 4.3.6
       lodash.debounce: 4.0.8
       resolve: 1.22.8
@@ -16390,7 +16402,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.25.2
       '@babel/helper-compilation-targets': 7.24.6
-      '@babel/helper-plugin-utils': 7.24.6
+      '@babel/helper-plugin-utils': 7.24.8
       debug: 4.3.6
       lodash.debounce: 4.0.8
       resolve: 1.22.8
@@ -16758,12 +16770,12 @@ snapshots:
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.24.4)':
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.24.6
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.6
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.24.4)':
     dependencies:
@@ -16848,22 +16860,22 @@ snapshots:
   '@babel/plugin-syntax-import-attributes@7.24.6(@babel/core@7.24.4)':
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.24.6
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-import-attributes@7.24.6(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.6
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.24.4)':
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.24.6
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.6
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.24.4)':
     dependencies:
@@ -16885,6 +16897,11 @@ snapshots:
       '@babel/core': 7.25.2
       '@babel/helper-plugin-utils': 7.24.6
 
+  '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.24.4)':
+    dependencies:
+      '@babel/core': 7.24.4
+      '@babel/helper-plugin-utils': 7.24.8
+
   '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
@@ -16893,12 +16910,12 @@ snapshots:
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.24.4)':
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.24.6
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.6
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.24.4)':
     dependencies:
@@ -16913,12 +16930,12 @@ snapshots:
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.24.4)':
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.24.6
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.6
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.24.4)':
     dependencies:
@@ -16933,12 +16950,12 @@ snapshots:
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.24.4)':
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.24.6
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.6
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.24.4)':
     dependencies:
@@ -16953,12 +16970,12 @@ snapshots:
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.24.4)':
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-plugin-utils': 7.24.6
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.25.2)':
     dependencies:
       '@babel/core': 7.25.2
-      '@babel/helper-plugin-utils': 7.24.6
+      '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.24.4)':
     dependencies:
@@ -20053,7 +20070,32 @@ snapshots:
       - supports-color
       - webpack-sources
 
+  '@nuxt/devtools-kit@1.5.2(magicast@0.3.5)(rollup@3.29.4)(vite@5.3.1(@types/node@20.14.0)(lightningcss@1.24.1)(terser@5.32.0))(webpack-sources@3.2.3)':
+    dependencies:
+      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3)
+      '@nuxt/schema': 3.13.2(rollup@3.29.4)(webpack-sources@3.2.3)
+      execa: 7.2.0
+      vite: 5.3.1(@types/node@20.14.0)(lightningcss@1.24.1)(terser@5.32.0)
+    transitivePeerDependencies:
+      - magicast
+      - rollup
+      - supports-color
+      - webpack-sources
+
   '@nuxt/devtools-wizard@1.5.1':
+    dependencies:
+      consola: 3.2.3
+      diff: 7.0.0
+      execa: 7.2.0
+      global-directory: 4.0.1
+      magicast: 0.3.5
+      pathe: 1.1.2
+      pkg-types: 1.2.0
+      prompts: 2.4.2
+      rc9: 2.1.2
+      semver: 7.6.3
+
+  '@nuxt/devtools-wizard@1.5.2':
     dependencies:
       consola: 3.2.3
       diff: 7.0.0
@@ -20152,6 +20194,54 @@ snapshots:
       vite: 5.3.1(@types/node@20.14.0)(lightningcss@1.24.1)(terser@5.32.0)
       vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@4.18.0)(webpack-sources@3.2.3))(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.0)(lightningcss@1.24.1)(terser@5.32.0))
       vite-plugin-vue-inspector: 5.2.0(vite@5.3.1(@types/node@20.14.0)(lightningcss@1.24.1)(terser@5.32.0))
+      which: 3.0.1
+      ws: 8.18.0
+    transitivePeerDependencies:
+      - bufferutil
+      - rollup
+      - supports-color
+      - utf-8-validate
+      - vue
+      - webpack-sources
+
+  '@nuxt/devtools@1.5.2(rollup@3.29.4)(vite@5.3.1(@types/node@20.14.0)(lightningcss@1.24.1)(terser@5.32.0))(vue@3.4.25(typescript@5.5.2))(webpack-sources@3.2.3)':
+    dependencies:
+      '@antfu/utils': 0.7.10
+      '@nuxt/devtools-kit': 1.5.2(magicast@0.3.5)(rollup@3.29.4)(vite@5.3.1(@types/node@20.14.0)(lightningcss@1.24.1)(terser@5.32.0))(webpack-sources@3.2.3)
+      '@nuxt/devtools-wizard': 1.5.2
+      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3)
+      '@vue/devtools-core': 7.4.4(vite@5.3.1(@types/node@20.14.0)(lightningcss@1.24.1)(terser@5.32.0))(vue@3.4.25(typescript@5.5.2))
+      '@vue/devtools-kit': 7.4.4
+      birpc: 0.2.17
+      consola: 3.2.3
+      cronstrue: 2.50.0
+      destr: 2.0.3
+      error-stack-parser-es: 0.1.5
+      execa: 7.2.0
+      fast-npm-meta: 0.2.2
+      flatted: 3.3.1
+      get-port-please: 3.1.2
+      hookable: 5.5.3
+      image-meta: 0.2.1
+      is-installed-globally: 1.0.0
+      launch-editor: 2.9.1
+      local-pkg: 0.5.0
+      magicast: 0.3.5
+      nypm: 0.3.11
+      ohash: 1.1.4
+      pathe: 1.1.2
+      perfect-debounce: 1.0.0
+      pkg-types: 1.2.0
+      rc9: 2.1.2
+      scule: 1.3.0
+      semver: 7.6.3
+      simple-git: 3.27.0
+      sirv: 2.0.4
+      tinyglobby: 0.2.6
+      unimport: 3.12.0(rollup@3.29.4)(webpack-sources@3.2.3)
+      vite: 5.3.1(@types/node@20.14.0)(lightningcss@1.24.1)(terser@5.32.0)
+      vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.2(magicast@0.3.5)(rollup@3.29.4)(webpack-sources@3.2.3))(rollup@3.29.4)(vite@5.3.1(@types/node@20.14.0)(lightningcss@1.24.1)(terser@5.32.0))
+      vite-plugin-vue-inspector: 5.1.3(vite@5.3.1(@types/node@20.14.0)(lightningcss@1.24.1)(terser@5.32.0))
       which: 3.0.1
       ws: 8.18.0
     transitivePeerDependencies:
@@ -23964,10 +24054,25 @@ snapshots:
   '@vue/babel-plugin-jsx@1.1.5(@babel/core@7.24.4)':
     dependencies:
       '@babel/core': 7.24.4
-      '@babel/helper-module-imports': 7.24.6
-      '@babel/plugin-syntax-jsx': 7.24.6(@babel/core@7.24.4)
-      '@babel/template': 7.24.6
-      '@babel/traverse': 7.24.1
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.24.4)
+      '@babel/template': 7.25.0
+      '@babel/traverse': 7.25.6
+      '@babel/types': 7.25.6
+      '@vue/babel-helper-vue-transform-on': 1.1.5
+      camelcase: 6.3.0
+      html-tags: 3.3.1
+      svg-tags: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vue/babel-plugin-jsx@1.1.5(@babel/core@7.25.2)':
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.25.2)
+      '@babel/template': 7.25.0
+      '@babel/traverse': 7.25.6
       '@babel/types': 7.25.6
       '@vue/babel-helper-vue-transform-on': 1.1.5
       camelcase: 6.3.0
@@ -25981,10 +26086,6 @@ snapshots:
   eastasianwidth@0.2.0: {}
 
   ee-first@1.1.1: {}
-
-  effect-log@0.32.0(effect@3.7.2):
-    dependencies:
-      effect: 3.7.2
 
   effect@3.7.2: {}
 
@@ -29537,7 +29638,7 @@ snapshots:
 
   metro-babel-transformer@0.80.9:
     dependencies:
-      '@babel/core': 7.24.4
+      '@babel/core': 7.25.2
       hermes-parser: 0.20.1
       nullthrows: 1.1.1
     transitivePeerDependencies:
@@ -29623,7 +29724,7 @@ snapshots:
 
   metro-transform-plugins@0.80.9:
     dependencies:
-      '@babel/core': 7.24.4
+      '@babel/core': 7.25.2
       '@babel/generator': 7.24.4
       '@babel/template': 7.24.6
       '@babel/traverse': 7.24.1
@@ -29633,7 +29734,7 @@ snapshots:
 
   metro-transform-worker@0.80.9(encoding@0.1.13):
     dependencies:
-      '@babel/core': 7.24.4
+      '@babel/core': 7.25.2
       '@babel/generator': 7.24.4
       '@babel/parser': 7.25.6
       '@babel/types': 7.25.6
@@ -34951,6 +35052,21 @@ snapshots:
       vitefu: 0.2.5(vite@5.3.1(@types/node@20.14.0)(lightningcss@1.24.1)(terser@5.32.0))
     optionalDependencies:
       '@testing-library/jest-dom': 6.4.8
+    transitivePeerDependencies:
+      - supports-color
+
+  vite-plugin-vue-inspector@5.1.3(vite@5.3.1(@types/node@20.14.0)(lightningcss@1.24.1)(terser@5.32.0)):
+    dependencies:
+      '@babel/core': 7.25.2
+      '@babel/plugin-proposal-decorators': 7.24.1(@babel/core@7.25.2)
+      '@babel/plugin-syntax-import-attributes': 7.24.6(@babel/core@7.25.2)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.25.2)
+      '@babel/plugin-transform-typescript': 7.24.4(@babel/core@7.25.2)
+      '@vue/babel-plugin-jsx': 1.1.5(@babel/core@7.25.2)
+      '@vue/compiler-dom': 3.4.25
+      kolorist: 1.8.0
+      magic-string: 0.30.11
+      vite: 5.3.1(@types/node@20.14.0)(lightningcss@1.24.1)(terser@5.32.0)
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ importers:
         version: 2.27.1
       '@effect/vitest':
         specifier: 0.13.1
-        version: 0.13.1(effect@3.10.1)(vitest@2.1.2(@types/node@20.16.11)(@vitest/browser@2.1.2)(happy-dom@13.10.1)(lightningcss@1.24.1)(msw@2.2.13(patch_hash=mpkjv35lscrawpqthnrnago5ai)(typescript@5.6.2))(terser@5.34.1))
+        version: 0.13.1(effect@3.10.2)(vitest@2.1.2(@types/node@20.16.11)(@vitest/browser@2.1.2)(happy-dom@13.10.1)(lightningcss@1.24.1)(msw@2.2.13(patch_hash=mpkjv35lscrawpqthnrnago5ai)(typescript@5.6.2))(terser@5.34.1))
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^4.2.1
         version: 4.2.1(@vue/compiler-sfc@3.5.11)(prettier@3.3.3)
@@ -345,11 +345,11 @@ importers:
   examples/backend-adapters/server:
     dependencies:
       '@effect/platform':
-        specifier: 0.69.5
-        version: 0.69.5(effect@3.10.1)
+        specifier: 0.69.6
+        version: 0.69.6(effect@3.10.2)
       '@effect/platform-node':
-        specifier: 0.64.6
-        version: 0.64.6(@effect/platform@0.69.5(effect@3.10.1))(effect@3.10.1)
+        specifier: 0.64.7
+        version: 0.64.7(@effect/platform@0.69.6(effect@3.10.2))(effect@3.10.2)
       '@elysiajs/cors':
         specifier: ^1.1.1
         version: 1.1.1(elysia@1.1.16(@sinclair/typebox@0.27.8)(openapi-types@12.1.3)(typescript@5.6.2))
@@ -366,8 +366,8 @@ importers:
         specifier: ^16.4.5
         version: 16.4.5
       effect:
-        specifier: 3.10.1
-        version: 3.10.1
+        specifier: 3.10.2
+        version: 3.10.2
       elysia:
         specifier: ^1.1.16
         version: 1.1.16(@sinclair/typebox@0.27.8)(openapi-types@12.1.3)(typescript@5.6.2)
@@ -1479,8 +1479,8 @@ importers:
         specifier: workspace:*
         version: link:../mime-types
       effect:
-        specifier: 3.10.1
-        version: 3.10.1
+        specifier: 3.10.2
+        version: 3.10.2
       sqids:
         specifier: ^0.3.0
         version: 0.3.0
@@ -1605,8 +1605,8 @@ importers:
   packages/uploadthing:
     dependencies:
       '@effect/platform':
-        specifier: 0.69.5
-        version: 0.69.5(effect@3.10.1)
+        specifier: 0.69.6
+        version: 0.69.6(effect@3.10.2)
       '@uploadthing/mime-types':
         specifier: workspace:*
         version: link:../mime-types
@@ -1614,8 +1614,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       effect:
-        specifier: 3.10.1
-        version: 3.10.1
+        specifier: 3.10.2
+        version: 3.10.2
     devDependencies:
       '@remix-run/server-runtime':
         specifier: ^2.12.0
@@ -2921,22 +2921,22 @@ packages:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
 
-  '@effect/platform-node-shared@0.19.5':
-    resolution: {integrity: sha512-+BPCoYVqdhlBxozJP0bfIIzneA8L3N+2+tjLgleNA9yHrKoYzeyEkF4DJ5/WifPa80o78FqU0TP94HQQypZDRA==}
+  '@effect/platform-node-shared@0.19.6':
+    resolution: {integrity: sha512-mgWeB1Td8SjfB9UacodJyIZcK7vRtdu9NCBGt9UvgRBlTWpjjdW3FgUWDHTq3uBWog0upC8o2BjDX3JRenmt5w==}
     peerDependencies:
-      '@effect/platform': ^0.69.5
-      effect: ^3.10.1
+      '@effect/platform': ^0.69.6
+      effect: ^3.10.2
 
-  '@effect/platform-node@0.64.6':
-    resolution: {integrity: sha512-GRRBxkGhZR2lEVHuQsFoeVLhJ/c5GNKvMpKnFKMitXr/0R2pouanwRMYufnNcRlf1FpeRTvRz4QzuR8iKGeXQQ==}
+  '@effect/platform-node@0.64.7':
+    resolution: {integrity: sha512-a/wNZ6+NMN+X3xZ+11A/Ce0XDwyud2vkP+HtsuK8Td/Xw+VVW/UyvOVl3V2R5ytVdNxCszO9d/oSD9Y+EXP7+w==}
     peerDependencies:
-      '@effect/platform': ^0.69.5
-      effect: ^3.10.1
+      '@effect/platform': ^0.69.6
+      effect: ^3.10.2
 
-  '@effect/platform@0.69.5':
-    resolution: {integrity: sha512-1CLhrXbZPyqRdtbZQc4dOzTXLnJEwwhF9BBEQoMK5aGBpp7sCtzOyF/MPbFNTVaK+7jO338YsOiY6sMX2ao3Mg==}
+  '@effect/platform@0.69.6':
+    resolution: {integrity: sha512-1bFUVdWNuEAhmTkpZ4nyiVms95fVELbM+1ba1q6Rjd13eEHh7dMF/iZXO+Su3shdgx4CdNitUAO53F+nr93zdg==}
     peerDependencies:
-      effect: ^3.10.1
+      effect: ^3.10.2
 
   '@effect/vitest@0.13.1':
     resolution: {integrity: sha512-0Haoi17RqFKsz7MQMqaw9KmOqRkR8jbmKaVqYZeOtw2IgL8FbZHTBxNeVOF72wmXjlDphVSXGXnltn67ZuLAQg==}
@@ -8718,8 +8718,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  effect@3.10.1:
-    resolution: {integrity: sha512-Ny0I3WvGykUnlgmQVkNVbkXHE/pPTWVwmnYfpVZYyLlpe53LVyWViY9+a/7iS/Rqml0xUwJoXx5HK6ksK09Y2Q==}
+  effect@3.10.2:
+    resolution: {integrity: sha512-Sj73q9jwwR4t3WV6E0sw4KMhx0fAHebXavYS5rsHLrWKcf4fzhDh6IixJB6mDhT7rEax/9UsoYjzrc1p7VLwbw==}
 
   electron-to-chromium@1.5.28:
     resolution: {integrity: sha512-VufdJl+rzaKZoYVUijN13QcXVF5dWPZANeFTLNy+OSpHdDL5ynXTF35+60RSBbaQYB1ae723lQXHCrf4pyLsMw==}
@@ -17537,18 +17537,18 @@ snapshots:
 
   '@discoveryjs/json-ext@0.5.7': {}
 
-  '@effect/platform-node-shared@0.19.5(@effect/platform@0.69.5(effect@3.10.1))(effect@3.10.1)':
+  '@effect/platform-node-shared@0.19.6(@effect/platform@0.69.6(effect@3.10.2))(effect@3.10.2)':
     dependencies:
-      '@effect/platform': 0.69.5(effect@3.10.1)
+      '@effect/platform': 0.69.6(effect@3.10.2)
       '@parcel/watcher': 2.4.1
-      effect: 3.10.1
+      effect: 3.10.2
       multipasta: 0.2.5
 
-  '@effect/platform-node@0.64.6(@effect/platform@0.69.5(effect@3.10.1))(effect@3.10.1)':
+  '@effect/platform-node@0.64.7(@effect/platform@0.69.6(effect@3.10.2))(effect@3.10.2)':
     dependencies:
-      '@effect/platform': 0.69.5(effect@3.10.1)
-      '@effect/platform-node-shared': 0.19.5(@effect/platform@0.69.5(effect@3.10.1))(effect@3.10.1)
-      effect: 3.10.1
+      '@effect/platform': 0.69.6(effect@3.10.2)
+      '@effect/platform-node-shared': 0.19.6(@effect/platform@0.69.6(effect@3.10.2))(effect@3.10.2)
+      effect: 3.10.2
       mime: 3.0.0
       undici: 6.19.8
       ws: 8.18.0
@@ -17556,15 +17556,15 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform@0.69.5(effect@3.10.1)':
+  '@effect/platform@0.69.6(effect@3.10.2)':
     dependencies:
-      effect: 3.10.1
+      effect: 3.10.2
       find-my-way-ts: 0.1.5
       multipasta: 0.2.5
 
-  '@effect/vitest@0.13.1(effect@3.10.1)(vitest@2.1.2(@types/node@20.16.11)(@vitest/browser@2.1.2)(happy-dom@13.10.1)(lightningcss@1.24.1)(msw@2.2.13(patch_hash=mpkjv35lscrawpqthnrnago5ai)(typescript@5.6.2))(terser@5.34.1))':
+  '@effect/vitest@0.13.1(effect@3.10.2)(vitest@2.1.2(@types/node@20.16.11)(@vitest/browser@2.1.2)(happy-dom@13.10.1)(lightningcss@1.24.1)(msw@2.2.13(patch_hash=mpkjv35lscrawpqthnrnago5ai)(typescript@5.6.2))(terser@5.34.1))':
     dependencies:
-      effect: 3.10.1
+      effect: 3.10.2
       vitest: 2.1.2(@types/node@20.16.11)(@vitest/browser@2.1.2(@vitest/spy@2.1.2)(typescript@5.6.2)(vite@5.4.8(@types/node@20.16.11)(lightningcss@1.24.1)(terser@5.34.1))(vitest@2.1.2))(happy-dom@13.10.1)(lightningcss@1.24.1)(msw@2.2.13(patch_hash=mpkjv35lscrawpqthnrnago5ai)(typescript@5.6.2))(terser@5.34.1)
 
   '@egjs/agent@2.4.3': {}
@@ -24974,7 +24974,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  effect@3.10.1:
+  effect@3.10.2:
     dependencies:
       fast-check: 3.22.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,8 +26,8 @@ importers:
         specifier: ^2.27.1
         version: 2.27.1
       '@effect/vitest':
-        specifier: 0.12.1
-        version: 0.12.1(effect@3.9.2)(vitest@2.1.2(@types/node@20.16.11)(@vitest/browser@2.1.2)(happy-dom@13.10.1)(lightningcss@1.24.1)(msw@2.2.13(patch_hash=mpkjv35lscrawpqthnrnago5ai)(typescript@5.6.2))(terser@5.34.1))
+        specifier: 0.13.1
+        version: 0.13.1(effect@3.10.1)(vitest@2.1.2(@types/node@20.16.11)(@vitest/browser@2.1.2)(happy-dom@13.10.1)(lightningcss@1.24.1)(msw@2.2.13(patch_hash=mpkjv35lscrawpqthnrnago5ai)(typescript@5.6.2))(terser@5.34.1))
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^4.2.1
         version: 4.2.1(@vue/compiler-sfc@3.5.11)(prettier@3.3.3)
@@ -345,14 +345,11 @@ importers:
   examples/backend-adapters/server:
     dependencies:
       '@effect/platform':
-        specifier: 0.68.5
-        version: 0.68.5(@effect/schema@0.75.4(effect@3.9.2))(effect@3.9.2)
+        specifier: 0.69.5
+        version: 0.69.5(effect@3.10.1)
       '@effect/platform-node':
-        specifier: 0.63.5
-        version: 0.63.5(@effect/platform@0.68.5(@effect/schema@0.75.4(effect@3.9.2))(effect@3.9.2))(effect@3.9.2)
-      '@effect/schema':
-        specifier: 0.75.4
-        version: 0.75.4(effect@3.9.2)
+        specifier: 0.64.6
+        version: 0.64.6(@effect/platform@0.69.5(effect@3.10.1))(effect@3.10.1)
       '@elysiajs/cors':
         specifier: ^1.1.1
         version: 1.1.1(elysia@1.1.16(@sinclair/typebox@0.27.8)(openapi-types@12.1.3)(typescript@5.6.2))
@@ -369,8 +366,8 @@ importers:
         specifier: ^16.4.5
         version: 16.4.5
       effect:
-        specifier: 3.9.2
-        version: 3.9.2
+        specifier: 3.10.1
+        version: 3.10.1
       elysia:
         specifier: ^1.1.16
         version: 1.1.16(@sinclair/typebox@0.27.8)(openapi-types@12.1.3)(typescript@5.6.2)
@@ -1482,8 +1479,8 @@ importers:
         specifier: workspace:*
         version: link:../mime-types
       effect:
-        specifier: 3.9.2
-        version: 3.9.2
+        specifier: 3.10.1
+        version: 3.10.1
       sqids:
         specifier: ^0.3.0
         version: 0.3.0
@@ -1608,11 +1605,8 @@ importers:
   packages/uploadthing:
     dependencies:
       '@effect/platform':
-        specifier: 0.68.5
-        version: 0.68.5(@effect/schema@0.75.4(effect@3.9.2))(effect@3.9.2)
-      '@effect/schema':
-        specifier: 0.75.4
-        version: 0.75.4(effect@3.9.2)
+        specifier: 0.69.5
+        version: 0.69.5(effect@3.10.1)
       '@uploadthing/mime-types':
         specifier: workspace:*
         version: link:../mime-types
@@ -1620,8 +1614,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       effect:
-        specifier: 3.9.2
-        version: 3.9.2
+        specifier: 3.10.1
+        version: 3.10.1
     devDependencies:
       '@remix-run/server-runtime':
         specifier: ^2.12.0
@@ -2927,33 +2921,27 @@ packages:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
 
-  '@effect/platform-node-shared@0.18.5':
-    resolution: {integrity: sha512-7x+ixL7x/q2xcY1WA2e6TED0PQrjk04NbvPuNbP9rmlJmrYRrJWTiHJ+mBLCmShBqjs645qwe7bUX0MdXtI8dg==}
+  '@effect/platform-node-shared@0.19.5':
+    resolution: {integrity: sha512-+BPCoYVqdhlBxozJP0bfIIzneA8L3N+2+tjLgleNA9yHrKoYzeyEkF4DJ5/WifPa80o78FqU0TP94HQQypZDRA==}
     peerDependencies:
-      '@effect/platform': ^0.68.5
-      effect: ^3.9.2
+      '@effect/platform': ^0.69.5
+      effect: ^3.10.1
 
-  '@effect/platform-node@0.63.5':
-    resolution: {integrity: sha512-sSd37p613YEsJuvG8IOa+vGBZFKdV6IpWlxzs0/S5nDar3fj8zmq4lrdtyX0JgqLdluNnuoaxrNjirjp9ye29w==}
+  '@effect/platform-node@0.64.6':
+    resolution: {integrity: sha512-GRRBxkGhZR2lEVHuQsFoeVLhJ/c5GNKvMpKnFKMitXr/0R2pouanwRMYufnNcRlf1FpeRTvRz4QzuR8iKGeXQQ==}
     peerDependencies:
-      '@effect/platform': ^0.68.5
-      effect: ^3.9.2
+      '@effect/platform': ^0.69.5
+      effect: ^3.10.1
 
-  '@effect/platform@0.68.5':
-    resolution: {integrity: sha512-r3W8c9aTlVDHz/7L+mll8ivM/sO1JXWW3GrJGsZvL6X2jdkCBUuaAtJzOw085eVRye916dUP+uiLjlLid9mMuw==}
+  '@effect/platform@0.69.5':
+    resolution: {integrity: sha512-1CLhrXbZPyqRdtbZQc4dOzTXLnJEwwhF9BBEQoMK5aGBpp7sCtzOyF/MPbFNTVaK+7jO338YsOiY6sMX2ao3Mg==}
     peerDependencies:
-      '@effect/schema': ^0.75.4
-      effect: ^3.9.2
+      effect: ^3.10.1
 
-  '@effect/schema@0.75.4':
-    resolution: {integrity: sha512-qpFOkkoCFgQz/r6FIeO2w3CxAD1O/K1n2ELA69VHHy9VDUskBnX+4zzYOGCi5yKAtgg61zueDIwouRwQ3dlhqw==}
+  '@effect/vitest@0.13.1':
+    resolution: {integrity: sha512-0Haoi17RqFKsz7MQMqaw9KmOqRkR8jbmKaVqYZeOtw2IgL8FbZHTBxNeVOF72wmXjlDphVSXGXnltn67ZuLAQg==}
     peerDependencies:
-      effect: ^3.9.2
-
-  '@effect/vitest@0.12.1':
-    resolution: {integrity: sha512-dUzg1CVgro8aeAVYeCEEMQlnx60CXxbztxH9KDG6/oLRZ/YixHWNytA9PGsC9UPYSgHAahjsn446HgQAnCpX4Q==}
-    peerDependencies:
-      effect: ^3.9.2
+      effect: ^3.10.1
       vitest: ^2.0.5
 
   '@egjs/agent@2.4.3':
@@ -8730,8 +8718,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  effect@3.9.2:
-    resolution: {integrity: sha512-1sx/v1HTWHTodXfzWxAFg+SCF+ACgpJVruaAMIh/NmDVvrUsf0x9PzpXvkgJUbQ1fMdmKYK//FqxeHSQ+Zxv/Q==}
+  effect@3.10.1:
+    resolution: {integrity: sha512-Ny0I3WvGykUnlgmQVkNVbkXHE/pPTWVwmnYfpVZYyLlpe53LVyWViY9+a/7iS/Rqml0xUwJoXx5HK6ksK09Y2Q==}
 
   electron-to-chromium@1.5.28:
     resolution: {integrity: sha512-VufdJl+rzaKZoYVUijN13QcXVF5dWPZANeFTLNy+OSpHdDL5ynXTF35+60RSBbaQYB1ae723lQXHCrf4pyLsMw==}
@@ -17549,18 +17537,18 @@ snapshots:
 
   '@discoveryjs/json-ext@0.5.7': {}
 
-  '@effect/platform-node-shared@0.18.5(@effect/platform@0.68.5(@effect/schema@0.75.4(effect@3.9.2))(effect@3.9.2))(effect@3.9.2)':
+  '@effect/platform-node-shared@0.19.5(@effect/platform@0.69.5(effect@3.10.1))(effect@3.10.1)':
     dependencies:
-      '@effect/platform': 0.68.5(@effect/schema@0.75.4(effect@3.9.2))(effect@3.9.2)
+      '@effect/platform': 0.69.5(effect@3.10.1)
       '@parcel/watcher': 2.4.1
-      effect: 3.9.2
+      effect: 3.10.1
       multipasta: 0.2.5
 
-  '@effect/platform-node@0.63.5(@effect/platform@0.68.5(@effect/schema@0.75.4(effect@3.9.2))(effect@3.9.2))(effect@3.9.2)':
+  '@effect/platform-node@0.64.6(@effect/platform@0.69.5(effect@3.10.1))(effect@3.10.1)':
     dependencies:
-      '@effect/platform': 0.68.5(@effect/schema@0.75.4(effect@3.9.2))(effect@3.9.2)
-      '@effect/platform-node-shared': 0.18.5(@effect/platform@0.68.5(@effect/schema@0.75.4(effect@3.9.2))(effect@3.9.2))(effect@3.9.2)
-      effect: 3.9.2
+      '@effect/platform': 0.69.5(effect@3.10.1)
+      '@effect/platform-node-shared': 0.19.5(@effect/platform@0.69.5(effect@3.10.1))(effect@3.10.1)
+      effect: 3.10.1
       mime: 3.0.0
       undici: 6.19.8
       ws: 8.18.0
@@ -17568,21 +17556,15 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform@0.68.5(@effect/schema@0.75.4(effect@3.9.2))(effect@3.9.2)':
+  '@effect/platform@0.69.5(effect@3.10.1)':
     dependencies:
-      '@effect/schema': 0.75.4(effect@3.9.2)
-      effect: 3.9.2
+      effect: 3.10.1
       find-my-way-ts: 0.1.5
       multipasta: 0.2.5
 
-  '@effect/schema@0.75.4(effect@3.9.2)':
+  '@effect/vitest@0.13.1(effect@3.10.1)(vitest@2.1.2(@types/node@20.16.11)(@vitest/browser@2.1.2)(happy-dom@13.10.1)(lightningcss@1.24.1)(msw@2.2.13(patch_hash=mpkjv35lscrawpqthnrnago5ai)(typescript@5.6.2))(terser@5.34.1))':
     dependencies:
-      effect: 3.9.2
-      fast-check: 3.22.0
-
-  '@effect/vitest@0.12.1(effect@3.9.2)(vitest@2.1.2(@types/node@20.16.11)(@vitest/browser@2.1.2)(happy-dom@13.10.1)(lightningcss@1.24.1)(msw@2.2.13(patch_hash=mpkjv35lscrawpqthnrnago5ai)(typescript@5.6.2))(terser@5.34.1))':
-    dependencies:
-      effect: 3.9.2
+      effect: 3.10.1
       vitest: 2.1.2(@types/node@20.16.11)(@vitest/browser@2.1.2(@vitest/spy@2.1.2)(typescript@5.6.2)(vite@5.4.8(@types/node@20.16.11)(lightningcss@1.24.1)(terser@5.34.1))(vitest@2.1.2))(happy-dom@13.10.1)(lightningcss@1.24.1)(msw@2.2.13(patch_hash=mpkjv35lscrawpqthnrnago5ai)(typescript@5.6.2))(terser@5.34.1)
 
   '@egjs/agent@2.4.3': {}
@@ -24992,7 +24974,9 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  effect@3.9.2: {}
+  effect@3.10.1:
+    dependencies:
+      fast-check: 3.22.0
 
   electron-to-chromium@1.5.28: {}
 


### PR DESCRIPTION
There's been a couple times where people report debug logs and expose their API keys. Playing around with [`effect/Redacted`](https://effect.website/docs/other/data-types/redacted) to see if we can mitigate this

Currently doesn't quite solve the issue though as we need to unpack it before giving the value to `@effect/platform`, which then exposes it when the response gets logged. Talked with the effect folks and they seem to agree that platform should accept `Redacted` values and handle the unpacking internally and keeping the values Redacted when logging the Request/Response. Ref: https://discord.com/channels/795981131316985866/1233513641735618661/1290807495878774895

---

Also switches to the built-in pretty logger (introduced in Effect 3.6 iirc) instead of the 3rd party one, one less dep and it handles annotations a bit better:
![CleanShot 2024-10-03 at 00 21 29](https://github.com/user-attachments/assets/4ea7834e-bbd2-4e26-8c1f-53efb1a991cf)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced security for sensitive data handling by utilizing a redaction mechanism for API keys and secrets across various components.
  
- **Bug Fixes**
	- Corrected type handling for sensitive fields in schemas and functions to ensure consistent redaction.

- **Documentation**
	- Updated import paths for the `Schema` module to reflect structural changes in the project.

- **Tests**
	- Improved test cases to utilize redacted values for sensitive information, ensuring better security practices in testing.

- **Chores**
	- Incremented dependency versions for improved functionality and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->