### PR TITLE
fix: typo

### DIFF
--- a/docs/src/app/(docs)/faq/page.mdx
+++ b/docs/src/app/(docs)/faq/page.mdx
@@ -38,7 +38,7 @@ Make sure that `/api/uploadthing` is NOT blocked through your middleware. It
 serves as both a validation endpoint for the client AND a webhook for the
 `onUploadComplete` calls.""
 
-If you are seeing this issue in development, and are using edge runtine, there
+If you are seeing this issue in development, and are using edge runtime, there
 is a limitation in Next.js where it does not allow an edge function to fetch
 itself, which is what the dev hook is doing (in production, the callback request
 comes from Uploadthing's servers, so this is not an issue).


### PR DESCRIPTION
Pardon my OCD.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected a typographical error in the docs, updating "edge runtine" to "edge runtime" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->