### PR TITLE
fix: Construction of content-disposition header

### DIFF
--- a/.changeset/olive-comics-smile.md
+++ b/.changeset/olive-comics-smile.md
@@ -1,0 +1,5 @@
+---
+"@uploadthing/shared": patch
+---
+
+fix: Construction of content-disposition header - follow RFC6266 spec

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -210,7 +210,7 @@ export function contentDisposition(
 
   //UTF-8 encode for the extended parameter (RFC 5987)
   const utf8FileName = encodeURIComponent(fileName)
-    .replace(/['()]/g, escape)
+    .replace(/[')(]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`)
     .replace(/\*/g, "%2A");
 
   return [

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -194,15 +194,29 @@ export function filterDefinedObjectValues<T>(
   );
 }
 
-/** construct content-disposition header */
+/** construct content-disposition header according to RFC 6266 section 4.1
+ * https://www.rfc-editor.org/rfc/rfc6266#section-4.1
+ *
+ * @example
+ * contentDisposition("inline", 'my "special" file,name.pdf');
+ * // => "inline; filename="my \"special\" file\,name.pdf"; filename*=UTF-8''my%20%22special%22%20file%2Cname.pdf"
+ */
 export function contentDisposition(
   contentDisposition: ContentDisposition,
   fileName: string,
 ) {
+  // Encode the filename for the legacy parameter
+  const legacyFileName = fileName.replace(/[",\\']/g, "\\$&");
+
+  //UTF-8 encode for the extended parameter (RFC 5987)
+  const utf8FileName = encodeURIComponent(fileName)
+    .replace(/['()]/g, escape)
+    .replace(/\*/g, "%2A");
+
   return [
     contentDisposition,
-    `filename="${encodeURI(fileName)}"`,
-    `filename*=UTF-8''${encodeURI(fileName)}`,
+    `filename="${legacyFileName}"`,
+    `filename*=UTF-8''${utf8FileName}`,
   ].join("; ");
 }
 

--- a/packages/shared/test/utils.test.ts
+++ b/packages/shared/test/utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { contentDisposition } from "../src";
+
+describe("contentDisposition", () => {
+  it("handles filenames with special characters", () => {
+    const result = contentDisposition("inline", 'my "special" file,name.pdf');
+    expect(result).toBe(
+      'inline; filename="my \\"special\\" file\\,name.pdf"; filename*=UTF-8\'\'my%20%22special%22%20file%2Cname.pdf',
+    );
+  });
+
+  it("handles filenames with unicode characters", () => {
+    const result = contentDisposition(
+      "attachment",
+      "3$ Mù FRANçé_33902_Country_5_202105",
+    );
+    expect(result).toBe(
+      "attachment; filename=\"3$ Mù FRANçé_33902_Country_5_202105\"; filename*=UTF-8''3%24%20M%C3%B9%20FRAN%C3%A7%C3%A9_33902_Country_5_202105",
+    );
+  });
+
+  it("handles simple filenames", () => {
+    const result = contentDisposition("attachment", "simple.txt");
+    expect(result).toBe(
+      "attachment; filename=\"simple.txt\"; filename*=UTF-8''simple.txt",
+    );
+  });
+});


### PR DESCRIPTION
Previously, certain special characters would break the header, and cause loss of parts of the file name and extension (#1052)

This should more strictly follow the header spec, properly escaping and encoding the parts of the header. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved filename encoding for better compatibility with legacy systems.
	- Expanded documentation for the contentDisposition function, including usage examples.

- **Bug Fixes**
	- Enhanced handling of special characters in filenames to prevent issues during file downloads.
	- Ensured compliance with RFC 6266 for content-disposition headers.

- **Documentation**
	- Updated comments to clarify the encoding process for both legacy and UTF-8 filename parameters.
	- Introduced a new test suite for the contentDisposition function to validate its behavior under various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->