### PR TITLE
fix: don't pin peer dep to exact version

### DIFF
--- a/.changeset/large-dryers-worry.md
+++ b/.changeset/large-dryers-worry.md
@@ -1,0 +1,13 @@
+---
+"@uploadthing/expo": patch
+"@uploadthing/mime-types": patch
+"@uploadthing/nuxt": patch
+"@uploadthing/react": patch
+"@uploadthing/shared": patch
+"@uploadthing/solid": patch
+"@uploadthing/svelte": patch
+"uploadthing": patch
+"@uploadthing/vue": patch
+---
+
+chore: more relaxed peer dep requirements between uploadthing packages

--- a/.github/release-canary.js
+++ b/.github/release-canary.js
@@ -41,8 +41,13 @@ async function version() {
 
     // Update dependencies
     for (const dep in pkg.dependencies) {
-      if (versions[dep]) {
+      if (versions[dep] && pkg.dependencies[dep].startsWith("workspace:")) {
         pkg.dependencies[dep] = versions[dep];
+      }
+    }
+    for (const dep in pkg.peerDependencies) {
+      if (versions[dep] && pkg.peerDependencies[dep].startsWith("workspace:")) {
+        pkg.peerDependencies[dep] = versions[dep];
       }
     }
 

--- a/.github/replace-workspace-protocol.ts
+++ b/.github/replace-workspace-protocol.ts
@@ -34,11 +34,16 @@ await Promise.all(
 const workspacePkg = await Bun.file("package.json").json();
 for (const dep in workspacePkg.dependencies) {
   if (dep in packageVersions) {
-    workspacePkg.dependencies[dep] = packageVersions[dep];
+    if (workspacePkg.dependencies[dep].startsWith("workspace:")) {
+      workspacePkg.dependencies[dep] = packageVersions[dep];
+    }
   }
 }
 for (const dep in workspacePkg.peerDependencies) {
-  if (dep in packageVersions) {
+  if (
+    dep in packageVersions &&
+    workspacePkg.peerDependencies[dep].startsWith("workspace:")
+  ) {
     workspacePkg.peerDependencies[dep] = packageVersions[dep];
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced dependency management scripts for release and workspace protocol handling
	- Improved version tracking for dependencies and peer dependencies
	- Added more robust checks when updating package configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->