### PR TITLE
docs: Use proper imports for seperate Dropzone and Button

### DIFF
--- a/docs/src/app/(docs)/getting-started/svelte/page.mdx
+++ b/docs/src/app/(docs)/getting-started/svelte/page.mdx
@@ -210,7 +210,7 @@ separately. Both are included in the `@uploadthing/svelte` package.
 <script lang="ts">
   import { createUploader } from "$lib/utils/uploadthing";
 
-  import { Uploader } from "@uploadthing/svelte";
+  import { UploadButton, UploadDropzone } from "@uploadthing/svelte";
 
   const uploader = createUploader("imageUploader", {
     onClientUploadComplete: (res) => {


### PR DESCRIPTION
Currently, the section in the Svelte docs that tells users about the separate Button and Dropzone components imports `Uploader` instead of `UploadButton` and `UploadDropzone`. This causes the example code to not work (see below). This PR fixes it by using the proper imports.

![image](https://github.com/user-attachments/assets/3ad914b9-afe8-4fe5-a8d6-e5fac0ba9f1f)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the file upload interface by replacing the single uploader with two distinct interactive components: one providing a button and the other a dropzone for file uploads.
  - Maintained robust upload functionality and consistent handling of upload events for a smooth user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->