### PR TITLE
docs: add missing `generatePermittedFileTypes` import

### DIFF
--- a/docs/src/app/(docs)/api-reference/react/page.mdx
+++ b/docs/src/app/(docs)/api-reference/react/page.mdx
@@ -592,7 +592,10 @@ and `useUploadThing` hooks. For a more complete example, take a look at
 
 ```tsx {{ title: "app/example-custom-uploader.tsx" }}
 import { useDropzone } from "@uploadthing/react";
-import { generateClientDropzoneAccept } from "uploadthing/client";
+import {
+  generateClientDropzoneAccept,
+  generatePermittedFileTypes,
+} from "uploadthing/client";
 
 import { useUploadThing } from "~/utils/uploadthing";
 


### PR DESCRIPTION
Example for `useDropzone` is missing `generatePermittedFileTypes` import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `generateUploadButton` and `generateUploadDropzone` functions for improved component generation.
  - Added `routeConfig` property to `useUploadThing` hook for enhanced file type information.

- **Deprecations**
  - Deprecated `generateComponents` function.
  - Deprecated `permittedFileTypes` property in `useUploadThing` hook.

- **Documentation**
  - Updated API reference with detailed usage examples for new functions and properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->