### PR TITLE
fix: remove node env from build pipeline

### DIFF
--- a/packages/uploadthing/src/internal/config.test.ts
+++ b/packages/uploadthing/src/internal/config.test.ts
@@ -277,6 +277,7 @@ describe("IsDevelopment", () => {
   it.effect("is true if NODE_ENV is development", () =>
     Effect.gen(function* () {
       // @ts-expect-error - it says it's readonly but we can mutate it
+      // eslint-disable-next-line turbo/no-undeclared-env-vars
       process.env.NODE_ENV = "development";
 
       const isDev = yield* IsDevelopment.pipe(

--- a/packages/uploadthing/src/internal/config.ts
+++ b/packages/uploadthing/src/internal/config.ts
@@ -53,6 +53,7 @@ export const configProvider = (options: unknown) =>
 export const IsDevelopment = Config.boolean("isDev").pipe(
   Config.orElse(() =>
     Config.succeed(
+      // eslint-disable-next-line turbo/no-undeclared-env-vars
       typeof process !== "undefined" ? process.env.NODE_ENV : undefined,
     ).pipe(Config.map((_) => _ === "development")),
   ),

--- a/turbo.json
+++ b/turbo.json
@@ -9,13 +9,7 @@
     "UPLOADTHING_API_URL",
     "UPLOADTHING_INGEST_URL"
   ],
-  "globalPassThroughEnv": [
-    "VERCEL_URL",
-    "VERCEL_ENV",
-    "NODE",
-    "NODE_ENV",
-    "CI"
-  ],
+  "globalPassThroughEnv": ["VERCEL_URL", "VERCEL_ENV", "CI"],
   "tasks": {
     "topo": {
       "dependsOn": ["^topo"]


### PR DESCRIPTION
NODE_ENV being present during build causes static replacement and breaks automatic dev mode detection