### PR TITLE
chore: deprecate `UTApi.getFileUrls`

### DIFF
--- a/.changeset/chilled-zoos-exist.md
+++ b/.changeset/chilled-zoos-exist.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+chore: deprecate `UTApi.getFileUrls`. 📚 Read [Accessing files](https://docs.uploadthing.com/working-with-files#accessing-files) on how to safely access files without requiring an extra API call

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -271,6 +271,8 @@ export class UTApi {
    * @example
    * const data = await getFileUrls(["2e0fdb64-9957-4262-8e45-f372ba903ac8_image.jpg","1649353b-04ea-48a2-9db7-31de7f562c8d_image2.jpg"])
    * console.log(data) // [{key: "2e0fdb64-9957-4262-8e45-f372ba903ac8_image.jpg", url: "https://uploadthing.com/f/2e0fdb64-9957-4262-8e45-f372ba903ac8_image.jpg" },{key: "1649353b-04ea-48a2-9db7-31de7f562c8d_image2.jpg", url: "https://uploadthing.com/f/1649353b-04ea-48a2-9db7-31de7f562c8d_image2.jpg"}]
+   *
+   * @deprecated - See https://docs.uploadthing.com/working-with-files#accessing-files for info how to access files
    */
   getFileUrls = async (keys: string[] | string, opts?: GetFileUrlsOptions) => {
     guardServerOnly();


### PR DESCRIPTION
the endpoint is already deprecated long ago and no longer part of the OpenAPI spec: https://docs.uploadthing.com/api-reference/openapi-spec

Docs also says it's deprecated already: https://docs.uploadthing.com/api-reference/ut-api#get-file-urls
