### PR TITLE
docs(utapi): Update "key" -> "fileKey" for renameFiles

### DIFF
--- a/docs/src/app/(docs)/api-reference/ut-api/page.mdx
+++ b/docs/src/app/(docs)/api-reference/ut-api/page.mdx
@@ -395,7 +395,7 @@ id.
 import { utapi } from "~/server/uploadthing.ts";
 
 await utapi.renameFiles({
-  key: "2e0fdb64-9957-4262-8e45-f372ba903ac8_image.jpg",
+  fileKey: "2e0fdb64-9957-4262-8e45-f372ba903ac8_image.jpg",
   newName: "myImage.jpg",
 });
 await utapi.renameFiles({
@@ -405,11 +405,11 @@ await utapi.renameFiles({
 
 await utapi.renameFiles([
   {
-    key: "2e0fdb64-9957-4262-8e45-f372ba903ac8_image.jpg",
+    fileKey: "2e0fdb64-9957-4262-8e45-f372ba903ac8_image.jpg",
     newName: "myImage.jpg",
   },
   {
-    key: "1649353b-04ea-48a2-9db7-31de7f562c8d_image2.jpg",
+    fileKey: "1649353b-04ea-48a2-9db7-31de7f562c8d_image2.jpg",
     newName: "myOtherImage.jpg",
   },
 ]);


### PR DESCRIPTION
Stumbled into the following error below while trying some of the extra challenges on [Theo's drive clone tutorial](https://youtu.be/c-hKSbzooAg?si=CQX4R4lK9EnSgDRP) (awesome vid btw).

![image](https://github.com/user-attachments/assets/aa4b5e60-3660-4c25-bd2d-d93ac5b0698f)

[Current docs](https://docs.uploadthing.com/api-reference/ut-api#rename-files) mention examples that look like the following
```
await utapi.renameFiles({
  key: "2e0fdb64-9957-4262-8e45-f372ba903ac8_image.jpg",
  newName: "myImage.jpg",
});
```

This is an issue because
* `renameFiles` takes a `RenameFileUpdate` or a `RenameFileUpdate[]`
https://github.com/pingdotgg/uploadthing/blob/d06824652fef79ac5bed32cbf5d1124093785b65/packages/uploadthing/src/sdk/index.ts#L349

* `RenameFileUpdate` is a `KeyRename` or a `CustomIdRename`
https://github.com/pingdotgg/uploadthing/blob/d06824652fef79ac5bed32cbf5d1124093785b65/packages/uploadthing/src/sdk/types.ts#L102

* `KeyRename` takes a `fileKey`, not a `key`!
https://github.com/pingdotgg/uploadthing/blob/d06824652fef79ac5bed32cbf5d1124093785b65/packages/uploadthing/src/sdk/types.ts#L100

This PR updates docs to use `fileKey` instead of `key`. This is the only method that currently uses `RenameFileUpdate` so small set of changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated file renaming examples in the documentation to use a standardized parameter name for both individual and batch operations, enhancing consistency and clarity for developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->