### PR TITLE
fix(docs): typo in api-reference/client

### DIFF
--- a/docs/src/app/(docs)/api-reference/client/page.mdx
+++ b/docs/src/app/(docs)/api-reference/client/page.mdx
@@ -3,7 +3,7 @@ import { docsMetadata } from "@/lib/utils";
 export const metadata = docsMetadata({
   title: "uploadthing/client",
   description:
-    "The UploadThing Client module provides utilities for working files in your application and communicating with your backend file router.",
+    "The UploadThing Client module provides utilities for working with files in your application and communicating with your backend file router.",
   category: "API Reference",
 });
 


### PR DESCRIPTION
Added missing "with".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation description for UploadThing Client module to improve grammatical clarity
	- Added preposition "with" to clarify file utility description

<!-- end of auto-generated comment: release notes by coderabbit.ai -->