### PR TITLE
chore: warn instead of error on version mismatch

### DIFF
--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -140,13 +140,11 @@ export const createRequestHandler = <TRouter extends FileRouter>(
       );
 
       if (clientVersion !== pkgJson.version) {
-        const msg = `Server version: ${pkgJson.version}, Client version: ${clientVersion}`;
-        yield* Effect.logError(msg);
-        return yield* new UploadThingError({
-          code: "BAD_REQUEST",
-          message: "Client version mismatch",
-          cause: msg,
-        });
+        const msg = `
+Client version mismatch. Things may not work as expected, please sync your versions to ensure compatibility.
+  Server version: ${pkgJson.version}, Client version: ${clientVersion}
+`;
+        yield* Effect.logWarning(msg);
       }
 
       const { slug, actionType } = yield* HttpRouter.schemaParams(

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -140,11 +140,10 @@ export const createRequestHandler = <TRouter extends FileRouter>(
       );
 
       if (clientVersion !== pkgJson.version) {
-        const msg = `
-Client version mismatch. Things may not work as expected, please sync your versions to ensure compatibility.
-  Server version: ${pkgJson.version}, Client version: ${clientVersion}
-`;
-        yield* Effect.logWarning(msg);
+        const serverVersion = pkgJson.version;
+        yield* Effect.logWarning(
+          "Client version mismatch. Things may not work as expected, please sync your versions to ensure compatibility.",
+        ).pipe(Effect.annotateLogs({ clientVersion, serverVersion }));
       }
 
       const { slug, actionType } = yield* HttpRouter.schemaParams(


### PR DESCRIPTION
If you're deploying client and server separately it's impossible to upgrade without downtime.

Many versions will still work when they're out of sync, so we can just warn and not cancel the request entirely.