### PR TITLE
fix(docs): 1 hour from now in milliseconds instead of seconds

### DIFF
--- a/docs/src/app/(docs)/uploading-files/page.mdx
+++ b/docs/src/app/(docs)/uploading-files/page.mdx
@@ -316,7 +316,7 @@ the URL:
 ```ts
 const searchParams = new URLSearchParams({
   // Required
-  expires: Date.now() + (60 * 60 * 1000), // 1 hour from now (you choose)
+  expires: Math.floor(Date.now() / 1000) + 3600, // 1 hour from now (you choose)
   "x-ut-identifier": "MY_APP_ID",
   "x-ut-file-name": "my-file.png",
   "x-ut-file-size": 131072,

--- a/docs/src/app/(docs)/uploading-files/page.mdx
+++ b/docs/src/app/(docs)/uploading-files/page.mdx
@@ -316,7 +316,7 @@ the URL:
 ```ts
 const searchParams = new URLSearchParams({
   // Required
-  expires: Date.now() + (60 * 60 * 1000), // 1 hour from now (you choose)
+  expires: Date.now() + 60 * 60 * 1000, // 1 hour from now (you choose)
   "x-ut-identifier": "MY_APP_ID",
   "x-ut-file-name": "my-file.png",
   "x-ut-file-size": 131072,

--- a/docs/src/app/(docs)/uploading-files/page.mdx
+++ b/docs/src/app/(docs)/uploading-files/page.mdx
@@ -316,7 +316,7 @@ the URL:
 ```ts
 const searchParams = new URLSearchParams({
   // Required
-  expires: Math.floor(Date.now() / 1000) + 3600, // 1 hour from now (you choose)
+  expires: Date.now() + (60 * 60 * 1000), // 1 hour from now (you choose)
   "x-ut-identifier": "MY_APP_ID",
   "x-ut-file-name": "my-file.png",
   "x-ut-file-size": 131072,


### PR DESCRIPTION
It seems that that V7 upload to ingest fails when `expires` parameter is in seconds. UT can not verify the URL.
So I changed the docs's default example of `expire parameter` to `Date.now() + (60 * 60 * 1000)`. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Enhanced clarity and accuracy of the uploading files documentation.
	- Updated code snippet for generating expiration time for signed URLs to align with JavaScript conventions.
	- Improved readability and structure, including added notes and warnings for user guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->