### PR TITLE
feat: onFileUploadComplete

### DIFF
--- a/packages/react/src/components/button.tsx
+++ b/packages/react/src/components/button.tsx
@@ -3,6 +3,11 @@
 import type { CSSProperties } from "react";
 import { useCallback, useMemo, useRef, useState } from "react";
 
+import type {
+  ContentField,
+  ErrorMessage,
+  StyleField,
+} from "@uploadthing/shared";
 import {
   allowedContentTextLabelGenerator,
   contentFieldToContent,
@@ -14,11 +19,6 @@ import {
   styleFieldToClassName,
   styleFieldToCssObject,
   UploadAbortedError,
-} from "@uploadthing/shared";
-import type {
-  ContentField,
-  ErrorMessage,
-  StyleField,
 } from "@uploadthing/shared";
 import type { FileRouter } from "uploadthing/types";
 
@@ -116,6 +116,9 @@ export function UploadButton<
     {
       signal: acRef.current.signal,
       headers: $props.headers,
+      onFileUploadComplete: (uploadResponse, index, total) => {
+        $props?.onFileUploadComplete?.(uploadResponse, index, total);
+      },
       onClientUploadComplete: (res) => {
         if (fileInputRef.current) {
           fileInputRef.current.value = "";

--- a/packages/react/src/components/button.tsx
+++ b/packages/react/src/components/button.tsx
@@ -116,9 +116,7 @@ export function UploadButton<
     {
       signal: acRef.current.signal,
       headers: $props.headers,
-      onFileUploadComplete: (uploadResponse, index, total) => {
-        $props?.onFileUploadComplete?.(uploadResponse, index, total);
-      },
+      onFileUploadComplete: $props.onFileUploadComplete,
       onClientUploadComplete: (res) => {
         if (fileInputRef.current) {
           fileInputRef.current.value = "";

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -54,6 +54,14 @@ export type UseUploadthingProps<
   TServerOutput = inferEndpointOutput<TFileRoute>,
 > = {
   /**
+   * Called when a file upload is completed
+   */
+  onFileUploadComplete?: (
+    uploadResponse: any,
+    index: number,
+    total: number,
+  ) => void;
+  /**
    * Called when the upload is submitted and the server is about to be queried for presigned URLs
    * Can be used to modify the files before they are uploaded, e.g. renaming them
    */

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -56,11 +56,22 @@ export type UseUploadthingProps<
   /**
    * Called when a file upload is completed
    */
-  onFileUploadComplete?: (
-    uploadResponse: any,
-    index: number,
-    total: number,
-  ) => void;
+  onFileUploadComplete?:
+    | ((_: {
+        /**
+         * The response from the upload
+         */
+        fileData: ClientUploadedFileData<TServerOutput>;
+        /**
+         * The file object that was uploaded
+         */
+        file: File;
+        /**
+         * All the files that are in this upload
+         */
+        files: File[];
+      }) => void)
+    | undefined;
   /**
    * Called when the upload is submitted and the server is about to be queried for presigned URLs
    * Can be used to modify the files before they are uploaded, e.g. renaming them

--- a/packages/react/src/use-uploadthing.ts
+++ b/packages/react/src/use-uploadthing.ts
@@ -91,6 +91,7 @@ function useUploadThingInternal<
         signal: opts?.signal,
         headers: opts?.headers,
         files,
+        onFileUploadComplete: opts?.onFileUploadComplete,
         onUploadProgress: (progress) => {
           if (!opts?.onUploadProgress) return;
           fileProgress.current.set(progress.file, progress.progress);

--- a/packages/uploadthing/src/_internal/upload-browser.ts
+++ b/packages/uploadthing/src/_internal/upload-browser.ts
@@ -108,6 +108,9 @@ export const uploadFile = <
   file: File,
   presigned: NewPresignedUrl,
   opts: {
+    onFileUploadComplete?: (
+      uploadResponse: UploadPutResult<TServerOutput>,
+    ) => void;
     onUploadProgress?: (progressEvent: {
       loaded: number;
       delta: number;
@@ -133,6 +136,7 @@ export const uploadFile = <
       ),
     ),
     Micro.map(unsafeCoerce<unknown, UploadPutResult<TServerOutput>>),
+    Micro.tap((uploadResponse) => opts.onFileUploadComplete?.(uploadResponse)),
     Micro.map((uploadResponse) => ({
       name: file.name,
       size: file.size,
@@ -204,6 +208,14 @@ export const uploadFilesInternal = <
                 opts.files[i]!,
                 presigned,
                 {
+                  onFileUploadComplete: (uploadResponse) => {
+                    // @ts-expect-error temp
+                    opts.onFileUploadComplete?.(
+                      uploadResponse,
+                      i,
+                      opts.files.length,
+                    );
+                  },
                   onUploadProgress: (ev) => {
                     totalLoaded += ev.delta;
                     opts.onUploadProgress?.({

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -253,13 +253,7 @@ export const genUploader = <TRouter extends FileRouter>(
     opts: Omit<
       UploadFilesOptions<TRouter[TEndpoint]>,
       keyof GenerateUploaderOptions
-    > & {
-      onFileUploadComplete?: (
-        uploadResponse: any,
-        index: number,
-        total: number,
-      ) => void;
-    },
+    >,
   ) => {
     const endpoint = typeof slug === "function" ? slug(routeRegistry) : slug;
     const fetchFn: FetchEsque = initOpts?.fetch ?? window.fetch;

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -253,7 +253,13 @@ export const genUploader = <TRouter extends FileRouter>(
     opts: Omit<
       UploadFilesOptions<TRouter[TEndpoint]>,
       keyof GenerateUploaderOptions
-    >,
+    > & {
+      onFileUploadComplete?: (
+        uploadResponse: any,
+        index: number,
+        total: number,
+      ) => void;
+    },
   ) => {
     const endpoint = typeof slug === "function" ? slug(routeRegistry) : slug;
     const fetchFn: FetchEsque = initOpts?.fetch ?? window.fetch;

--- a/packages/uploadthing/src/types.ts
+++ b/packages/uploadthing/src/types.ts
@@ -9,6 +9,7 @@ import type {
 
 import type { LogFormat } from "./_internal/logger";
 import type { AnyFileRoute, FileRoute } from "./_internal/types";
+import type { ClientUploadedFileData } from "./types";
 
 export * from "./sdk/types";
 
@@ -122,6 +123,25 @@ export type UploadFilesOptions<TFileRoute extends AnyFileRoute> = {
         totalLoaded: number;
         /** Percentage of the total loaded bytes for the upload */
         totalProgress: number;
+      }) => void)
+    | undefined;
+  /**
+   * Called when a file upload is completed
+   */
+  onFileUploadComplete?:
+    | ((_: {
+        /**
+         * The response from the upload
+         */
+        fileData: ClientUploadedFileData<inferEndpointOutput<TFileRoute>>;
+        /**
+         * The file object that was uploaded
+         */
+        file: File;
+        /**
+         * All the files that are in this upload
+         */
+        files: File[];
       }) => void)
     | undefined;
   /**


### PR DESCRIPTION
I was speaking with Mark about if the upload progress is available on React Native. He mentioned implementation issues with XHR referencing https://github.com/expo/expo/issues/28269. 

I asked if there was a callback or hook when a file is uploaded vs all files uploaded. Having this would allow us to "fake" upload progress by saying "Uploading file 1 out of 5", etc. 

This PR starts the initial callback functionality for React. It's working on my local pnpm link setup as expected. The types are iffy since I'm unsure how all the types work in the uploadthing repo, so I'd love some help with that. I'm open to changing anything that fits the general public vs just my usecase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a callback option to handle file upload completion events, allowing developers to easily execute custom logic when an upload finishes.
  - Enhanced the upload process by seamlessly integrating this callback for improved user feedback and control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->