### PR TITLE
fix: automatic dev mode detection

### DIFF
--- a/.changeset/tame-stingrays-brush.md
+++ b/.changeset/tame-stingrays-brush.md
@@ -2,4 +2,4 @@
 uploadthing: patch
 ---
 
-don't inject NODE_ENV to rollup replace plugin
+fix automatic dev mode detection

--- a/.changeset/tame-stingrays-brush.md
+++ b/.changeset/tame-stingrays-brush.md
@@ -1,0 +1,5 @@
+---
+uploadthing: patch
+---
+
+don't inject NODE_ENV to rollup replace plugin

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
   "pnpm": {
     "patchedDependencies": {
       "msw@2.2.13": "patches/msw@2.2.13.patch",
-      "@mswjs/interceptors@0.26.15": "patches/@mswjs__interceptors@0.26.15.patch"
+      "@mswjs/interceptors@0.26.15": "patches/@mswjs__interceptors@0.26.15.patch",
+      "bunchee@6.1.2": "patches/bunchee@6.1.2.patch"
     }
   }
 }

--- a/patches/bunchee@6.1.2.patch
+++ b/patches/bunchee@6.1.2.patch
@@ -1,0 +1,34 @@
+diff --git a/dist/index.js b/dist/index.js
+index 4cadc4dd7e95da967da5b897ba8d20dae25bf7c1..2c742f6da291d5f66aed0033ff5dc1ea2a6f12d4 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1068,9 +1068,9 @@ async function writeDefaultTsconfig(tsConfigPath) {
+ /**
+  * @return {Record<string, string>} env { 'process.env.<key>': '<value>' }
+  */ function getDefinedInlineVariables(envs, parsedExportCondition) {
+-    if (!envs.includes('NODE_ENV')) {
+-        envs.push('NODE_ENV');
+-    }
++    // if (!envs.includes('NODE_ENV')) {
++    //     envs.push('NODE_ENV');
++    // }
+     const envVars = envs.reduce((acc, key)=>{
+         const value = process.env[key];
+         if (typeof value !== 'undefined') {
+@@ -1087,11 +1087,11 @@ async function writeDefaultTsconfig(tsConfigPath) {
+         return acc;
+     }, new Set());
+     // For development and production convention, we override the NODE_ENV value
+-    if (exportConditionNames.has('development')) {
+-        envVars['process.env.NODE_ENV'] = JSON.stringify('development');
+-    } else if (exportConditionNames.has('production')) {
+-        envVars['process.env.NODE_ENV'] = JSON.stringify('production');
+-    }
++    // if (exportConditionNames.has('development')) {
++    //     envVars['process.env.NODE_ENV'] = JSON.stringify('development');
++    // } else if (exportConditionNames.has('production')) {
++    //     envVars['process.env.NODE_ENV'] = JSON.stringify('production');
++    // }
+     if (exportConditionNames.has('edge-light')) {
+         envVars['EdgeRuntime'] = JSON.stringify('edge-runtime');
+     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ patchedDependencies:
   '@mswjs/interceptors@0.26.15':
     hash: b4i3mfjisdgapabfrhqgz5r23e
     path: patches/@mswjs__interceptors@0.26.15.patch
+  bunchee@6.1.2:
+    hash: zsxtdggzsv4wyktgrmbmvae3om
+    path: patches/bunchee@6.1.2.patch
   msw@2.2.13:
     hash: mpkjv35lscrawpqthnrnago5ai
     path: patches/msw@2.2.13.patch
@@ -1331,7 +1334,7 @@ importers:
         version: link:../../tooling/tsconfig
       bunchee:
         specifier: ^6.1.2
-        version: 6.1.2(typescript@5.6.2)
+        version: 6.1.2(patch_hash=zsxtdggzsv4wyktgrmbmvae3om)(typescript@5.6.2)
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
@@ -1370,7 +1373,7 @@ importers:
         version: link:../../tooling/tsconfig
       bunchee:
         specifier: ^6.1.2
-        version: 6.1.2(typescript@5.6.2)
+        version: 6.1.2(patch_hash=zsxtdggzsv4wyktgrmbmvae3om)(typescript@5.6.2)
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
@@ -1459,7 +1462,7 @@ importers:
         version: 2.1.2(@vitest/spy@2.1.2)(playwright@1.45.0)(typescript@5.6.2)(vite@5.4.8(@types/node@20.16.11)(lightningcss@1.28.1)(terser@5.34.1))(vitest@2.1.2)
       bunchee:
         specifier: ^6.1.2
-        version: 6.1.2(typescript@5.6.2)
+        version: 6.1.2(patch_hash=zsxtdggzsv4wyktgrmbmvae3om)(typescript@5.6.2)
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
@@ -1511,7 +1514,7 @@ importers:
         version: link:../../tooling/tsconfig
       bunchee:
         specifier: ^6.1.2
-        version: 6.1.2(typescript@5.6.2)
+        version: 6.1.2(patch_hash=zsxtdggzsv4wyktgrmbmvae3om)(typescript@5.6.2)
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
@@ -1661,7 +1664,7 @@ importers:
         version: 1.20.3
       bunchee:
         specifier: ^6.1.2
-        version: 6.1.2(typescript@5.6.2)
+        version: 6.1.2(patch_hash=zsxtdggzsv4wyktgrmbmvae3om)(typescript@5.6.2)
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
@@ -1728,7 +1731,7 @@ importers:
         version: link:../../tooling/tsconfig
       bunchee:
         specifier: ^6.1.2
-        version: 6.1.2(typescript@5.6.2)
+        version: 6.1.2(patch_hash=zsxtdggzsv4wyktgrmbmvae3om)(typescript@5.6.2)
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
@@ -27986,7 +27989,7 @@ snapshots:
       '@types/node': 20.12.14
       '@types/ws': 8.5.10
 
-  bunchee@6.1.2(typescript@5.6.2):
+  bunchee@6.1.2(patch_hash=zsxtdggzsv4wyktgrmbmvae3om)(typescript@5.6.2):
     dependencies:
       '@rollup/plugin-commonjs': 28.0.1(rollup@4.29.1)
       '@rollup/plugin-json': 6.1.0(rollup@4.29.1)


### PR DESCRIPTION
this bug is so cursed...

NODE_ENV is set when the docs are built on Vercel, which causes the packages to be built with this variable defined.

and then when we go and publish pacakges we're pickign up that cached build and getting the `process.env.NODE_ENV` statically replaced...

tried fixing this by omitting the variable from the turbo process in #1105 but that was pure pain..

fix by patching bunchee to not append NODE_ENV to the `@rollup/plugin-replace` plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a patch for `bunchee@6.1.2` to resolve dependency configuration
	- Updated formatting for patched dependencies in project configuration

- **Bug Fixes**
	- Improved automatic detection of development mode for the `uploadthing` module

<!-- end of auto-generated comment: release notes by coderabbit.ai -->