### PR TITLE
docs: remove typo in express docs page

### DIFF
--- a/docs/src/app/(docs)/backend-adapters/express/page.mdx
+++ b/docs/src/app/(docs)/backend-adapters/express/page.mdx
@@ -58,7 +58,7 @@ export const uploadRouter = {
   imageUploader: f({
     image: {
       /**
-       * For full list of options and defaults and defaults, see the File Route API reference
+       * For full list of options and defaults, see the File Route API reference
        * @see https://docs.uploadthing.com/file-routes#route-config
        */
       maxFileSize: "4MB",


### PR DESCRIPTION
Hey, just noticed this typo in the docs (and defaults is duplicated).

Also, loving uploadthing so far! Would be great if the docs for svelte would be updated to use Svelte 5 syntax😄 Only small changes would be needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the description text to enhance clarity by removing redundant wording in the file upload configuration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->