### PR TITLE
chore: use ufsUrl in examples

### DIFF
--- a/examples/profile-picture/src/app/_components/profile-pic-uploader.tsx
+++ b/examples/profile-picture/src/app/_components/profile-pic-uploader.tsx
@@ -44,8 +44,8 @@ export function ProfilePictureCard(props: { user: User }) {
 
         setNewImageLoading(true);
         await Promise.all([
-          updateUserImage(uploadedFile.url),
-          waitForImageToLoad(uploadedFile.url).catch(toast.error),
+          updateUserImage(uploadedFile.ufsUrl),
+          waitForImageToLoad(uploadedFile.ufsUrl).catch(toast.error),
         ]);
         setNewImageLoading(false);
 

--- a/examples/profile-picture/src/uploadthing/server.ts
+++ b/examples/profile-picture/src/uploadthing/server.ts
@@ -40,7 +40,7 @@ export const uploadRouter = {
        */
       await db
         .update(User)
-        .set({ image: file.url })
+        .set({ image: file.ufsUrl })
         .where(eq(User.id, metadata.userId));
 
       /**

--- a/examples/with-clerk-remix/app/routes/api.uploadthing.tsx
+++ b/examples/with-clerk-remix/app/routes/api.uploadthing.tsx
@@ -24,7 +24,7 @@ export const uploadRouter = {
     })
     .onUploadComplete(async ({ metadata, file }) => {
       console.log("Upload complete for userId:", metadata.userId);
-      console.log("file url", file.url);
+      console.log("file url", file.ufsUrl);
     }),
 } satisfies FileRouter;
 

--- a/examples/with-drizzle-appdir/src/server/uploadthing.ts
+++ b/examples/with-drizzle-appdir/src/server/uploadthing.ts
@@ -48,7 +48,7 @@ export const uploadRouter = {
       await db.insert(files).values({
         name: file.name,
         key: file.key,
-        url: file.url,
+        url: file.ufsUrl,
         uploadedBy: metadata.uploaderId,
       });
 

--- a/examples/with-drizzle-pagesdir/src/server/uploadthing.ts
+++ b/examples/with-drizzle-pagesdir/src/server/uploadthing.ts
@@ -46,7 +46,7 @@ export const uploadRouter = {
       await db.insert(files).values({
         name: file.name,
         key: file.key,
-        url: file.url,
+        url: file.ufsUrl,
         uploadedBy: metadata.uploaderId,
       });
     }),

--- a/examples/with-serveractions/src/app/page.tsx
+++ b/examples/with-serveractions/src/app/page.tsx
@@ -37,7 +37,7 @@ export default function Home() {
           const uploadedFile = await uploadFromUrl(fd);
           if (uploadedFile) {
             setIsUploading(false);
-            open(uploadedFile.url, "_blank");
+            open(uploadedFile.ufsUrl, "_blank");
           }
         }}
       >


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated file upload URL retrieval across multiple example projects
	- Corrected URL property from `file.url` to `file.ufsUrl` in upload-related components and server configurations

- **Refactor**
	- Standardized URL handling in upload processes across different example implementations

The changes ensure consistent URL access for uploaded files across various project examples, improving overall upload functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->