### PR TITLE
refactor: simplify types for built file route

### DIFF
--- a/.changeset/fifty-candles-fix.md
+++ b/.changeset/fifty-candles-fix.md
@@ -1,0 +1,11 @@
+---
+"@uploadthing/expo": patch
+"@uploadthing/nuxt": patch
+"@uploadthing/react": patch
+"@uploadthing/solid": patch
+"@uploadthing/svelte": patch
+"uploadthing": patch
+"@uploadthing/vue": patch
+---
+
+refactor: simplify types for built file route

--- a/packages/expo/src/document-picker.ts
+++ b/packages/expo/src/document-picker.ts
@@ -36,7 +36,7 @@ export const GENERATE_useDocumentUploader = <
 }) => {
   const useDocumentUploader = <TEndpoint extends keyof TRouter>(
     endpoint: TEndpoint,
-    opts?: UseUploadthingProps<TRouter, TEndpoint>,
+    opts?: UseUploadthingProps<TRouter[TEndpoint]>,
   ) => {
     const { routeConfig, startUpload, isUploading } = __useUploadThingInternal(
       initOpts.url,

--- a/packages/expo/src/image-picker.ts
+++ b/packages/expo/src/image-picker.ts
@@ -28,7 +28,7 @@ export const GENERATE_useImageUploader = <
 }) => {
   const useImageUploader = <TEndpoint extends keyof TRouter>(
     endpoint: TEndpoint,
-    opts?: UseUploadthingProps<TRouter, TEndpoint>,
+    opts?: UseUploadthingProps<TRouter[TEndpoint]>,
   ) => {
     const { routeConfig, startUpload, isUploading } = __useUploadThingInternal(
       initOpts.url,

--- a/packages/expo/src/index.ts
+++ b/packages/expo/src/index.ts
@@ -3,7 +3,7 @@ import Constants from "expo-constants";
 import { generateReactHelpers } from "@uploadthing/react/native";
 import { warnIfInvalidPeerDependency } from "@uploadthing/shared";
 import { version as uploadthingClientVersion } from "uploadthing/client";
-import type { FileRouter } from "uploadthing/internal/types";
+import type { FileRouter } from "uploadthing/types";
 
 import { peerDependencies } from "../package.json";
 import { GENERATE_useDocumentUploader } from "./document-picker";

--- a/packages/nuxt/src/module.ts
+++ b/packages/nuxt/src/module.ts
@@ -16,7 +16,7 @@ import type { Nuxt, NuxtOptions } from "@nuxt/schema";
 import type { ModuleOptions as TailwindModuleOptions } from "@nuxtjs/tailwindcss";
 import defu from "defu";
 
-import type { RouteHandlerConfig } from "uploadthing/internal/types";
+import type { RouteHandlerConfig } from "uploadthing/types";
 
 // Module options TypeScript interface definition
 export type ModuleOptions = RouteHandlerConfig & {

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -6,6 +6,7 @@ import type {
   UploadThingError,
 } from "@uploadthing/shared";
 import type {
+  AnyFileRoute,
   ClientUploadedFileData,
   EndpointArg,
   FileRouter,
@@ -28,9 +29,8 @@ export interface GenerateTypedHelpersOptions {
 }
 
 export type UseUploadthingProps<
-  TRouter extends FileRouter,
-  TEndpoint extends keyof TRouter,
-  TServerOutput = inferEndpointOutput<TRouter[TEndpoint]>,
+  TFileRoute extends AnyFileRoute,
+  TServerOutput = inferEndpointOutput<TFileRoute>,
 > = {
   /**
    * Called when the upload is submitted and the server is about to be queried for presigned URLs
@@ -74,7 +74,7 @@ export type UseUploadthingProps<
    * Called if the upload fails
    */
   onUploadError?:
-    | ((e: UploadThingError<inferErrorShape<TRouter>>) => MaybePromise<void>)
+    | ((e: UploadThingError<inferErrorShape<TFileRoute>>) => MaybePromise<void>)
     | undefined;
   /**
    * Set custom headers that'll get sent with requests
@@ -94,7 +94,7 @@ export type UploadthingComponentProps<
   TRouter extends FileRouter,
   TEndpoint extends keyof TRouter,
 > = Omit<
-  UseUploadthingProps<TRouter, TEndpoint>,
+  UseUploadthingProps<TRouter[TEndpoint]>,
   /**
    * Signal is omitted, component has its own AbortController
    * If you need to control the interruption with more granularity,

--- a/packages/react/src/useUploadThing.ts
+++ b/packages/react/src/useUploadThing.ts
@@ -55,7 +55,7 @@ export function __useUploadThingInternal<
 >(
   url: URL,
   endpoint: EndpointArg<TRouter, TEndpoint>,
-  opts?: UseUploadthingProps<TRouter, TEndpoint>,
+  opts?: UseUploadthingProps<TRouter[TEndpoint]>,
 ) {
   const { uploadFiles, routeRegistry } = genUploader<TRouter>({
     url,
@@ -115,9 +115,9 @@ export function __useUploadThingInternal<
        */
       if (e instanceof UploadAbortedError) throw e;
 
-      let error: UploadThingError<inferErrorShape<TRouter>>;
+      let error: UploadThingError<inferErrorShape<TRouter[TEndpoint]>>;
       if (e instanceof UploadThingError) {
-        error = e as UploadThingError<inferErrorShape<TRouter>>;
+        error = e as UploadThingError<inferErrorShape<TRouter[TEndpoint]>>;
       } else {
         error = INTERNAL_DO_NOT_USE__fatalClientError(e as Error);
         console.error(
@@ -161,7 +161,7 @@ export const generateReactHelpers = <TRouter extends FileRouter>(
 
   function useUploadThing<TEndpoint extends keyof TRouter>(
     endpoint: EndpointArg<TRouter, TEndpoint>,
-    opts?: UseUploadthingProps<TRouter, TEndpoint>,
+    opts?: UseUploadthingProps<TRouter[TEndpoint]>,
   ) {
     return __useUploadThingInternal(url, endpoint, opts);
   }

--- a/packages/solid/src/create-uploadthing.ts
+++ b/packages/solid/src/create-uploadthing.ts
@@ -44,7 +44,7 @@ export const INTERNAL_createUploadThingGen = <
 
   const createUploadThing = <TEndpoint extends keyof TRouter>(
     endpoint: EndpointArg<TRouter, TEndpoint>,
-    opts?: CreateUploadthingProps<TRouter, TEndpoint>,
+    opts?: CreateUploadthingProps<TRouter[TEndpoint]>,
   ) => {
     const [isUploading, setUploading] = createSignal(false);
     let uploadProgress = 0;
@@ -99,9 +99,9 @@ export const INTERNAL_createUploadThingGen = <
          */
         if (e instanceof UploadAbortedError) throw e;
 
-        let error: UploadThingError<inferErrorShape<TRouter>>;
+        let error: UploadThingError<inferErrorShape<TRouter[TEndpoint]>>;
         if (e instanceof UploadThingError) {
-          error = e as UploadThingError<inferErrorShape<TRouter>>;
+          error = e as UploadThingError<inferErrorShape<TRouter[TEndpoint]>>;
         } else {
           error = INTERNAL_DO_NOT_USE__fatalClientError(e as Error);
           console.error(

--- a/packages/solid/src/types.ts
+++ b/packages/solid/src/types.ts
@@ -6,6 +6,7 @@ import type {
   UploadThingError,
 } from "@uploadthing/shared";
 import type {
+  AnyFileRoute,
   ClientUploadedFileData,
   EndpointArg,
   FileRouter,
@@ -28,9 +29,8 @@ export interface GenerateTypedHelpersOptions {
 }
 
 export type CreateUploadthingProps<
-  TRouter extends FileRouter,
-  TEndpoint extends keyof TRouter,
-  TServerOutput = inferEndpointOutput<TRouter[TEndpoint]>,
+  TFileRoute extends AnyFileRoute,
+  TServerOutput = inferEndpointOutput<TFileRoute>,
 > = {
   /**
    * Called when the upload is submitted and the server is about to be queried for presigned URLs
@@ -74,7 +74,7 @@ export type CreateUploadthingProps<
    * Called if the upload fails
    */
   onUploadError?:
-    | ((e: UploadThingError<inferErrorShape<TRouter>>) => MaybePromise<void>)
+    | ((e: UploadThingError<inferErrorShape<TFileRoute>>) => MaybePromise<void>)
     | undefined;
   /**
    * Set custom headers that'll get sent with requests
@@ -94,16 +94,15 @@ export type CreateUploadthingProps<
  * @deprecated Use `CreateUploadthingProps` instead
  */
 export type UseUploadThingProps<
-  TRouter extends FileRouter,
-  TEndpoint extends keyof TRouter,
-  TServerOutput = inferEndpointOutput<TRouter[TEndpoint]>,
-> = CreateUploadthingProps<TRouter, TEndpoint, TServerOutput>;
+  TFileRoute extends AnyFileRoute,
+  TServerOutput = inferEndpointOutput<TFileRoute>,
+> = CreateUploadthingProps<TFileRoute, TServerOutput>;
 
 export type UploadthingComponentProps<
   TRouter extends FileRouter,
   TEndpoint extends keyof TRouter,
 > = Omit<
-  CreateUploadthingProps<TRouter, TEndpoint>,
+  CreateUploadthingProps<TRouter[TEndpoint]>,
   /**
    * Signal is omitted, component has its own AbortController
    * If you need to control the interruption with more granularity,

--- a/packages/svelte/src/lib/create-uploadthing.ts
+++ b/packages/svelte/src/lib/create-uploadthing.ts
@@ -48,7 +48,7 @@ export const INTERNAL_createUploadThingGen = <
 
   const useUploadThing = <TEndpoint extends keyof TRouter>(
     endpoint: EndpointArg<TRouter, TEndpoint>,
-    opts?: UseUploadthingProps<TRouter, TEndpoint>,
+    opts?: UseUploadthingProps<TRouter[TEndpoint]>,
   ) => {
     const isUploading = writable(false);
     let uploadProgress = 0;
@@ -103,9 +103,9 @@ export const INTERNAL_createUploadThingGen = <
          */
         if (e instanceof UploadAbortedError) throw e;
 
-        let error: UploadThingError<inferErrorShape<TRouter>>;
+        let error: UploadThingError<inferErrorShape<TRouter[TEndpoint]>>;
         if (e instanceof UploadThingError) {
-          error = e as UploadThingError<inferErrorShape<TRouter>>;
+          error = e as UploadThingError<inferErrorShape<TRouter[TEndpoint]>>;
         } else {
           error = INTERNAL_DO_NOT_USE__fatalClientError(e as Error);
           console.error(

--- a/packages/svelte/src/lib/types.ts
+++ b/packages/svelte/src/lib/types.ts
@@ -6,6 +6,7 @@ import type {
   UploadThingError,
 } from "@uploadthing/shared";
 import type {
+  AnyFileRoute,
   ClientUploadedFileData,
   EndpointArg,
   FileRouter,
@@ -28,9 +29,8 @@ export interface GenerateTypedHelpersOptions {
 }
 
 export type UseUploadthingProps<
-  TRouter extends FileRouter,
-  TEndpoint extends keyof TRouter,
-  TServerOutput = inferEndpointOutput<TRouter[TEndpoint]>,
+  TFileRoute extends AnyFileRoute,
+  TServerOutput = inferEndpointOutput<TFileRoute>,
 > = {
   /**
    * Called when the upload is submitted and the server is about to be queried for presigned URLs
@@ -74,7 +74,7 @@ export type UseUploadthingProps<
    * Called if the upload fails
    */
   onUploadError?:
-    | ((e: UploadThingError<inferErrorShape<TRouter>>) => MaybePromise<void>)
+    | ((e: UploadThingError<inferErrorShape<TFileRoute>>) => MaybePromise<void>)
     | undefined;
   /**
    * Set custom headers that'll get sent with requests
@@ -94,7 +94,7 @@ export type UploadthingComponentProps<
   TRouter extends FileRouter,
   TEndpoint extends keyof TRouter,
 > = Omit<
-  UseUploadthingProps<TRouter, TEndpoint>,
+  UseUploadthingProps<TRouter[TEndpoint]>,
   /**
    * Signal is omitted, component has its own AbortController
    * If you need to control the interruption with more granularity,

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -92,7 +92,7 @@ export const genUploader = <TRouter extends FileRouter>(
   >(
     slug: EndpointArg<TRouter, TEndpoint>,
     opts: Omit<
-      CreateUploadOptions<TRouter, TEndpoint>,
+      CreateUploadOptions<TRouter[TEndpoint]>,
       keyof GenerateUploaderOptions
     >,
   ) => {
@@ -249,7 +249,7 @@ export const genUploader = <TRouter extends FileRouter>(
   const typedUploadFiles = <TEndpoint extends keyof TRouter>(
     slug: EndpointArg<TRouter, TEndpoint>,
     opts: Omit<
-      UploadFilesOptions<TRouter, TEndpoint>,
+      UploadFilesOptions<TRouter[TEndpoint]>,
       keyof GenerateUploaderOptions
     >,
   ) => {

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -16,15 +16,16 @@ import {
 import * as pkgJson from "../package.json";
 import type { Deferred } from "./internal/deferred";
 import { createDeferred } from "./internal/deferred";
-import type { FileRouter, inferEndpointOutput } from "./internal/types";
 import { uploadFile, uploadFilesInternal } from "./internal/upload.browser";
 import { createUTReporter } from "./internal/ut-reporter";
 import type {
   ClientUploadedFileData,
   CreateUploadOptions,
   EndpointArg,
+  FileRouter,
   GenerateUploaderOptions,
   inferEndpointInput,
+  inferEndpointOutput,
   NewPresignedUrl,
   RouteRegistry,
   UploadFilesOptions,

--- a/packages/uploadthing/src/effect-platform.ts
+++ b/packages/uploadthing/src/effect-platform.ts
@@ -6,9 +6,9 @@ import type { Json } from "@uploadthing/shared";
 
 import { configProvider } from "./internal/config";
 import { createRequestHandler, MiddlewareArguments } from "./internal/handler";
-import type { FileRouter, RouteHandlerConfig } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
+import type { FileRouter, RouteHandlerConfig } from "./types";
 
 export { UTFiles } from "./internal/types";
 export type { FileRouter };

--- a/packages/uploadthing/src/express.ts
+++ b/packages/uploadthing/src/express.ts
@@ -10,9 +10,9 @@ import type { Json } from "@uploadthing/shared";
 
 import { makeAdapterHandler } from "./internal/handler";
 import { getPostBody, toWebRequest } from "./internal/to-web-request";
-import type { FileRouter, RouteHandlerOptions } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
+import type { FileRouter, RouteHandlerOptions } from "./types";
 
 export { UTFiles } from "./internal/types";
 export type { FileRouter };

--- a/packages/uploadthing/src/fastify.ts
+++ b/packages/uploadthing/src/fastify.ts
@@ -5,9 +5,9 @@ import type { Json } from "@uploadthing/shared";
 
 import { makeAdapterHandler } from "./internal/handler";
 import { toWebRequest } from "./internal/to-web-request";
-import type { FileRouter, RouteHandlerOptions } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
+import type { FileRouter, RouteHandlerOptions } from "./types";
 
 export { UTFiles } from "./internal/types";
 export type { FileRouter };

--- a/packages/uploadthing/src/h3.ts
+++ b/packages/uploadthing/src/h3.ts
@@ -5,9 +5,9 @@ import { defineEventHandler, toWebRequest } from "h3";
 import type { Json } from "@uploadthing/shared";
 
 import { makeAdapterHandler } from "./internal/handler";
-import type { FileRouter, RouteHandlerOptions } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
+import type { FileRouter, RouteHandlerOptions } from "./types";
 
 export { UTFiles } from "./internal/types";
 export type { FileRouter };

--- a/packages/uploadthing/src/internal/error-formatter.ts
+++ b/packages/uploadthing/src/internal/error-formatter.ts
@@ -1,6 +1,6 @@
 import type { UploadThingError } from "@uploadthing/shared";
 
-import type { FileRouter, inferErrorShape } from "./types";
+import type { FileRouter, inferErrorShape } from "../types";
 
 export function defaultErrorFormatter(error: UploadThingError) {
   return {

--- a/packages/uploadthing/src/internal/error-formatter.ts
+++ b/packages/uploadthing/src/internal/error-formatter.ts
@@ -8,13 +8,12 @@ export function defaultErrorFormatter(error: UploadThingError) {
   };
 }
 
-export function formatError<TRouter extends FileRouter>(
+export function formatError(
   error: UploadThingError,
-  router: TRouter,
-): inferErrorShape<TRouter> {
+  router: FileRouter,
+): inferErrorShape<FileRouter[string]> {
   const errorFormatter =
     router[Object.keys(router)[0]]?.errorFormatter ?? defaultErrorFormatter;
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return errorFormatter(error);
 }

--- a/packages/uploadthing/src/internal/error-formatter.ts
+++ b/packages/uploadthing/src/internal/error-formatter.ts
@@ -13,8 +13,7 @@ export function formatError<TRouter extends FileRouter>(
   router: TRouter,
 ): inferErrorShape<TRouter> {
   const errorFormatter =
-    router[Object.keys(router)[0]]?._def.errorFormatter ??
-    defaultErrorFormatter;
+    router[Object.keys(router)[0]]?.errorFormatter ?? defaultErrorFormatter;
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   return errorFormatter(error);

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -27,6 +27,7 @@ import {
 } from "@uploadthing/shared";
 
 import * as pkgJson from "../../package.json";
+import type { FileRouter, RouteHandlerOptions } from "../types";
 import { IngestUrl, IsDevelopment, UTToken } from "./config";
 import { formatError } from "./error-formatter";
 import { handleJsonLineStream } from "./jsonl";
@@ -44,13 +45,7 @@ import {
   UploadThingHook,
 } from "./shared-schemas";
 import { UTFiles } from "./types";
-import type {
-  AnyUploader,
-  FileRouter,
-  MiddlewareFnArgs,
-  RouteHandlerOptions,
-  UTEvents,
-} from "./types";
+import type { AnyUploader, MiddlewareFnArgs, UTEvents } from "./types";
 
 export class MiddlewareArguments extends Context.Tag(
   "uploadthing/MiddlewareArguments",

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -45,7 +45,7 @@ import {
   UploadThingHook,
 } from "./shared-schemas";
 import { UTFiles } from "./types";
-import type { AnyUploader, MiddlewareFnArgs, UTEvents } from "./types";
+import type { AnyFileRoute, MiddlewareFnArgs, UTEvents } from "./types";
 
 export class MiddlewareArguments extends Context.Tag(
   "uploadthing/MiddlewareArguments",
@@ -228,7 +228,7 @@ export const createRequestHandler = <TRouter extends FileRouter>(
     );
   }).pipe(Effect.withLogSpan("createRequestHandler"));
 
-const handleErrorRequest = (opts: { uploadable: AnyUploader }) =>
+const handleErrorRequest = (opts: { uploadable: AnyFileRoute }) =>
   Effect.gen(function* () {
     const { uploadable } = opts;
     const request = yield* HttpServerRequest.HttpServerRequest;
@@ -289,7 +289,7 @@ const handleErrorRequest = (opts: { uploadable: AnyUploader }) =>
   }).pipe(Effect.withLogSpan("handleErrorRequest"));
 
 const handleCallbackRequest = (opts: {
-  uploadable: AnyUploader;
+  uploadable: AnyFileRoute;
   fePackage: string;
   beAdapter: string;
 }) =>
@@ -381,7 +381,7 @@ const handleCallbackRequest = (opts: {
 
 const runRouteMiddleware = (opts: {
   json: typeof UploadActionPayload.Type;
-  uploadable: AnyUploader;
+  uploadable: AnyFileRoute;
 }) =>
   Effect.gen(function* () {
     const middlewareArgs = yield* MiddlewareArguments;
@@ -441,7 +441,7 @@ const runRouteMiddleware = (opts: {
   }).pipe(Effect.withLogSpan("runRouteMiddleware"));
 
 const handleUploadAction = (opts: {
-  uploadable: AnyUploader;
+  uploadable: AnyFileRoute;
   fePackage: string;
   beAdapter: string;
   slug: string;

--- a/packages/uploadthing/src/internal/logger.ts
+++ b/packages/uploadthing/src/internal/logger.ts
@@ -37,6 +37,7 @@ export const LogFormat = Config.literal(
   "structured",
   "pretty",
 )("logFormat");
+export type LogFormat = Config.Config.Success<typeof LogFormat>;
 
 export const withLogFormat = Effect.gen(function* () {
   const isDev = yield* IsDevelopment;

--- a/packages/uploadthing/src/internal/route-config.ts
+++ b/packages/uploadthing/src/internal/route-config.ts
@@ -20,8 +20,8 @@ import {
   UploadThingError,
 } from "@uploadthing/shared";
 
+import type { FileRouter } from "../types";
 import type { UploadActionPayload } from "./shared-schemas";
-import type { FileRouter } from "./types";
 
 class FileSizeMismatch extends Data.Error<{
   reason: string;

--- a/packages/uploadthing/src/internal/route-config.ts
+++ b/packages/uploadthing/src/internal/route-config.ts
@@ -118,8 +118,8 @@ export const extractRouterConfig = <TRouter extends FileRouter>(
   router: TRouter,
 ) =>
   Effect.forEach(objectKeys(router), (slug) =>
-    Effect.map(
-      fillInputRouteConfig(router[slug]._def.routerConfig),
-      (config) => ({ slug, config }),
-    ),
+    Effect.map(fillInputRouteConfig(router[slug].routerConfig), (config) => ({
+      slug,
+      config,
+    })),
   );

--- a/packages/uploadthing/src/internal/types.ts
+++ b/packages/uploadthing/src/internal/types.ts
@@ -141,7 +141,7 @@ export interface UploadBuilder<TParams extends AnyParams> {
       >,
       TOutput
     >,
-  ) => Uploader<{
+  ) => FileRoute<{
     input: TParams["_input"]["in"] extends UnsetMarker
       ? void
       : TParams["_input"]["in"];
@@ -158,7 +158,7 @@ export type AnyBuiltUploaderTypes = {
   errorShape: any;
 };
 
-export interface Uploader<TTypes extends AnyBuiltUploaderTypes> {
+export interface FileRoute<TTypes extends AnyBuiltUploaderTypes> {
   $types: TTypes;
   routerConfig: FileRouterInputConfig;
   routeOptions: RouteOptions;
@@ -168,7 +168,7 @@ export interface Uploader<TTypes extends AnyBuiltUploaderTypes> {
   errorFormatter: (err: UploadThingError) => any;
   onUploadComplete: UploadCompleteFn<any, any>;
 }
-export type AnyUploader = Uploader<AnyBuiltUploaderTypes>;
+export type AnyFileRoute = FileRoute<AnyBuiltUploaderTypes>;
 
 /**
  * Map actionType to the required payload for that action

--- a/packages/uploadthing/src/internal/types.ts
+++ b/packages/uploadthing/src/internal/types.ts
@@ -86,7 +86,7 @@ type UploadCompleteFn<TMetadata, TOutput extends JsonObject | void> = (opts: {
 type UploadErrorFn = (input: {
   error: UploadThingError;
   fileKey: string;
-}) => Promise<void> | void;
+}) => MaybePromise<void>;
 
 export interface UploadBuilder<TParams extends AnyParams> {
   input: <TParser extends JsonParser>(
@@ -143,11 +143,13 @@ export interface UploadBuilder<TParams extends AnyParams> {
     >,
   ) => FileRoute<{
     input: TParams["_input"]["in"] extends UnsetMarker
-      ? void
+      ? undefined
       : TParams["_input"]["in"];
     output: TParams["_routeOptions"]["awaitServerData"] extends false
-      ? void
-      : TOutput;
+      ? null
+      : TOutput extends void | undefined // JSON serialization
+        ? null
+        : TOutput;
     errorShape: TParams["_errorShape"];
   }>;
 }

--- a/packages/uploadthing/src/internal/upload-builder.ts
+++ b/packages/uploadthing/src/internal/upload-builder.ts
@@ -7,8 +7,8 @@ import type {
 
 import { defaultErrorFormatter } from "./error-formatter";
 import type {
+  AnyBuiltUploaderTypes,
   AnyUploader,
-  BuiltUploaderTypes,
   MiddlewareFnArgs,
   UnsetMarker,
   UploadBuilder,
@@ -31,7 +31,7 @@ function internalCreateBuilder<
   _output: UnsetMarker;
 }> {
   const _def: AnyUploader = {
-    $types: {} as BuiltUploaderTypes,
+    $types: {} as AnyBuiltUploaderTypes,
     // Default router config
     routerConfig: {
       image: {

--- a/packages/uploadthing/src/internal/upload-builder.ts
+++ b/packages/uploadthing/src/internal/upload-builder.ts
@@ -8,11 +8,10 @@ import type {
 import { defaultErrorFormatter } from "./error-formatter";
 import type {
   AnyBuiltUploaderTypes,
-  AnyUploader,
+  AnyFileRoute,
   MiddlewareFnArgs,
   UnsetMarker,
   UploadBuilder,
-  Uploader,
 } from "./types";
 
 function internalCreateBuilder<
@@ -20,7 +19,7 @@ function internalCreateBuilder<
   TRouteOptions extends RouteOptions,
   TErrorShape extends Json = { message: string },
 >(
-  initDef: Partial<AnyUploader> = {},
+  initDef: Partial<AnyFileRoute> = {},
 ): UploadBuilder<{
   _routeOptions: TRouteOptions;
   _input: { in: UnsetMarker; out: UnsetMarker };
@@ -30,7 +29,7 @@ function internalCreateBuilder<
   _errorFn: UnsetMarker;
   _output: UnsetMarker;
 }> {
-  const _def: AnyUploader = {
+  const _def: AnyFileRoute = {
     $types: {} as AnyBuiltUploaderTypes,
     // Default router config
     routerConfig: {
@@ -77,7 +76,7 @@ function internalCreateBuilder<
       return {
         ..._def,
         onUploadComplete: userUploadComplete,
-      } as Uploader<any>;
+      } as AnyFileRoute;
     },
     onUploadError(userOnUploadError) {
       return internalCreateBuilder({

--- a/packages/uploadthing/src/internal/upload-builder.ts
+++ b/packages/uploadthing/src/internal/upload-builder.ts
@@ -7,11 +7,11 @@ import type {
 
 import { defaultErrorFormatter } from "./error-formatter";
 import type {
-  AnyParams,
+  AnyUploader,
+  BuiltUploaderTypes,
   MiddlewareFnArgs,
   UnsetMarker,
   UploadBuilder,
-  UploadBuilderDef,
   Uploader,
 } from "./types";
 
@@ -20,7 +20,7 @@ function internalCreateBuilder<
   TRouteOptions extends RouteOptions,
   TErrorShape extends Json = { message: string },
 >(
-  initDef: Partial<UploadBuilderDef<any>> = {},
+  initDef: Partial<AnyUploader> = {},
 ): UploadBuilder<{
   _routeOptions: TRouteOptions;
   _input: { in: UnsetMarker; out: UnsetMarker };
@@ -30,7 +30,8 @@ function internalCreateBuilder<
   _errorFn: UnsetMarker;
   _output: UnsetMarker;
 }> {
-  const _def: UploadBuilderDef<AnyParams> = {
+  const _def: AnyUploader = {
+    $types: {} as BuiltUploaderTypes,
     // Default router config
     routerConfig: {
       image: {
@@ -51,6 +52,7 @@ function internalCreateBuilder<
     onUploadError: () => {
       // noop
     },
+    onUploadComplete: () => undefined,
 
     errorFormatter: initDef.errorFormatter ?? defaultErrorFormatter,
 
@@ -73,8 +75,8 @@ function internalCreateBuilder<
     },
     onUploadComplete(userUploadComplete) {
       return {
-        _def,
-        resolver: userUploadComplete,
+        ..._def,
+        onUploadComplete: userUploadComplete,
       } as Uploader<any>;
     },
     onUploadError(userOnUploadError) {

--- a/packages/uploadthing/src/internal/upload.browser.ts
+++ b/packages/uploadthing/src/internal/upload.browser.ts
@@ -116,7 +116,7 @@ export const uploadFilesInternal = <
   TServerOutput = inferEndpointOutput<TRouter[TEndpoint]>,
 >(
   endpoint: TEndpoint,
-  opts: UploadFilesOptions<TRouter, TEndpoint>,
+  opts: UploadFilesOptions<TRouter[TEndpoint]>,
 ): Micro.Micro<
   ClientUploadedFileData<TServerOutput>[],
   UploadThingError | FetchError

--- a/packages/uploadthing/src/next-legacy.ts
+++ b/packages/uploadthing/src/next-legacy.ts
@@ -5,9 +5,9 @@ import type { Json } from "@uploadthing/shared";
 
 import { makeAdapterHandler } from "./internal/handler";
 import { toWebRequest } from "./internal/to-web-request";
-import type { FileRouter, RouteHandlerOptions } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
+import type { FileRouter, RouteHandlerOptions } from "./types";
 
 export { UTFiles } from "./internal/types";
 export type { FileRouter };

--- a/packages/uploadthing/src/next.ts
+++ b/packages/uploadthing/src/next.ts
@@ -4,9 +4,9 @@ import * as Effect from "effect/Effect";
 import type { Json } from "@uploadthing/shared";
 
 import { makeAdapterHandler } from "./internal/handler";
-import type { FileRouter, RouteHandlerOptions } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
+import type { FileRouter, RouteHandlerOptions } from "./types";
 
 export type { FileRouter };
 export { UTFiles } from "./internal/types";

--- a/packages/uploadthing/src/remix.ts
+++ b/packages/uploadthing/src/remix.ts
@@ -4,9 +4,9 @@ import * as Effect from "effect/Effect";
 import type { Json } from "@uploadthing/shared";
 
 import { makeAdapterHandler } from "./internal/handler";
-import type { FileRouter, RouteHandlerOptions } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
+import type { FileRouter, RouteHandlerOptions } from "./types";
 
 export type { FileRouter };
 export { UTFiles } from "./internal/types";

--- a/packages/uploadthing/src/server.ts
+++ b/packages/uploadthing/src/server.ts
@@ -5,9 +5,9 @@ import { UploadThingError } from "@uploadthing/shared";
 
 import { makeAdapterHandler } from "./internal/handler";
 import { extractRouterConfig as extractEffect } from "./internal/route-config";
-import type { FileRouter, RouteHandlerOptions } from "./internal/types";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
+import type { FileRouter, RouteHandlerOptions } from "./types";
 
 export { UTFiles } from "./internal/types";
 export { UTApi } from "./sdk";

--- a/packages/uploadthing/src/types.ts
+++ b/packages/uploadthing/src/types.ts
@@ -1,4 +1,3 @@
-import type * as Config from "effect/Config";
 import type * as LogLevel from "effect/LogLevel";
 
 import type {
@@ -45,7 +44,7 @@ export type RouteHandlerConfig = {
    * @default "pretty" in development, else "json"
    * @see https://effect.website/docs/guides/observability/logging#built-in-loggers
    */
-  logFormat?: Config.Config.Success<typeof LogFormat>;
+  logFormat?: LogFormat;
   callbackUrl?: string;
   token?: string;
   /**

--- a/packages/uploadthing/src/types.ts
+++ b/packages/uploadthing/src/types.ts
@@ -9,7 +9,7 @@ import type {
 } from "@uploadthing/shared";
 
 import type { LogFormat } from "./internal/logger";
-import type { AnyUploader } from "./internal/types";
+import type { AnyFileRoute } from "./internal/types";
 
 export * from "./sdk/types";
 
@@ -26,18 +26,19 @@ export type {
   NewPresignedUrl,
 } from "./internal/shared-schemas";
 
-export type FileRouter = Record<string, AnyUploader>;
+export type { AnyFileRoute };
+export type FileRouter = Record<string, AnyFileRoute>;
 
-export type inferEndpointInput<TUploader extends AnyUploader> =
-  TUploader["$types"]["input"];
+export type inferEndpointInput<TFileRoute extends AnyFileRoute> =
+  TFileRoute["$types"]["input"];
 
-export type inferEndpointOutput<TUploader extends AnyUploader> =
-  TUploader["$types"]["output"] extends void | undefined
+export type inferEndpointOutput<TFileRoute extends AnyFileRoute> =
+  TFileRoute["$types"]["output"] extends void | undefined
     ? null
-    : TUploader["$types"]["output"];
+    : TFileRoute["$types"]["output"];
 
-export type inferErrorShape<TRouter extends FileRouter> =
-  TRouter[keyof TRouter]["$types"]["errorShape"];
+export type inferErrorShape<TFileRoute extends AnyFileRoute> =
+  TFileRoute["$types"]["errorShape"];
 
 export type RouteHandlerConfig = {
   logLevel?: LogLevel.Literal;
@@ -85,10 +86,7 @@ export type RouteHandlerOptions<TRouter extends FileRouter> = {
   config?: RouteHandlerConfig;
 };
 
-export type UploadFilesOptions<
-  TRouter extends FileRouter,
-  TEndpoint extends keyof TRouter,
-> = {
+export type UploadFilesOptions<TFileRoute extends AnyFileRoute> = {
   /**
    * The files to upload
    */
@@ -156,14 +154,11 @@ export type UploadFilesOptions<
    */
   package: string;
 } & ExtendObjectIf<
-  inferEndpointInput<TRouter[TEndpoint]>,
-  { input: inferEndpointInput<TRouter[TEndpoint]> }
+  inferEndpointInput<TFileRoute>,
+  { input: inferEndpointInput<TFileRoute> }
 >;
 
-export type CreateUploadOptions<
-  TRouter extends FileRouter,
-  TEndpoint extends keyof TRouter,
-> = {
+export type CreateUploadOptions<TFileRoute extends AnyFileRoute> = {
   /**
    * The files to upload
    */
@@ -193,8 +188,8 @@ export type CreateUploadOptions<
    */
   headers?: HeadersInit | (() => MaybePromise<HeadersInit>) | undefined;
 } & ExtendObjectIf<
-  inferEndpointInput<TRouter[TEndpoint]>,
-  { input: inferEndpointInput<TRouter[TEndpoint]> }
+  inferEndpointInput<TFileRoute>,
+  { input: inferEndpointInput<TFileRoute> }
 >;
 
 export type GenerateUploaderOptions = {

--- a/packages/uploadthing/src/types.ts
+++ b/packages/uploadthing/src/types.ts
@@ -33,9 +33,7 @@ export type inferEndpointInput<TFileRoute extends AnyFileRoute> =
   TFileRoute["$types"]["input"];
 
 export type inferEndpointOutput<TFileRoute extends AnyFileRoute> =
-  TFileRoute["$types"]["output"] extends void | undefined
-    ? null
-    : TFileRoute["$types"]["output"];
+  TFileRoute["$types"]["output"];
 
 export type inferErrorShape<TFileRoute extends AnyFileRoute> =
   TFileRoute["$types"]["errorShape"];

--- a/packages/uploadthing/test/upload-builder.test.ts
+++ b/packages/uploadthing/test/upload-builder.test.ts
@@ -79,9 +79,9 @@ it("uses defaults for not-chained", async () => {
 
   const uploadable = f(["image"]).onUploadComplete(() => {});
 
-  expect(uploadable._def.routerConfig).toEqual(["image"]);
+  expect(uploadable.routerConfig).toEqual(["image"]);
 
-  const metadata = await uploadable._def.middleware({
+  const metadata = await uploadable.middleware({
     req: new Request("http://localhost", {
       headers: { header1: "woohoo" },
     }),
@@ -91,7 +91,6 @@ it("uses defaults for not-chained", async () => {
     files: [{ name: "test.txt", size: 123456, type: "text/plain" }],
   });
   expect(metadata).toEqual({});
-  expectTypeOf<Record<string, never>>(metadata);
 });
 
 it("allows async middleware", () => {
@@ -166,9 +165,9 @@ it("smoke", async () => {
       }>(metadata);
     });
 
-  expect(uploadable._def.routerConfig).toEqual(["image", "video"]);
+  expect(uploadable.routerConfig).toEqual(["image", "video"]);
 
-  const metadata = await uploadable._def.middleware({
+  const metadata = await uploadable.middleware({
     req: new Request("http://localhost", {
       headers: { header1: "woohoo" },
     }),

--- a/packages/vue/src/components/button.tsx
+++ b/packages/vue/src/components/button.tsx
@@ -88,7 +88,7 @@ export const generateUploadButton = <TRouter extends FileRouter>(
       const uploadProgress = ref(0);
       const files = ref<File[]>([]);
 
-      const useUploadthingProps: UseUploadthingProps<TRouter, TEndpoint> =
+      const useUploadthingProps: UseUploadthingProps<TRouter[TEndpoint]> =
         reactive({
           signal: acRef.value.signal,
           headers: $props.headers,

--- a/packages/vue/src/components/dropzone.tsx
+++ b/packages/vue/src/components/dropzone.tsx
@@ -115,7 +115,7 @@ export const generateUploadDropzone = <TRouter extends FileRouter>(
       const files = ref<File[]>([]);
       const uploadProgress = ref(0);
 
-      const useUploadthingProps: UseUploadthingProps<TRouter, TEndpoint> =
+      const useUploadthingProps: UseUploadthingProps<TRouter[TEndpoint]> =
         reactive({
           signal: acRef.value.signal,
           headers: $props.headers,

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -6,6 +6,7 @@ import type {
   UploadThingError,
 } from "@uploadthing/shared";
 import type {
+  AnyFileRoute,
   ClientUploadedFileData,
   EndpointArg,
   FileRouter,
@@ -28,9 +29,8 @@ export interface GenerateTypedHelpersOptions {
 }
 
 export type UseUploadthingProps<
-  TRouter extends FileRouter,
-  TEndpoint extends keyof TRouter,
-  TServerOutput = inferEndpointOutput<TRouter[TEndpoint]>,
+  TFileRoute extends AnyFileRoute,
+  TServerOutput = inferEndpointOutput<TFileRoute>,
 > = {
   /**
    * Called when the upload is submitted and the server is about to be queried for presigned URLs
@@ -74,7 +74,7 @@ export type UseUploadthingProps<
    * Called if the upload fails
    */
   onUploadError?:
-    | ((e: UploadThingError<inferErrorShape<TRouter>>) => MaybePromise<void>)
+    | ((e: UploadThingError<inferErrorShape<TFileRoute>>) => MaybePromise<void>)
     | undefined;
   /**
    * Set custom headers that'll get sent with requests
@@ -94,7 +94,7 @@ export type UploadthingComponentProps<
   TRouter extends FileRouter,
   TEndpoint extends keyof TRouter,
 > = Omit<
-  UseUploadthingProps<TRouter, TEndpoint>,
+  UseUploadthingProps<TRouter[TEndpoint]>,
   /**
    * Signal is omitted, component has its own AbortController
    * If you need to control the interruption with more granularity,

--- a/packages/vue/src/useUploadThing.ts
+++ b/packages/vue/src/useUploadThing.ts
@@ -55,7 +55,7 @@ export const INTERNAL_uploadthingHookGen = <
 
   const useUploadThing = <TEndpoint extends keyof TRouter>(
     endpoint: EndpointArg<TRouter, TEndpoint>,
-    opts?: UseUploadthingProps<TRouter, TEndpoint>,
+    opts?: UseUploadthingProps<TRouter[TEndpoint]>,
   ) => {
     const isUploading = ref(false);
     const uploadProgress = ref(0);
@@ -110,9 +110,9 @@ export const INTERNAL_uploadthingHookGen = <
          */
         if (e instanceof UploadAbortedError) throw e;
 
-        let error: UploadThingError<inferErrorShape<TRouter>>;
+        let error: UploadThingError<inferErrorShape<TRouter[TEndpoint]>>;
         if (e instanceof UploadThingError) {
-          error = e as UploadThingError<inferErrorShape<TRouter>>;
+          error = e as UploadThingError<inferErrorShape<TRouter[TEndpoint]>>;
         } else {
           error = INTERNAL_DO_NOT_USE__fatalClientError(e as Error);
           console.error(


### PR DESCRIPTION
This PR simplifies the types of a built file route making hover much nicer and grokable. The idea is simple, the built uploader (i.e. after calling `.onUploadComplete`) does not need to keep around all the internal types, we just need to expose the types that the client needs for inference

## Before

### Server
![CleanShot 2024-11-05 at 21 33 33@2x](https://github.com/user-attachments/assets/800a98eb-36f0-4660-97b6-d3b9c2c44c85)

### Client
![CleanShot 2024-11-05 at 21 34 47@2x](https://github.com/user-attachments/assets/becd303e-329f-4fd5-a7c4-6352fc36da2c)
![image](https://github.com/user-attachments/assets/0e0d659d-207d-491c-ac7c-362440ce8343)


## After

### Server
![CleanShot 2024-11-05 at 22 34 27@2x](https://github.com/user-attachments/assets/e9baf3f3-5a58-4b01-bbf8-e2a4b7768741)

### Client
![CleanShot 2024-11-05 at 22 34 11@2x](https://github.com/user-attachments/assets/e0f539e1-364c-4615-a090-16739e2c37f0)
![CleanShot 2024-11-05 at 23 11 54@2x](https://github.com/user-attachments/assets/cd9d9753-a976-4c88-9ffc-af3e9ca1b0fa)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced upload handling with simplified type definitions and improved error handling.
  - Introduction of new types for inferring endpoint input and output, enhancing type safety.
  - Refined type definitions for various upload-related functions, ensuring more specific and accurate type inference.

- **Bug Fixes**
  - Refined property access in error formatting and router configuration for better clarity.
  - Improved error handling to specifically catch and manage upload errors related to endpoint types.

- **Tests**
  - Updated test cases to reflect changes in property access, ensuring type safety and validation of error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->