### PR TITLE
feat: use AbortController to remove/abort events

### DIFF
--- a/docs/src/app/providers.tsx
+++ b/docs/src/app/providers.tsx
@@ -18,6 +18,7 @@ function ThemeWatcher() {
   let { resolvedTheme, setTheme } = useTheme();
 
   useEffect(() => {
+    const controller = new AbortController();
     let media = window.matchMedia("(prefers-color-scheme: dark)");
 
     function onMediaChange() {
@@ -28,10 +29,12 @@ function ThemeWatcher() {
     }
 
     onMediaChange();
-    media.addEventListener("change", onMediaChange);
+    media.addEventListener("change", onMediaChange, {
+      signal: controller.signal,
+    });
 
     return () => {
-      media.removeEventListener("change", onMediaChange);
+      controller.abort();
     };
   }, [resolvedTheme, setTheme]);
 

--- a/docs/src/components/Search.tsx
+++ b/docs/src/components/Search.tsx
@@ -297,6 +297,8 @@ function SearchDialog({
       return;
     }
 
+    const controller = new AbortController();
+
     function onKeyDown(event: KeyboardEvent) {
       if (event.key === "k" && (event.metaKey || event.ctrlKey)) {
         event.preventDefault();
@@ -304,10 +306,12 @@ function SearchDialog({
       }
     }
 
-    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keydown", onKeyDown, {
+      signal: controller.signal,
+    });
 
     return () => {
-      window.removeEventListener("keydown", onKeyDown);
+      controller.abort();
     };
   }, [open, setOpen]);
 

--- a/docs/src/components/SectionProvider.tsx
+++ b/docs/src/components/SectionProvider.tsx
@@ -107,14 +107,19 @@ function useVisibleSections(sectionStore: StoreApi<SectionState>) {
       setVisibleSections(newVisibleSections);
     }
 
+    const controller = new AbortController();
     let raf = window.requestAnimationFrame(() => checkVisibleSections());
-    window.addEventListener("scroll", checkVisibleSections, { passive: true });
-    window.addEventListener("resize", checkVisibleSections);
+    window.addEventListener("scroll", checkVisibleSections, {
+      passive: true,
+      signal: controller.signal,
+    });
+    window.addEventListener("resize", checkVisibleSections, {
+      signal: controller.signal,
+    });
 
     return () => {
       window.cancelAnimationFrame(raf);
-      window.removeEventListener("scroll", checkVisibleSections);
-      window.removeEventListener("resize", checkVisibleSections);
+      controller.abort();
     };
   }, [setVisibleSections, sections]);
 }

--- a/packages/react/src/components/dropzone.tsx
+++ b/packages/react/src/components/dropzone.tsx
@@ -450,9 +450,12 @@ export function useDropzone({
       }
     };
 
-    window.addEventListener("focus", onWindowFocus, false);
+    const controller = new AbortController();
+    window.addEventListener("focus", onWindowFocus, {
+      signal: controller.signal,
+    });
     return () => {
-      window.removeEventListener("focus", onWindowFocus, false);
+      controller.abort();
     };
   }, [state.isFileDialogActive]);
 
@@ -466,13 +469,19 @@ export function useDropzone({
     };
     const onDocumentDragOver = (e: Pick<Event, "preventDefault">) =>
       e.preventDefault();
+    const controller = new AbortController();
 
-    document.addEventListener("dragover", onDocumentDragOver, false);
-    document.addEventListener("drop", onDocumentDrop, false);
+    document.addEventListener("dragover", onDocumentDragOver, {
+      capture: false,
+      signal: controller.signal,
+    });
+    document.addEventListener("drop", onDocumentDrop, {
+      capture: false,
+      signal: controller.signal,
+    });
 
     return () => {
-      document.removeEventListener("dragover", onDocumentDragOver);
-      document.removeEventListener("drop", onDocumentDrop);
+      controller.abort();
     };
   }, []);
 

--- a/packages/react/src/utils/usePaste.ts
+++ b/packages/react/src/utils/usePaste.ts
@@ -7,9 +7,12 @@ export const usePaste = (callback: PasteCallback) => {
   const stableCallback = useEvent(callback);
 
   useEffect(() => {
-    window.addEventListener("paste", stableCallback);
+    const controller = new AbortController();
+    window.addEventListener("paste", stableCallback, {
+      signal: controller.signal,
+    });
     return () => {
-      window.removeEventListener("paste", stableCallback);
+      controller.abort();
     };
   }, [stableCallback]);
 };

--- a/packages/solid/src/components/button.tsx
+++ b/packages/solid/src/components/button.tsx
@@ -156,6 +156,7 @@ export function UploadButton<
   createEffect(() => {
     if (!appendOnPaste) return;
 
+    const controller = new AbortController();
     const pasteHandler = (e: ClipboardEvent) => {
       if (document.activeElement !== inputRef) return;
 
@@ -168,9 +169,11 @@ export function UploadButton<
 
       if (mode === "auto") uploadFiles(files());
     };
-    document.addEventListener("paste", pasteHandler);
+    document.addEventListener("paste", pasteHandler, {
+      signal: controller.signal,
+    });
 
-    onCleanup(() => document.removeEventListener("paste", pasteHandler));
+    onCleanup(() => controller.abort());
   });
 
   const styleFieldArg = {

--- a/packages/solid/src/components/dropzone.tsx
+++ b/packages/solid/src/components/dropzone.tsx
@@ -200,6 +200,7 @@ export const UploadDropzone = <
   createEffect(() => {
     if (!appendOnPaste) return;
 
+    const controller = new AbortController();
     const pasteHandler = (e: ClipboardEvent) => {
       if (document.activeElement !== rootRef) return;
 
@@ -212,10 +213,12 @@ export const UploadDropzone = <
 
       if (mode === "auto") uploadFiles(files());
     };
-    document.addEventListener("paste", pasteHandler);
+    document.addEventListener("paste", pasteHandler, {
+      signal: controller.signal,
+    });
 
     onCleanup(() => {
-      document.removeEventListener("paste", pasteHandler);
+      controller.abort();
     });
   });
 
@@ -371,6 +374,7 @@ export function createDropzone(_props: DropzoneOptions) {
   const [state, setState] = createStore(initialState);
 
   createEffect(() => {
+    const controller = new AbortController();
     const onWindowFocus = () => {
       if (state.isFileDialogActive) {
         setTimeout(() => {
@@ -386,13 +390,17 @@ export function createDropzone(_props: DropzoneOptions) {
       }
     };
 
-    window.addEventListener("focus", onWindowFocus, false);
+    window.addEventListener("focus", onWindowFocus, {
+      capture: false,
+      signal: controller.signal,
+    });
     onCleanup(() => {
-      window.removeEventListener("focus", onWindowFocus, false);
+      controller.abort();
     });
   });
 
   createEffect(() => {
+    const controller = new AbortController();
     const onDocumentDrop = (event: DropEvent) => {
       const root = rootRef();
 
@@ -406,12 +414,17 @@ export function createDropzone(_props: DropzoneOptions) {
     const onDocumentDragOver = (e: Pick<Event, "preventDefault">) =>
       e.preventDefault();
 
-    document.addEventListener("dragover", onDocumentDragOver, false);
-    document.addEventListener("drop", onDocumentDrop, false);
+    document.addEventListener("dragover", onDocumentDragOver, {
+      capture: false,
+      signal: controller.signal,
+    });
+    document.addEventListener("drop", onDocumentDrop, {
+      capture: false,
+      signal: controller.signal,
+    });
 
     onCleanup(() => {
-      document.removeEventListener("dragover", onDocumentDragOver, false);
-      document.removeEventListener("drop", onDocumentDrop, false);
+      controller.abort();
     });
   });
 

--- a/packages/svelte/src/lib/component/UploadButton.svelte
+++ b/packages/svelte/src/lib/component/UploadButton.svelte
@@ -108,6 +108,7 @@
   })();
 
   onMount(() => {
+    const controller = new AbortController()
     const handlePaste = (event: ClipboardEvent) => {
       if (!appendOnPaste) return;
       // eslint-disable-next-line no-undef
@@ -123,10 +124,10 @@
       if (mode === "auto") uploadFiles(files);
     };
     // eslint-disable-next-line no-undef
-    document.addEventListener("paste", handlePaste);
+    document.addEventListener("paste", handlePaste, { signal: controller.signal });
 
     // eslint-disable-next-line no-undef
-    return () => document.removeEventListener("paste", handlePaste);
+    return () => controller.abort();
   });
 
   $: styleFieldArg = {

--- a/packages/svelte/src/lib/component/UploadDropzone.svelte
+++ b/packages/svelte/src/lib/component/UploadDropzone.svelte
@@ -158,6 +158,7 @@
   onMount(() => {
     if (!appendOnPaste) return;
 
+    const controller = new AbortController()
     const handlePaste = (event: ClipboardEvent) => {
       // eslint-disable-next-line no-undef
       if (document.activeElement !== rootRef) return;
@@ -172,10 +173,12 @@
       if (mode === "auto") uploadFiles(files);
     };
     // eslint-disable-next-line no-undef
-    document.addEventListener("paste", handlePaste);
+    document.addEventListener("paste", handlePaste, {
+      signal: controller.signal
+    });
 
     // eslint-disable-next-line no-undef
-    return () => document.removeEventListener("paste", handlePaste);
+    return () => controller.abort();
   });
 
   $: styleFieldArg = {

--- a/packages/vue/src/components/dropzone.tsx
+++ b/packages/vue/src/components/dropzone.tsx
@@ -434,6 +434,7 @@ export const generateUploadDropzone = <TRouter extends FileRouter>(
 export type DropEvent = InputEvent | DragEvent | Event;
 
 export function useDropzone(options: DropzoneOptions) {
+  const controller = new AbortController();
   const optionsRef = ref({
     disabled: false,
     maxSize: Number.POSITIVE_INFINITY,
@@ -487,14 +488,21 @@ export function useDropzone(options: DropzoneOptions) {
   };
 
   onMounted(() => {
-    window.addEventListener("focus", onWindowFocus, false);
-    document.addEventListener("dragover", onDocumentDragOver, false);
-    document.addEventListener("drop", onDocumentDrop, false);
+    window.addEventListener("focus", onWindowFocus, {
+      capture: false,
+      signal: controller.signal,
+    });
+    document.addEventListener("dragover", onDocumentDragOver, {
+      capture: false,
+      signal: controller.signal,
+    });
+    document.addEventListener("drop", onDocumentDrop, {
+      capture: false,
+      signal: controller.signal,
+    });
   });
   onUnmounted(() => {
-    window.removeEventListener("focus", onWindowFocus, false);
-    document.removeEventListener("dragover", onDocumentDragOver, false);
-    document.removeEventListener("drop", onDocumentDrop, false);
+    controller.abort();
   });
 
   const onDragenter = (event: DragEvent) => {

--- a/packages/vue/src/components/shared.tsx
+++ b/packages/vue/src/components/shared.tsx
@@ -4,11 +4,15 @@ import { onMounted, onUnmounted } from "vue";
 import type { ClassListMerger } from "@uploadthing/shared";
 
 export const usePaste = (callback: (e: ClipboardEvent) => void) => {
+  const controller = new AbortController();
+
   onMounted(() => {
-    document.addEventListener("paste", callback);
+    document.addEventListener("paste", callback, {
+      signal: controller.signal,
+    });
   });
   onUnmounted(() => {
-    document.removeEventListener("paste", callback);
+    controller.abort();
   });
 };
 


### PR DESCRIPTION
Following Theo's video about AbortController, this PR introduces it to manage events and abort them all together instead of using `removeEventListener`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved event listener management across multiple components using `AbortController`
	- Enhanced resource cleanup and prevention of potential memory leaks
	- Standardized event listener cancellation mechanism

- **Performance**
	- Optimized component lifecycle management
	- More robust handling of event listeners during component unmounting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->