### PR TITLE
docs(nuxt): fix file path for file router

### DIFF
--- a/docs/src/app/(docs)/getting-started/nuxt/page.mdx
+++ b/docs/src/app/(docs)/getting-started/nuxt/page.mdx
@@ -96,7 +96,7 @@ the [File Router API](/file-routes).
   `UploadRouter` for the module to pick up your router and it's types.
 </Note>
 
-```ts {{ title: "src/lib/server/uploadthing.ts" }}
+```ts {{ title: "server/uploadthing.ts" }}
 import type { H3Event } from "h3";
 
 import { createUploadthing } from "uploadthing/h3";

--- a/packages/nuxt/playground/nuxt.config.ts
+++ b/packages/nuxt/playground/nuxt.config.ts
@@ -3,4 +3,5 @@ export default defineNuxtConfig({
   devtools: { enabled: true },
   modules: ["../src/module", "@nuxtjs/tailwindcss"],
   telemetry: false,
+  compatibilityDate: "2024-04-03",
 });


### PR DESCRIPTION
Changed the file path for the file router to match Nuxt's structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated Nuxt module setup guide with simplified file path for `uploadthing.ts`
	- Added compatibility date configuration for Nuxt project

<!-- end of auto-generated comment: release notes by coderabbit.ai -->