### PR TITLE
feat: forward request context to `onUploadComplete` and `onUploadError`

### DIFF
--- a/.changeset/warm-moons-count.md
+++ b/.changeset/warm-moons-count.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": minor
+---
+
+feat: forward request context to `onUploadComplete` and `onUploadError`

--- a/examples/backend-adapters/server/src/router.ts
+++ b/examples/backend-adapters/server/src/router.ts
@@ -61,8 +61,8 @@ export const uploadRouter = {
       console.log("upload error", { message: error.message, fileKey });
       throw error;
     })
-    .onUploadComplete(async (data) => {
-      console.log("upload completed", data);
+    .onUploadComplete(async ({ metadata, file }) => {
+      console.log("upload completed", metadata, file);
       // await new Promise((r) => setTimeout(r, 15000));
       return { foo: "bar", baz: "qux" };
     }),

--- a/packages/uploadthing/src/effect-platform.ts
+++ b/packages/uploadthing/src/effect-platform.ts
@@ -13,7 +13,7 @@ import type { FileRouter, RouteHandlerConfig } from "./types";
 export { UTFiles } from "./internal/types";
 export type { FileRouter };
 
-type MiddlewareArgs = {
+type AdapterArgs = {
   req: HttpServerRequest.HttpServerRequest;
   res: undefined;
   event: undefined;
@@ -21,7 +21,7 @@ type MiddlewareArgs = {
 
 export const createUploadthing = <TErrorShape extends Json>(
   opts?: CreateBuilderOptions<TErrorShape>,
-) => createBuilder<MiddlewareArgs, TErrorShape>(opts);
+) => createBuilder<AdapterArgs, TErrorShape>(opts);
 
 export const createRouteHandler = <TRouter extends FileRouter>(opts: {
   router: TRouter;

--- a/packages/uploadthing/src/effect-platform.ts
+++ b/packages/uploadthing/src/effect-platform.ts
@@ -5,7 +5,7 @@ import * as Layer from "effect/Layer";
 import type { Json } from "@uploadthing/shared";
 
 import { configProvider } from "./internal/config";
-import { createRequestHandler, MiddlewareArguments } from "./internal/handler";
+import { AdapterArguments, createRequestHandler } from "./internal/handler";
 import type { CreateBuilderOptions } from "./internal/upload-builder";
 import { createBuilder } from "./internal/upload-builder";
 import type { FileRouter, RouteHandlerConfig } from "./types";
@@ -52,7 +52,7 @@ export const createRouteHandler = <TRouter extends FileRouter>(opts: {
 
   return HttpRouter.provideServiceEffect(
     router,
-    MiddlewareArguments,
+    AdapterArguments,
     Effect.map(HttpServerRequest.HttpServerRequest, (serverRequest) => ({
       req: serverRequest,
       res: undefined,

--- a/packages/uploadthing/src/express.ts
+++ b/packages/uploadthing/src/express.ts
@@ -17,7 +17,7 @@ import type { FileRouter, RouteHandlerOptions } from "./types";
 export { UTFiles } from "./internal/types";
 export type { FileRouter };
 
-type MiddlewareArgs = {
+type AdapterArgs = {
   req: ExpressRequest;
   res: ExpressResponse;
   event: undefined;
@@ -25,7 +25,7 @@ type MiddlewareArgs = {
 
 export const createUploadthing = <TErrorShape extends Json>(
   opts?: CreateBuilderOptions<TErrorShape>,
-) => createBuilder<MiddlewareArgs, TErrorShape>(opts);
+) => createBuilder<AdapterArgs, TErrorShape>(opts);
 
 export const createRouteHandler = <TRouter extends FileRouter>(
   opts: RouteHandlerOptions<TRouter>,

--- a/packages/uploadthing/src/fastify.ts
+++ b/packages/uploadthing/src/fastify.ts
@@ -12,7 +12,7 @@ import type { FileRouter, RouteHandlerOptions } from "./types";
 export { UTFiles } from "./internal/types";
 export type { FileRouter };
 
-type MiddlewareArgs = {
+type AdapterArgs = {
   req: FastifyRequest;
   res: FastifyReply;
   event: undefined;
@@ -20,7 +20,7 @@ type MiddlewareArgs = {
 
 export const createUploadthing = <TErrorShape extends Json>(
   opts?: CreateBuilderOptions<TErrorShape>,
-) => createBuilder<MiddlewareArgs, TErrorShape>(opts);
+) => createBuilder<AdapterArgs, TErrorShape>(opts);
 
 export const createRouteHandler = <TRouter extends FileRouter>(
   fastify: FastifyInstance,

--- a/packages/uploadthing/src/h3.ts
+++ b/packages/uploadthing/src/h3.ts
@@ -12,7 +12,11 @@ import type { FileRouter, RouteHandlerOptions } from "./types";
 export { UTFiles } from "./internal/types";
 export type { FileRouter };
 
-type AdapterArgs = { req: undefined; res: undefined; event: H3Event };
+type AdapterArgs = {
+  req: undefined;
+  res: undefined;
+  event: H3Event;
+};
 
 export const createUploadthing = <TErrorShape extends Json>(
   opts?: CreateBuilderOptions<TErrorShape>,

--- a/packages/uploadthing/src/h3.ts
+++ b/packages/uploadthing/src/h3.ts
@@ -12,11 +12,11 @@ import type { FileRouter, RouteHandlerOptions } from "./types";
 export { UTFiles } from "./internal/types";
 export type { FileRouter };
 
-type MiddlewareArgs = { req: undefined; res: undefined; event: H3Event };
+type AdapterArgs = { req: undefined; res: undefined; event: H3Event };
 
 export const createUploadthing = <TErrorShape extends Json>(
   opts?: CreateBuilderOptions<TErrorShape>,
-) => createBuilder<MiddlewareArgs, TErrorShape>(opts);
+) => createBuilder<AdapterArgs, TErrorShape>(opts);
 
 export const createRouteHandler = <TRouter extends FileRouter>(
   opts: RouteHandlerOptions<TRouter>,

--- a/packages/uploadthing/src/internal/handler.ts
+++ b/packages/uploadthing/src/internal/handler.ts
@@ -325,8 +325,8 @@ const handleCallbackRequest = (opts: {
      * Run `.onUploadComplete` as a daemon to prevent the
      * request from UT to potentially timeout.
      */
-    const adapterArgs = yield* AdapterArguments;
     const fiber = yield* Effect.gen(function* () {
+      const adapterArgs = yield* AdapterArguments;
       const serverData = yield* Effect.tryPromise({
         try: async () =>
           uploadable.onUploadComplete({
@@ -385,13 +385,13 @@ const runRouteMiddleware = (opts: {
   uploadable: AnyFileRoute;
 }) =>
   Effect.gen(function* () {
-    const adapterArgs = yield* AdapterArguments;
     const {
       json: { files, input },
       uploadable,
     } = opts;
 
     yield* Effect.logDebug("Running middleware");
+    const adapterArgs = yield* AdapterArguments;
     const metadata = yield* Effect.tryPromise({
       try: async () =>
         uploadable.middleware({

--- a/packages/uploadthing/src/internal/upload-builder.ts
+++ b/packages/uploadthing/src/internal/upload-builder.ts
@@ -7,15 +7,15 @@ import type {
 
 import { defaultErrorFormatter } from "./error-formatter";
 import type {
+  AdapterFnArgs,
   AnyBuiltUploaderTypes,
   AnyFileRoute,
-  MiddlewareFnArgs,
   UnsetMarker,
   UploadBuilder,
 } from "./types";
 
 function internalCreateBuilder<
-  TMiddlewareArgs extends MiddlewareFnArgs<any, any, any>,
+  TAdapterFnArgs extends AdapterFnArgs<any, any, any>,
   TRouteOptions extends RouteOptions,
   TErrorShape extends Json = { message: string },
 >(
@@ -24,7 +24,7 @@ function internalCreateBuilder<
   _routeOptions: TRouteOptions;
   _input: { in: UnsetMarker; out: UnsetMarker };
   _metadata: UnsetMarker;
-  _middlewareArgs: TMiddlewareArgs;
+  _adapterFnArgs: TAdapterFnArgs;
   _errorShape: TErrorShape;
   _errorFn: UnsetMarker;
   _output: UnsetMarker;
@@ -92,7 +92,7 @@ export type CreateBuilderOptions<TErrorShape extends Json> = {
 };
 
 export function createBuilder<
-  TMiddlewareArgs extends MiddlewareFnArgs<any, any, any>,
+  TAdapterFnArgs extends AdapterFnArgs<any, any, any>,
   TErrorShape extends Json = { message: string },
 >(opts?: CreateBuilderOptions<TErrorShape>) {
   return <TRouteOptions extends RouteOptions>(
@@ -102,12 +102,12 @@ export function createBuilder<
     _routeOptions: TRouteOptions;
     _input: { in: UnsetMarker; out: UnsetMarker };
     _metadata: UnsetMarker;
-    _middlewareArgs: TMiddlewareArgs;
+    _adapterFnArgs: TAdapterFnArgs;
     _errorShape: TErrorShape;
     _errorFn: UnsetMarker;
     _output: UnsetMarker;
   }> => {
-    return internalCreateBuilder<TMiddlewareArgs, TRouteOptions, TErrorShape>({
+    return internalCreateBuilder<TAdapterFnArgs, TRouteOptions, TErrorShape>({
       routerConfig: input,
       routeOptions: config ?? {},
       ...opts,

--- a/packages/uploadthing/src/next-legacy.ts
+++ b/packages/uploadthing/src/next-legacy.ts
@@ -12,7 +12,7 @@ import type { FileRouter, RouteHandlerOptions } from "./types";
 export { UTFiles } from "./internal/types";
 export type { FileRouter };
 
-type MiddlewareArgs = {
+type AdapterArgs = {
   req: NextApiRequest;
   res: NextApiResponse;
   event: undefined;
@@ -20,7 +20,7 @@ type MiddlewareArgs = {
 
 export const createUploadthing = <TErrorShape extends Json>(
   opts?: CreateBuilderOptions<TErrorShape>,
-) => createBuilder<MiddlewareArgs, TErrorShape>(opts);
+) => createBuilder<AdapterArgs, TErrorShape>(opts);
 
 export const createRouteHandler = <TRouter extends FileRouter>(
   opts: RouteHandlerOptions<TRouter>,

--- a/packages/uploadthing/src/next.ts
+++ b/packages/uploadthing/src/next.ts
@@ -11,7 +11,11 @@ import type { FileRouter, RouteHandlerOptions } from "./types";
 export type { FileRouter };
 export { UTFiles } from "./internal/types";
 
-type AdapterArgs = { req: NextRequest; res: undefined; event: undefined };
+type AdapterArgs = {
+  req: NextRequest;
+  res: undefined;
+  event: undefined;
+};
 
 export const createUploadthing = <TErrorShape extends Json>(
   opts?: CreateBuilderOptions<TErrorShape>,

--- a/packages/uploadthing/src/next.ts
+++ b/packages/uploadthing/src/next.ts
@@ -11,11 +11,11 @@ import type { FileRouter, RouteHandlerOptions } from "./types";
 export type { FileRouter };
 export { UTFiles } from "./internal/types";
 
-type MiddlewareArgs = { req: NextRequest; res: undefined; event: undefined };
+type AdapterArgs = { req: NextRequest; res: undefined; event: undefined };
 
 export const createUploadthing = <TErrorShape extends Json>(
   opts?: CreateBuilderOptions<TErrorShape>,
-) => createBuilder<MiddlewareArgs, TErrorShape>(opts);
+) => createBuilder<AdapterArgs, TErrorShape>(opts);
 
 export const createRouteHandler = <TRouter extends FileRouter>(
   opts: RouteHandlerOptions<TRouter>,

--- a/packages/uploadthing/src/remix.ts
+++ b/packages/uploadthing/src/remix.ts
@@ -11,7 +11,7 @@ import type { FileRouter, RouteHandlerOptions } from "./types";
 export type { FileRouter };
 export { UTFiles } from "./internal/types";
 
-type MiddlewareArgs = {
+type AdapterArgs = {
   req: undefined;
   res: undefined;
   event: ActionFunctionArgs;
@@ -19,7 +19,7 @@ type MiddlewareArgs = {
 
 export const createUploadthing = <TErrorShape extends Json>(
   opts?: CreateBuilderOptions<TErrorShape>,
-) => createBuilder<MiddlewareArgs, TErrorShape>(opts);
+) => createBuilder<AdapterArgs, TErrorShape>(opts);
 
 export const createRouteHandler = <TRouter extends FileRouter>(
   opts: RouteHandlerOptions<TRouter>,

--- a/packages/uploadthing/src/server.ts
+++ b/packages/uploadthing/src/server.ts
@@ -14,11 +14,11 @@ export { UTApi } from "./sdk";
 export { UTFile } from "./sdk/ut-file";
 export { UploadThingError, type FileRouter };
 
-type MiddlewareArgs = { req: Request; res: undefined; event: undefined };
+type AdapterArgs = { req: Request; res: undefined; event: undefined };
 
 export const createUploadthing = <TErrorShape extends Json>(
   opts?: CreateBuilderOptions<TErrorShape>,
-) => createBuilder<MiddlewareArgs, TErrorShape>(opts);
+) => createBuilder<AdapterArgs, TErrorShape>(opts);
 
 export const createRouteHandler = <TRouter extends FileRouter>(
   opts: RouteHandlerOptions<TRouter>,

--- a/packages/uploadthing/src/server.ts
+++ b/packages/uploadthing/src/server.ts
@@ -14,7 +14,11 @@ export { UTApi } from "./sdk";
 export { UTFile } from "./sdk/ut-file";
 export { UploadThingError, type FileRouter };
 
-type AdapterArgs = { req: Request; res: undefined; event: undefined };
+type AdapterArgs = {
+  req: Request;
+  res: undefined;
+  event: undefined;
+};
 
 export const createUploadthing = <TErrorShape extends Json>(
   opts?: CreateBuilderOptions<TErrorShape>,

--- a/packages/uploadthing/test/request-handler.test.ts
+++ b/packages/uploadthing/test/request-handler.test.ts
@@ -426,21 +426,23 @@ describe(".onUploadComplete()", () => {
       signPayload(payload, testToken.decoded.apiKey),
     );
 
-    const res = await handler(
-      new Request(createApiUrl("imageUploader"), {
-        method: "POST",
-        headers: {
-          "uploadthing-hook": "callback",
-          "x-uploadthing-signature": signature,
-        },
-        body: payload,
-      }),
-    );
+    const request = new Request(createApiUrl("imageUploader"), {
+      method: "POST",
+      headers: {
+        "uploadthing-hook": "callback",
+        "x-uploadthing-signature": signature,
+      },
+      body: payload,
+    });
+    const res = await handler(request);
 
     expect(res.status).toBe(200);
     await expect(res.json()).resolves.toBe(null);
     expect(uploadCompleteMock).toHaveBeenCalledOnce();
     expect(uploadCompleteMock).toHaveBeenCalledWith({
+      event: undefined,
+      res: undefined,
+      req: request,
       file: {
         customId: null,
         key: "some-random-key.png",


### PR DESCRIPTION
currently you can only access the request in `middleware`. This adds so you can also access it in `onUploadComplete` and `onUploadError`. This is especially important in e.g. workers where your environment variables and bindings are on the request context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added the ability to forward request context to `onUploadComplete` and `onUploadError` callbacks, enhancing upload process visibility.

- **Bug Fixes**
  - Improved error handling for invalid requests, ensuring appropriate status codes and messages are returned for various error scenarios.
  - Strengthened input validation logic to enforce schema compliance and provide clear feedback on discrepancies.

- **Tests**
  - Enhanced test suite with new tests for error handling, middleware functionality, input validation, and file upload logic, ensuring comprehensive coverage of upload scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->