### PR TITLE
docs: Remove unnecessary @ts-expect-error from TSS

### DIFF
--- a/docs/src/app/(docs)/getting-started/tanstack-start/page.mdx
+++ b/docs/src/app/(docs)/getting-started/tanstack-start/page.mdx
@@ -159,7 +159,6 @@ export const { useUploadThing } = generateReactHelpers<UploadRouter>();
     Include our CSS in your root route to make sure the components look right!
 
     ```tsx {{ title: "app/routes/__root.tsx" }}
-    // @ts-expect-error
     import uploadthingCss from "@uploadthing/react/styles.css?url";
 
     export const Route = createRootRoute({


### PR DESCRIPTION
With the newest version of Tanstack/Start `?url` imports no longer error.