### PR TITLE
chore: more elaborate response log when API request fails

### DIFF
--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -379,11 +379,11 @@ const handleCallbackRequest = (opts: {
         }),
         HttpClientRequest.jsonBody(payload),
         Effect.flatMap(HttpClient.filterStatusOk(httpClient)),
-        Effect.tapErrorTag("ResponseError", ({ response: res }) =>
-          Effect.flatMap(res.json, (json) =>
+        Effect.tapErrorTag("ResponseError", (err) =>
+          Effect.flatMap(err.response.json, () =>
             Effect.logError(
-              `Failed to register callback result (${res.status})`,
-            ).pipe(Effect.annotateLogs("error", json)),
+              `Failed to register callback result (${err.response.status})`,
+            ).pipe(Effect.annotateLogs("response", err.response)),
           ),
         ),
         HttpClientResponse.schemaBodyJsonScoped(CallbackResultResponse),
@@ -619,13 +619,10 @@ const handleUploadAction = (opts: {
           ),
         onFailure: (err) =>
           err._tag === "ResponseError"
-            ? Effect.flatMap(err.response.json, (json) =>
+            ? Effect.flatMap(err.response.json, () =>
                 Effect.logError(
                   `Failed to register metadata (${err.response.status})`,
-                ).pipe(
-                  Effect.annotateLogs("response", err.response),
-                  Effect.annotateLogs("json", json),
-                ),
+                ).pipe(Effect.annotateLogs("response", err.response)),
               )
             : Effect.logError("Failed to register metadata").pipe(
                 Effect.annotateLogs("error", err),
@@ -667,12 +664,11 @@ const handleUploadAction = (opts: {
                     ),
                   onFailure: (err) =>
                     err._tag === "ResponseError"
-                      ? Effect.flatMap(err.response.json, (json) =>
+                      ? Effect.flatMap(err.response.json, () =>
                           Effect.logError(
                             `Failed to forward callback request from dev stream (${err.response.status})`,
                           ).pipe(
                             Effect.annotateLogs("response", err.response),
-                            Effect.annotateLogs("json", json),
                             Effect.annotateLogs("hook", hook),
                             Effect.annotateLogs("signature", signature),
                             Effect.annotateLogs("payload", payload),

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -622,7 +622,7 @@ const handleUploadAction = (opts: {
       onTrue: () =>
         metadataRequest.pipe(
           Effect.tapBoth({
-            onSuccess: logHttpClientResponse("Registerred metadata", {
+            onSuccess: logHttpClientResponse("Registered metadata", {
               mixin: "None", // We're reading the stream so can't call a body mixin
             }),
             onFailure: logHttpClientError("Failed to register metadata"),
@@ -656,7 +656,7 @@ const handleUploadAction = (opts: {
       onFalse: () =>
         metadataRequest.pipe(
           Effect.tapBoth({
-            onSuccess: logHttpClientResponse("Registerred metadata"),
+            onSuccess: logHttpClientResponse("Registered metadata"),
             onFailure: logHttpClientError("Failed to register metadata"),
           }),
           HttpClientResponse.schemaBodyJsonScoped(MetadataFetchResponse),

--- a/packages/uploadthing/src/internal/logger.ts
+++ b/packages/uploadthing/src/internal/logger.ts
@@ -1,3 +1,4 @@
+import type { HttpBody, HttpClientError } from "@effect/platform";
 import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -51,3 +52,14 @@ export const withLogFormat = Effect.gen(function* () {
   ),
   Layer.unwrapEffect,
 );
+
+export const logHttpClientError =
+  (message: string) =>
+  (err: HttpClientError.HttpClientError | HttpBody.HttpBodyError) =>
+    err._tag === "ResponseError"
+      ? Effect.flatMap(err.response.json, () =>
+          Effect.logError(`${message} (${err.response.status})`).pipe(
+            Effect.annotateLogs("response", err.response),
+          ),
+        )
+      : Effect.logError(message).pipe(Effect.annotateLogs("error", err));

--- a/packages/uploadthing/src/internal/logger.ts
+++ b/packages/uploadthing/src/internal/logger.ts
@@ -1,4 +1,8 @@
-import type { HttpBody, HttpClientError } from "@effect/platform";
+import type {
+  HttpBody,
+  HttpClientError,
+  HttpClientResponse,
+} from "@effect/platform";
 import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -53,13 +57,31 @@ export const withLogFormat = Effect.gen(function* () {
   Layer.unwrapEffect,
 );
 
+type HttpClientResponseMixinMethod = "json" | "text" | "arrayBuffer" | "None";
+
+export const logHttpClientResponse = (
+  message: string,
+  opts?: {
+    /** Level to log on, default "Debug" */
+    level?: LogLevel.Literal;
+    /** What body mixin to use to get the response body, default "json" */
+    mixin?: HttpClientResponseMixinMethod;
+  },
+) => {
+  const mixin = opts?.mixin ?? "json";
+  const level = LogLevel.fromLiteral(opts?.level ?? "Debug");
+
+  return (response: HttpClientResponse.HttpClientResponse) =>
+    Effect.flatMap(mixin !== "None" ? response[mixin] : Effect.void, () =>
+      Effect.logWithLevel(level, `${message} (${response.status})`).pipe(
+        Effect.annotateLogs("response", response),
+      ),
+    );
+};
+
 export const logHttpClientError =
   (message: string) =>
   (err: HttpClientError.HttpClientError | HttpBody.HttpBodyError) =>
     err._tag === "ResponseError"
-      ? Effect.flatMap(err.response.json, () =>
-          Effect.logError(`${message} (${err.response.status})`).pipe(
-            Effect.annotateLogs("response", err.response),
-          ),
-        )
+      ? logHttpClientResponse(message, { level: "Error" })(err.response)
       : Effect.logError(message).pipe(Effect.annotateLogs("error", err));

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -85,13 +85,10 @@ export class UTApi {
 
           onFailure: (err) =>
             err._tag === "ResponseError"
-              ? Effect.flatMap(err.response.json, (json) =>
+              ? Effect.flatMap(err.response.json, () =>
                   Effect.logError(
                     `Failed to request UploadThing API (${err.response.status})`,
-                  ).pipe(
-                    Effect.annotateLogs("response", err.response),
-                    Effect.annotateLogs("json", json),
-                  ),
+                  ).pipe(Effect.annotateLogs("response", err.response)),
                 )
               : Effect.logError("Failed to request UploadThing API").pipe(
                   Effect.annotateLogs("error", err),

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -27,7 +27,11 @@ import {
   UPLOADTHING_VERSION,
   UTToken,
 } from "../internal/config";
-import { withLogFormat, withMinimalLogLevel } from "../internal/logger";
+import {
+  logHttpClientError,
+  withLogFormat,
+  withMinimalLogLevel,
+} from "../internal/logger";
 import type {
   ACLUpdateOptions,
   DeleteFilesOptions,
@@ -79,20 +83,11 @@ export class UTApi {
         HttpClient.filterStatusOk(httpClient),
         Effect.tapBoth({
           onSuccess: (res) =>
-            Effect.logDebug(`UT Response`).pipe(
-              Effect.annotateLogs("res", res),
+            Effect.logDebug(`UploadThing API Response`).pipe(
+              Effect.annotateLogs("response", res),
             ),
 
-          onFailure: (err) =>
-            err._tag === "ResponseError"
-              ? Effect.flatMap(err.response.json, () =>
-                  Effect.logError(
-                    `Failed to request UploadThing API (${err.response.status})`,
-                  ).pipe(Effect.annotateLogs("response", err.response)),
-                )
-              : Effect.logError("Failed to request UploadThing API").pipe(
-                  Effect.annotateLogs("error", err),
-                ),
+          onFailure: logHttpClientError("Failed to request UploadThing API"),
         }),
         HttpClientResponse.schemaBodyJsonScoped(responseSchema),
       );

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -82,10 +82,20 @@ export class UTApi {
             Effect.logDebug(`UT Response`).pipe(
               Effect.annotateLogs("res", res),
             ),
+
           onFailure: (err) =>
-            Effect.logError("UploadThing error").pipe(
-              Effect.annotateLogs("error", err),
-            ),
+            err._tag === "ResponseError"
+              ? Effect.flatMap(err.response.json, (json) =>
+                  Effect.logError(
+                    `Failed to request UploadThing API (${err.response.status})`,
+                  ).pipe(
+                    Effect.annotateLogs("response", err.response),
+                    Effect.annotateLogs("json", json),
+                  ),
+                )
+              : Effect.logError("Failed to request UploadThing API").pipe(
+                  Effect.annotateLogs("error", err),
+                ),
         }),
         HttpClientResponse.schemaBodyJsonScoped(responseSchema),
       );

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -29,6 +29,7 @@ import {
 } from "../internal/config";
 import {
   logHttpClientError,
+  logHttpClientResponse,
   withLogFormat,
   withMinimalLogLevel,
 } from "../internal/logger";
@@ -82,11 +83,7 @@ export class UTApi {
         }),
         HttpClient.filterStatusOk(httpClient),
         Effect.tapBoth({
-          onSuccess: (res) =>
-            Effect.logDebug(`UploadThing API Response`).pipe(
-              Effect.annotateLogs("response", res),
-            ),
-
+          onSuccess: logHttpClientResponse("UploadThing API Response"),
           onFailure: logHttpClientError("Failed to request UploadThing API"),
         }),
         HttpClientResponse.schemaBodyJsonScoped(responseSchema),

--- a/packages/uploadthing/test/sdk.test.ts
+++ b/packages/uploadthing/test/sdk.test.ts
@@ -24,11 +24,6 @@ import {
   UTFS_IO_URL,
 } from "./__test-helpers";
 
-const fooFile = new File(["foo"], "foo.txt", { type: "text/plain" });
-
-const utapi = new UTApi({ token: testToken.encoded });
-const result = await utapi.uploadFiles(fooFile);
-
 describe("uploadFiles", () => {
   const fooFile = new File(["foo"], "foo.txt", { type: "text/plain" });
 

--- a/packages/uploadthing/test/sdk.test.ts
+++ b/packages/uploadthing/test/sdk.test.ts
@@ -24,6 +24,11 @@ import {
   UTFS_IO_URL,
 } from "./__test-helpers";
 
+const fooFile = new File(["foo"], "foo.txt", { type: "text/plain" });
+
+const utapi = new UTApi({ token: testToken.encoded });
+const result = await utapi.uploadFiles(fooFile);
+
 describe("uploadFiles", () => {
   const fooFile = new File(["foo"], "foo.txt", { type: "text/plain" });
 


### PR DESCRIPTION
just attaching `response` as a log annotation doesn't include the response body if it hasn't been consumed yet. this PR adds a helper that unwraps body for better debug info



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for upload requests, providing clearer insights into failures.
	- Improved logging for both successful and erroneous API responses.

- **Bug Fixes**
	- Streamlined error logging for HTTP client interactions, promoting clearer and more maintainable logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->