### PR TITLE
feat: add concurrency option to `UTApi.uploadFiles`

### DIFF
--- a/.changeset/neat-melons-protect.md
+++ b/.changeset/neat-melons-protect.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+add concurrency option to `UTApi.uploadFiles`

--- a/docs/src/app/(docs)/api-reference/ut-api/page.mdx
+++ b/docs/src/app/(docs)/api-reference/ut-api/page.mdx
@@ -175,6 +175,9 @@ uploaded to the storage provider.
     settings](/concepts/regions-acl#access-controls) and can only be used if the
     app allows per-request overrides.
   </Property>
+  <Property name="concurrency" type="number" since="7.6.1" defaultValue="1">
+    The number of files to upload concurrently. Must be a positive integer between 1 and 25.
+  </Property>
 </Properties>
 
 ### Returns
@@ -259,6 +262,9 @@ set a `customId` for the files. The function also takes some optional options:
     storage provider. Default value is is [configured on your app
     settings](/concepts/regions-acl#access-controls) and can only be used if the
     app allows per-request overrides.
+  </Property>
+  <Property name="concurrency" type="number" since="7.6.1" defaultValue="1">
+    The number of files to upload concurrently. Must be a positive integer between 1 and 25.
   </Property>
 </Properties>
 

--- a/packages/uploadthing/src/sdk/types.ts
+++ b/packages/uploadthing/src/sdk/types.ts
@@ -72,6 +72,11 @@ export interface UploadFilesOptions {
    * AbortSignal that can be used to cancel the upload
    */
   signal?: AbortSignal;
+  /**
+   * The number of files to upload concurrently. Must be a positive integer between 1 and 25.
+   * @default 1
+   */
+  concurrency?: number;
 }
 export type UploadFileResult = Either<
   UploadedFileData,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional concurrency setting to file upload methods, allowing users to control how many files are uploaded at the same time (between 1 and 25).
- **Documentation**
  - Updated API documentation to describe the new concurrency option and its usage in file upload methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->