### PR TITLE
fix: accept literals instead of labels

### DIFF
--- a/.changeset/fair-pets-leave.md
+++ b/.changeset/fair-pets-leave.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+fix: config validator for log level should match the type

--- a/packages/uploadthing/src/_internal/logger.ts
+++ b/packages/uploadthing/src/_internal/logger.ts
@@ -18,10 +18,10 @@ import { IsDevelopment } from "./config";
 /**
  * Config.logLevel counter-intuitively accepts LogLevel["label"]
  * instead of a literal, ripping it and changing to accept literal
+ * Effect 4.0 will change this to accept a literal and then we can
+ * remove this and go back to the built-in validator.
  */
-export const ConfigLogLevel = (
-  name?: string,
-): Config.Config<LogLevel.LogLevel> => {
+const ConfigLogLevel = (name?: string): Config.Config<LogLevel.LogLevel> => {
   const config = Config.mapOrFail(Config.string(), (literal) => {
     const level = LogLevel.allLevels.find((level) => level._tag === literal);
     return level === undefined


### PR DESCRIPTION
Closes #1163 


`Config.logLevel` accepts a label and not a literal, but have gotten a hint that this will change in Effect 4.0 so instead of changing our types to match the current behavior, I figured we'll just start accepting literals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue with logging configuration validation to ensure only valid log levels are accepted.

- **New Features**
  - Introduced enhanced error handling for logging settings, defaulting to a standard log level when provided values are invalid.
  - Added a new function for improved mapping of log levels to enhance clarity in configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->