### PR TITLE
chore: export the generic FileRoute type

### DIFF
--- a/.changeset/rude-pumas-explode.md
+++ b/.changeset/rude-pumas-explode.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+chore: export generic `FileRoute` type

--- a/packages/uploadthing/src/types.ts
+++ b/packages/uploadthing/src/types.ts
@@ -8,7 +8,7 @@ import type {
 } from "@uploadthing/shared";
 
 import type { LogFormat } from "./internal/logger";
-import type { AnyFileRoute } from "./internal/types";
+import type { AnyFileRoute, FileRoute } from "./internal/types";
 
 export * from "./sdk/types";
 
@@ -25,7 +25,7 @@ export type {
   NewPresignedUrl,
 } from "./internal/shared-schemas";
 
-export type { AnyFileRoute };
+export type { FileRoute, AnyFileRoute };
 export type FileRouter = Record<string, AnyFileRoute>;
 
 export type inferEndpointInput<TFileRoute extends AnyFileRoute> =


### PR DESCRIPTION
could be useful in monorepos to do a more schema-driven development where you define the upload router type in some shared package and used in UI components maybe

```ts
// packages/shared
import type { FileRoute } from "uploadthing/types";

export type UploadThingRouter = {
    mockRoute: FileRoute<{
        input: undefined;
        output: null;
        errorShape: { message: string };
    }>;
}


// packages/ui
import type { UploadThingRouter } from "@repo/shared";
import { generateReactHelpers } from "@uploadthing/react";

export const { useUploadThing } = generateReactHelpers<UploadThingRouter>();


// backend/api
import type { UploadThingRouter } from "@repo/shared";
import { createUploadthing, createRouteHandler } from "uploadthing/server";

const f = createUploadthing();

const router: UploadThingRouter = {
  mockRoute: f()...,
} // WILL ERROR IF DOESN'T MATCH DEFINED SCHEMA

const handler = createRouteHandler({
  router,
}); 
```