### PR TITLE
docs: update Tanstack Start guide

### DIFF
--- a/docs/src/app/(docs)/getting-started/tanstack-start/page.mdx
+++ b/docs/src/app/(docs)/getting-started/tanstack-start/page.mdx
@@ -209,7 +209,7 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import { UploadButton } from "../utils/uploadthing";
 
-export const Route = createFileRoute("/")({
+export const APIRoute = createFileRoute("/")({
   component: Home,
 });
 


### PR DESCRIPTION
Hello ! 

Looks like the documentation is not following the current version of tanstack start docs.

`Route` is not used anymore by the framework, it's `APIRoute`.

cc https://tanstack.com/start/latest/docs/framework/react/api-routes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated a routing identifier to improve naming consistency without impacting the application's behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->