### PR TITLE
chore: pass `files` to `styleFieldArg`

### DIFF
--- a/docs/src/app/(docs)/concepts/theming/page.mdx
+++ b/docs/src/app/(docs)/concepts/theming/page.mdx
@@ -135,6 +135,7 @@ type ButtonCallbackArguments = {
   isUploading: boolean;
   uploadProgress: number;
   fileTypes: string[];
+  files: File[];
 };
 
 type DropzoneCallbackArguments = {
@@ -143,6 +144,7 @@ type DropzoneCallbackArguments = {
   uploadProgress: number;
   fileTypes: string[];
   isDragActive: boolean;
+  files: File[];
 };
 ```
 

--- a/packages/react/src/components/button.tsx
+++ b/packages/react/src/components/button.tsx
@@ -32,6 +32,7 @@ type ButtonStyleFieldCallbackArgs = {
   isUploading: boolean;
   uploadProgress: number;
   fileTypes: string[];
+  files: File[];
 };
 
 type ButtonAppearance = {
@@ -218,12 +219,17 @@ export function UploadButton<
     if (mode === "auto") uploadFiles(files);
   });
 
-  const styleFieldArg = {
-    ready: state !== "readying",
-    isUploading: state === "uploading",
-    uploadProgress,
-    fileTypes,
-  } as ButtonStyleFieldCallbackArgs;
+  const styleFieldArg = useMemo(
+    () =>
+      ({
+        ready: state !== "readying",
+        isUploading: state === "uploading",
+        uploadProgress,
+        fileTypes,
+        files,
+      }) as ButtonStyleFieldCallbackArgs,
+    [fileTypes, files, state, uploadProgress],
+  );
 
   const renderButton = () => {
     const customContent = contentFieldToContent(

--- a/packages/react/src/components/dropzone.tsx
+++ b/packages/react/src/components/dropzone.tsx
@@ -60,6 +60,7 @@ type DropzoneStyleFieldCallbackArgs = {
   uploadProgress: number;
   fileTypes: string[];
   isDragActive: boolean;
+  files: File[];
 };
 
 type DropzoneAppearance = {
@@ -249,13 +250,18 @@ export function UploadDropzone<
     if (mode === "auto") uploadFiles(filesToUpload);
   });
 
-  const styleFieldArg = {
-    ready: state !== "readying",
-    isUploading: state === "uploading",
-    uploadProgress,
-    fileTypes,
-    isDragActive,
-  } as DropzoneStyleFieldCallbackArgs;
+  const styleFieldArg = useMemo(
+    () =>
+      ({
+        ready: state !== "readying",
+        isUploading: state === "uploading",
+        uploadProgress,
+        fileTypes,
+        files,
+        isDragActive,
+      }) as DropzoneStyleFieldCallbackArgs,
+    [fileTypes, files, state, uploadProgress, isDragActive],
+  );
 
   const getUploadButtonContents = () => {
     const customContent = contentFieldToContent(

--- a/packages/solid/src/components/button.tsx
+++ b/packages/solid/src/components/button.tsx
@@ -29,6 +29,7 @@ type ButtonStyleFieldCallbackArgs = {
   isUploading: () => boolean;
   uploadProgress: () => number;
   fileTypes: () => string[];
+  files: () => File[];
 };
 
 type ButtonAppearance = {
@@ -175,6 +176,7 @@ export function UploadButton<
     isUploading: uploadThing.isUploading,
     uploadProgress: uploadProgress,
     fileTypes: () => fileInfo().fileTypes,
+    files,
   } as ButtonStyleFieldCallbackArgs;
 
   const getButtonContent = () => {

--- a/packages/solid/src/components/dropzone.tsx
+++ b/packages/solid/src/components/dropzone.tsx
@@ -53,6 +53,7 @@ type DropzoneStyleFieldCallbackArgs = {
   uploadProgress: () => number;
   fileTypes: () => string[];
   isDragActive: () => boolean;
+  files: () => File[];
 };
 
 type DropzoneAppearance = {
@@ -222,6 +223,7 @@ export const UploadDropzone = <
     uploadProgress: uploadProgress,
     fileTypes: () => fileInfo().fileTypes,
     isDragActive: () => isDragActive,
+    files,
   } as DropzoneStyleFieldCallbackArgs;
 
   return (

--- a/packages/svelte/src/lib/component/UploadButton.svelte
+++ b/packages/svelte/src/lib/component/UploadButton.svelte
@@ -38,6 +38,7 @@
     isUploading: boolean;
     uploadProgress: number;
     fileTypes: string[];
+    files: File[];
   };
 
   type UploadButtonAppearance = {
@@ -135,6 +136,7 @@
     isUploading: state === "uploading",
     uploadProgress,
     fileTypes,
+    files,
   } as ButtonStyleFieldCallbackArgs;
 </script>
 

--- a/packages/svelte/src/lib/component/UploadDropzone.svelte
+++ b/packages/svelte/src/lib/component/UploadDropzone.svelte
@@ -40,6 +40,7 @@
     uploadProgress: number;
     fileTypes: string[];
     isDragActive: boolean;
+    files: File[];
   };
 
   type UploadDropzoneAppearance = {
@@ -185,6 +186,7 @@
     isUploading: $isUploading,
     ready,
     uploadProgress,
+    files,
   } satisfies DropzoneStyleFieldCallbackArgs;
 
   $: state = (() => {

--- a/packages/vue/src/components/button.tsx
+++ b/packages/vue/src/components/button.tsx
@@ -30,6 +30,7 @@ export type ButtonStyleFieldCallbackArgs = {
   isUploading: boolean;
   uploadProgress: number;
   fileTypes: string[];
+  files: File[];
 };
 
 export type ButtonAppearance = {
@@ -199,6 +200,7 @@ export const generateUploadButton = <TRouter extends FileRouter>(
             isUploading: state.value === "uploading",
             uploadProgress: uploadProgress.value,
             fileTypes: permittedFileTypes.value.fileTypes,
+            files: files.value,
           }) as ButtonStyleFieldCallbackArgs,
       );
 

--- a/packages/vue/src/components/dropzone.tsx
+++ b/packages/vue/src/components/dropzone.tsx
@@ -49,6 +49,7 @@ export type DropzoneStyleFieldCallbackArgs = {
   uploadProgress: number;
   fileTypes: string[];
   isDragActive: boolean;
+  files: File[];
 };
 
 export type DropzoneAppearance = {
@@ -236,6 +237,7 @@ export const generateUploadDropzone = <TRouter extends FileRouter>(
             uploadProgress: uploadProgress.value,
             fileTypes: permittedFileTypes.value.fileTypes,
             isDragActive: isDragActive.value,
+            files: files.value,
           }) as DropzoneStyleFieldCallbackArgs,
       );
 


### PR DESCRIPTION
Closes #897

Give `styleFieldArg` the list of selected files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced file upload components across various frameworks (React, Solid, Svelte, Vue) with a new `files` property for improved file management and context during uploads.
	- Updated `onChange` handlers in file input components for better handling of selected files.
	- Deprecated the `onDrop` method in favor of a unified `onChange` approach in the `UploadDropzone` component.

These updates improve the user experience by providing better feedback and control over file uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->