### PR TITLE
chore: make initOpts optional

### DIFF
--- a/.changeset/eleven-boxes-fold.md
+++ b/.changeset/eleven-boxes-fold.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+chore: make `genUploader(initOpts)` optional to match docs

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -82,7 +82,7 @@ export const isValidFileSize = (
  * @public
  */
 export const genUploader = <TRouter extends FileRouter>(
-  initOpts: GenerateUploaderOptions,
+  initOpts?: GenerateUploaderOptions,
 ) => {
   const routeRegistry = createIdentityProxy<RouteRegistry<TRouter>>();
 
@@ -108,11 +108,11 @@ export const genUploader = <TRouter extends FileRouter>(
 
     const utReporter = createUTReporter({
       endpoint: String(endpoint),
-      package: initOpts.package,
-      url: resolveMaybeUrlArg(initOpts.url),
+      package: initOpts?.package ?? "uploadthing/client",
+      url: resolveMaybeUrlArg(initOpts?.url),
       headers: opts.headers,
     });
-    const fetchFn: FetchEsque = initOpts.fetch ?? window.fetch;
+    const fetchFn: FetchEsque = initOpts?.fetch ?? window.fetch;
 
     const presigneds = await Micro.runPromise(
       utReporter("upload", {
@@ -256,13 +256,13 @@ export const genUploader = <TRouter extends FileRouter>(
     >,
   ) => {
     const endpoint = typeof slug === "function" ? slug(routeRegistry) : slug;
-    const fetchFn: FetchEsque = initOpts.fetch ?? window.fetch;
+    const fetchFn: FetchEsque = initOpts?.fetch ?? window.fetch;
 
     return uploadFilesInternal<TRouter, TEndpoint>(endpoint, {
       ...opts,
       skipPolling: {} as never, // Remove in a future version, it's type right not is an ErrorMessage<T> to help migrations.
-      url: resolveMaybeUrlArg(initOpts.url),
-      package: initOpts.package,
+      url: resolveMaybeUrlArg(initOpts?.url),
+      package: initOpts?.package ?? "uploadthing/client",
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       input: (opts as any).input as inferEndpointInput<TRouter[TEndpoint]>,
     })

--- a/packages/uploadthing/src/types.ts
+++ b/packages/uploadthing/src/types.ts
@@ -232,7 +232,7 @@ export type GenerateUploaderOptions = {
    *
    * This is used to identify the client in the server logs
    */
-  package: string;
+  package?: string;
 };
 
 export type EndpointArg<


### PR DESCRIPTION
no reason for this to be required and the docs already suggests it's optional

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The uploader now accepts optional configuration, streamlining its setup for a more flexible experience.
	- Default settings are automatically applied when custom options are omitted.
  
- **Bug Fixes**
	- Improved handling of missing configurations prevents runtime errors during uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->