### PR TITLE
fix: add application/yaml as mime type

### DIFF
--- a/.changeset/two-olives-shop.md
+++ b/.changeset/two-olives-shop.md
@@ -1,0 +1,5 @@
+---
+"@uploadthing/mime-types": patch
+---
+
+feat(@uploadthing/mime-types) add application/yaml as mime type

--- a/packages/mime-types/src/application.ts
+++ b/packages/mime-types/src/application.ts
@@ -2634,6 +2634,10 @@ export const application = {
     source: "iana",
     extensions: ["mxml", "xhvml", "xvml", "xvm"],
   },
+  "application/yaml": {
+    source: "iana",
+    extensions: ["yaml", "yml"],
+  },
   "application/yang": {
     source: "iana",
     extensions: ["yang"],


### PR DESCRIPTION
According to [RFC 9512](https://www.rfc-editor.org/rfc/rfc9512.html) Yaml is now an official media type and should be added to this list to support uploading yaml files through UploadThing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for the YAML file format with the new MIME type `application/yaml`, enabling better file handling and recognition in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->