### PR TITLE
docs: add callouts and examples for keygen in other languages

### DIFF
--- a/docs/src/app/(docs)/uploading-files/page.mdx
+++ b/docs/src/app/(docs)/uploading-files/page.mdx
@@ -102,6 +102,20 @@ The file seed can be anything you want, but it should be unique for each file,
 as well as url safe. In this example, we include a base64 encoding to ensure the
 file seed is url safe, but you can do this however you want.
 
+Although we currently only offer a JavaScript SDK, here are some reference
+implementations you can use to generate valid file keys. We also plan on making
+this process easier in the future.
+
+<Note>
+  If you struggle to implement it for your language, you can also request one
+  from the [`/v7/prepareUpload` REST
+  endpoint](/api-reference/openapi-spec#tag/default/POST/v7/prepareUpload). Keep
+  in mind that this adds extra latency to your uploads.
+</Note>
+
+<Tabs tabs={["JavaScript", "Python", "PHP", "Go"]}>
+  <Tab>
+
 ```ts
 import * as Hash from "effect/Hash";
 import SQIds, { defaultOptions } from "sqids";
@@ -123,10 +137,7 @@ function shuffle(str: string, seed: string) {
   return chars.join("");
 }
 
-function generateKey(
-  appId: string,
-  fileSeed: string,
-) =>
+function generateKey(appId: string, fileSeed: string) {
   // Hash and Encode the parts and apiKey as sqids
   const alphabet = shuffle(defaultOptions.alphabet, appId);
 
@@ -141,6 +152,142 @@ function generateKey(
   return `${encodedAppId}${encodedFileSeed}`;
 }
 ```
+
+  </Tab>
+  <Tab>
+
+```py
+import math
+import base64
+from sqids import Sqids
+from sqids.constants import DEFAULT_ALPHABET
+
+def hash_string(s: str) -> int:
+  h = 5381
+  for char in reversed(s):
+      h = (h * 33) ^ ord(char)
+      # 32-bit integer overflow
+      h &= 0xFFFFFFFF
+  h = (h & 0xBFFFFFFF) | ((h >> 1) & 0x40000000)
+
+  # Convert to signed 32-bit integer
+  if h >= 0x80000000:
+      h -= 0x100000000
+
+  return h
+
+
+def shuffle(string: str, seed: str) -> str:
+  chars = list(string)
+  seed_num = hash_string(seed)
+
+  for i in range(len(chars)):
+      j = int(math.fmod(math.fmod(seed_num, i + 1) + i, len(chars)))
+      chars[i], chars[j] = chars[j], chars[i]
+
+  return "".join(chars)
+
+
+def generate_key(file_seed: str, app_id: str) -> str:
+  alphabet = shuffle(constants.DEFAULT_ALPHABET, app_id)
+
+  encoded_app_id = Sqids(alphabet, min_length=12).encode(
+    [abs(hash_string(app_id))]
+  )
+
+  return encoded_app_id + file_seed
+```
+
+  </Tab>
+  <Tab>
+
+```php
+function hashString(string $string): int {
+  $h = 5381;
+  for ($i = strlen($s) - 1; $i >= 0; $i--) {
+      $char = $s[$i];
+      $h = ($h * 33) ^ ord($char);
+      // 32-bit integer overflow
+      $h &= 0xFFFFFFFF;
+  }
+  $h = ($h & 0xBFFFFFFF) | (($h >> 1) & 0x40000000);
+
+  // Convert to signed 32-bit integer
+  if ($h >= 0x80000000) {
+      $h -= 0x100000000;
+  }
+
+  return $h;
+}
+
+function shuffle(string $string, string $seed): string {
+    $chars = str_split($string);
+    $seed_num = hashString($seed);
+
+    for ($i = 0; $i < count($chars); $i++) {
+        $j = (($seed_num % ($i + 1)) + $i) % count($chars);
+        [$chars[$i], $chars[$j]] = [$chars[$j], $chars[$i]];
+    }
+
+    return implode('', $chars);
+}
+
+function generateKey(string $file_seed, string $appId): string {
+  $alphabet = shuffle(DEFAULT_ALPHABET, $appId);
+  $encodedAppId = new Sqids(minLength: 12)->encode(
+    [abs(hashString($appId))]
+  );
+
+  return $encodedAppId . $file_seed;
+}
+```
+
+  </Tab>
+  <Tab>
+
+```go
+func hashString(s string) int32 {
+	h := int32(5381)
+	for i := len(s) - 1; i >= 0; i-- {
+		h = (h * 33) ^ int32(s[i])
+		// 32-bit integer overflow
+		h &= 0xFFFFFFFF
+	}
+	h = (h & 0xBFFFFFFF) | ((h >> 1) & 0x40000000)
+
+	// Convert to signed 32-bit integer
+	if h >= 0x80000000 {
+		h -= 0x100000000
+	}
+
+	return h
+}
+
+func shuffle(input string, seed string) string {
+	chars := []rune(input)
+	seedNum := hashString(seed)
+
+	for i := 0; i < len(chars); i++ {
+		j := (int(seedNum)%(i+1) + i) % len(chars)
+		chars[i], chars[j] = chars[j], chars[i]
+	}
+
+	return string(chars)
+}
+
+func generateKey(fileSeed string, appId string) string {
+	alphabet := shuffle(DEFAULT_ALPHABET, appId)
+
+	encodedAppId := Sqids(alphabet, minLength: 12).encode(
+		[abs(hashString(appId))]
+	)
+
+	return encodedAppId + fileSeed
+}
+```
+
+  </Tab>
+</Tabs>
 
 The URL, to which you will upload the file, will depend on your app's region.
 You can find the list of regions in the

--- a/docs/src/app/(docs)/uploading-files/page.mdx
+++ b/docs/src/app/(docs)/uploading-files/page.mdx
@@ -202,43 +202,47 @@ def generate_key(file_seed: str, app_id: str) -> str:
   <Tab>
 
 ```php
-function hashString(string $string): int {
+use Sqids\Sqids;
+
+function hash_string(string $string): int {
   $h = 5381;
-  for ($i = strlen($s) - 1; $i >= 0; $i--) {
-      $char = $s[$i];
-      $h = ($h * 33) ^ ord($char);
-      // 32-bit integer overflow
-      $h &= 0xFFFFFFFF;
+  for ($i = strlen($string) - 1; $i >= 0; $i--) {
+    $char = $string[$i];
+    $h = ($h * 33) ^ ord($char);
+    // 32-bit integer overflow
+    $h &= 0xFFFFFFFF;
   }
   $h = ($h & 0xBFFFFFFF) | (($h >> 1) & 0x40000000);
 
   // Convert to signed 32-bit integer
   if ($h >= 0x80000000) {
-      $h -= 0x100000000;
+    $h -= 0x100000000;
   }
 
   return $h;
+  }
+
+function shuffle_string(string $string, string $seed): string {
+  $chars = str_split($string);
+  $seed_num = hash_string($seed);
+
+  for ($i = 0; $i < count($chars); $i++) {
+    $j = (($seed_num % ($i + 1)) + $i) % count($chars);
+    [$chars[$i], $chars[$j]] = [$chars[$j], $chars[$i]];
+  }
+
+  return implode('', $chars);
 }
 
-function shuffle(string $string, string $seed): string {
-    $chars = str_split($string);
-    $seed_num = hashString($seed);
+function generate_key(string $file_seed, string $appId): string {
+  $alphabet = shuffle_string(Sqids::DEFAULT_ALPHABET, $appId);
+  $sqids = new Sqids($alphabet, 12);
 
-    for ($i = 0; $i < count($chars); $i++) {
-        $j = (($seed_num % ($i + 1)) + $i) % count($chars);
-        [$chars[$i], $chars[$j]] = [$chars[$j], $chars[$i]];
-    }
-
-    return implode('', $chars);
-}
-
-function generateKey(string $file_seed, string $appId): string {
-  $alphabet = shuffle(DEFAULT_ALPHABET, $appId);
-  $encodedAppId = new Sqids(minLength: 12)->encode(
+  $encodedAppId = $sqids->encode(
     [abs(hashString($appId))]
   );
 
-  return $encodedAppId . $file_seed;
+  return $encodedAppId . base64_encode($file_seed);
 }
 ```
 

--- a/docs/src/app/(docs)/uploading-files/page.mdx
+++ b/docs/src/app/(docs)/uploading-files/page.mdx
@@ -239,7 +239,7 @@ function generate_key(string $file_seed, string $appId): string {
   $sqids = new Sqids($alphabet, 12);
 
   $encodedAppId = $sqids->encode(
-    [abs(hashString($appId))]
+    [abs(hash_string($appId))]
   );
 
   return $encodedAppId . base64_encode($file_seed);

--- a/docs/src/app/(docs)/uploading-files/page.mdx
+++ b/docs/src/app/(docs)/uploading-files/page.mdx
@@ -189,7 +189,7 @@ def shuffle(string: str, seed: str) -> str:
 
 
 def generate_key(file_seed: str, app_id: str) -> str:
-  alphabet = shuffle(constants.DEFAULT_ALPHABET, app_id)
+  alphabet = shuffle(DEFAULT_ALPHABET, app_id)
 
   encoded_app_id = Sqids(alphabet, min_length=12).encode(
     [abs(hash_string(app_id))]

--- a/docs/src/app/(docs)/uploading-files/page.mdx
+++ b/docs/src/app/(docs)/uploading-files/page.mdx
@@ -250,10 +250,15 @@ function generate_key(string $file_seed, string $appId): string {
   <Tab>
 
 ```go
+import (
+	"math"
+	"github.com/sqids/sqids-go"
+)
+
 func hashString(s string) int32 {
-	h := int32(5381)
+	h := int64(5381)
 	for i := len(s) - 1; i >= 0; i-- {
-		h = (h * 33) ^ int32(s[i])
+		h = (h * 33) ^ int64(s[i])
 		// 32-bit integer overflow
 		h &= 0xFFFFFFFF
 	}
@@ -264,7 +269,7 @@ func hashString(s string) int32 {
 		h -= 0x100000000
 	}
 
-	return h
+	return int32(h)
 }
 
 func shuffle(input string, seed string) string {
@@ -280,10 +285,14 @@ func shuffle(input string, seed string) string {
 }
 
 func generateKey(fileSeed string, appId string) string {
-	alphabet := shuffle(DEFAULT_ALPHABET, appId)
+	alphabet := shuffle("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", appId)
+	s, _ := sqids.New(sqids.Options{
+		MinLength: 12,
+		Alphabet:  alphabet,
+	})
 
-	encodedAppId := Sqids(alphabet, minLength: 12).encode(
-		[abs(hashString(appId))]
+	encodedAppId, _ := s.Encode(
+		[]uint64{uint64(math.Abs(float64(hashString(appId))))},
 	)
 
 	return encodedAppId + fileSeed

--- a/docs/src/mdx/rehype.js
+++ b/docs/src/mdx/rehype.js
@@ -37,6 +37,8 @@ function rehypeShiki() {
         "css",
         "python",
         "diff",
+        "go",
+        "php",
       ],
     });
 


### PR DESCRIPTION
### TODO

- [x] deploy the `/v7/prepareUpload` endpoint https://github.com/pingdotgg/uploadthing-infra/pull/584
- [x] test the PHP and Go snippets and make sure they are equal to JS impl.
- [ ] idk what other langs to include 😅 ruby?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Enhanced documentation for file uploads, including a new section on generating valid file keys using JavaScript SDK with examples in Python, PHP, and Go.
	- Added a note regarding potential latency when requesting file keys from the `/v7/prepareUpload` REST endpoint.
	- Improved document structure with tabs for different programming languages for easier navigation.
	- Clarified the server-side upload process and reinforced the importance of correct parameter handling.

- **Bug Fixes**
	- Updated function signature for `generateKey` to improve clarity in the documentation.

- **Chores**
	- Expanded syntax highlighting capabilities to include Go and PHP in code snippets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->