### PR TITLE
feat: Update image picker params for expo

### DIFF
--- a/.changeset/quick-crabs-draw.md
+++ b/.changeset/quick-crabs-draw.md
@@ -1,0 +1,5 @@
+---
+"@uploadthing/expo": patch
+---
+
+Add quality params to openImagePicker

--- a/packages/expo/src/image-picker.ts
+++ b/packages/expo/src/image-picker.ts
@@ -54,6 +54,11 @@ export const GENERATE_useImageUploader = <
          */
         allowsEditing?: boolean;
         /**
+         * The quality of the image to pick
+         * @default 1
+         */
+        quality?: number;
+        /**
          * Open Library or Camera
          * @default "library"
          */
@@ -71,7 +76,7 @@ export const GENERATE_useImageUploader = <
         { input: inferEndpointInput<TRouter[TEndpoint]> }
       >,
     ) => {
-      const { source = "library", allowsEditing = false } = opts;
+      const { source = "library", allowsEditing = false, quality = 1 } = opts;
       let launchFn: typeof ImagePicker.launchImageLibraryAsync;
       let getPermissionFn: () => Promise<ImagePicker.PermissionResponse>;
       let requestPermissionFn: () => Promise<ImagePicker.PermissionResponse>;
@@ -98,6 +103,7 @@ export const GENERATE_useImageUploader = <
         mediaTypes: mediaTypes ?? ImagePicker.MediaTypeOptions.All,
         allowsEditing: multiple ? false : allowsEditing,
         allowsMultipleSelection: multiple,
+        quality,
       });
       if (response.canceled) return opts.onCancel?.();
 


### PR DESCRIPTION
This pull request introduces changes to the `packages/expo/src/image-picker.ts` file to add a new `quality` parameter to the `openImagePicker` function. Additionally, it includes a documentation update in the `.changeset/quick-crabs-draw.md` file to reflect this new feature.

### Changes to `openImagePicker` function:

* Added `quality` parameter to the options interface for the image picker, with a default value of 1. (`packages/expo/src/image-picker.ts`)
* Updated the function to include the `quality` parameter when destructuring options. (`packages/expo/src/image-picker.ts`)
* Passed the `quality` parameter to the `ImagePicker.launchImageLibraryAsync` function. (`packages/expo/src/image-picker.ts`)

### Documentation update:

* Added a changeset file to document the addition of quality parameters to the `openImagePicker` function. (`.changeset/quick-crabs-draw.md`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the image picker to allow users to select the desired quality of images during selection, providing more control over image resolution while maintaining a default quality setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->