### PR TITLE
chore: initiate traceIds from client

### DIFF
--- a/packages/uploadthing/src/_internal/client-future.ts
+++ b/packages/uploadthing/src/_internal/client-future.ts
@@ -16,6 +16,7 @@ import type {
   FileRouter as AnyFileRouter,
   NewPresignedUrl,
 } from "../types";
+import { generateTraceHeaders } from "./random-hex";
 import type { UploadPutResult } from "./types";
 import { createUTReporter } from "./ut-reporter";
 
@@ -538,11 +539,13 @@ export function requestPresignedUrls<
   UTServerError<TRouter[TEndpoint]["$types"]["errorShape"]>,
   FetchContext
 > {
+  const traceHeaders = generateTraceHeaders();
   const reportEventToUT = createUTReporter({
     endpoint: String(options.endpoint),
     package: options.package,
     url: options.url,
     headers: options.headers,
+    traceHeaders,
   });
 
   return reportEventToUT("upload", {

--- a/packages/uploadthing/src/_internal/random-hex.ts
+++ b/packages/uploadthing/src/_internal/random-hex.ts
@@ -1,0 +1,22 @@
+export const randomHexString = (function () {
+  const characters = "abcdef0123456789";
+  const charactersLength = characters.length;
+  return function (length: number) {
+    let result = "";
+    for (let i = 0; i < length; i++) {
+      result += characters.charAt(Math.floor(Math.random() * charactersLength));
+    }
+    return result;
+  };
+})();
+
+export const generateTraceHeaders = () => {
+  const traceId = randomHexString(32);
+  const spanId = randomHexString(16);
+  const sampled = "01";
+
+  return {
+    b3: `${traceId}-${spanId}-${sampled}`,
+    traceparent: `00-${traceId}-${spanId}-${sampled}`,
+  };
+};

--- a/packages/uploadthing/src/_internal/random-hex.ts
+++ b/packages/uploadthing/src/_internal/random-hex.ts
@@ -10,7 +10,12 @@ export const randomHexString = (function () {
   };
 })();
 
-export const generateTraceHeaders = () => {
+export type TraceHeaders = {
+  b3: string;
+  traceparent: string;
+};
+
+export const generateTraceHeaders = (): TraceHeaders => {
   const traceId = randomHexString(32);
   const spanId = randomHexString(16);
   const sampled = "01";

--- a/packages/uploadthing/src/_internal/upload-browser.ts
+++ b/packages/uploadthing/src/_internal/upload-browser.ts
@@ -189,7 +189,8 @@ export const uploadFilesInternal = <
     endpoint: String(endpoint),
     package: opts.package,
     url: opts.url,
-    headers: { ...opts.headers, ...traceHeaders },
+    headers: opts.headers,
+    traceHeaders,
   });
 
   const totalSize = opts.files.reduce((acc, f) => acc + f.size, 0);

--- a/packages/uploadthing/src/_internal/ut-reporter.ts
+++ b/packages/uploadthing/src/_internal/ut-reporter.ts
@@ -10,6 +10,7 @@ import {
 } from "@uploadthing/shared";
 
 import * as pkgJson from "../../package.json";
+import type { TraceHeaders } from "./random-hex";
 import type { ActionType } from "./shared-schemas";
 import type { UTEvents } from "./types";
 
@@ -48,7 +49,7 @@ export const createUTReporter =
     endpoint: string;
     package?: string | undefined;
     headers: HeadersInit | (() => MaybePromise<HeadersInit>) | undefined;
-    traceHeaders: { b3: string; traceparent: string };
+    traceHeaders: TraceHeaders;
   }): UTReporter =>
   (type, payload) =>
     Micro.gen(function* () {

--- a/packages/uploadthing/src/_internal/ut-reporter.ts
+++ b/packages/uploadthing/src/_internal/ut-reporter.ts
@@ -48,6 +48,7 @@ export const createUTReporter =
     endpoint: string;
     package?: string | undefined;
     headers: HeadersInit | (() => MaybePromise<HeadersInit>) | undefined;
+    traceHeaders: { b3: string; traceparent: string };
   }): UTReporter =>
   (type, payload) =>
     Micro.gen(function* () {
@@ -66,6 +67,8 @@ export const createUTReporter =
       }
       headers.set("x-uploadthing-version", pkgJson.version);
       headers.set("Content-Type", "application/json");
+      headers.set("b3", cfg.traceHeaders.b3);
+      headers.set("traceparent", cfg.traceHeaders.traceparent);
 
       const response = yield* fetchEff(url, {
         method: "POST",

--- a/packages/uploadthing/src/client-future.ts
+++ b/packages/uploadthing/src/client-future.ts
@@ -27,6 +27,7 @@ import {
 } from "./_internal/client-future";
 import type { Deferred } from "./_internal/deferred";
 import { createDeferred } from "./_internal/deferred";
+import { generateTraceHeaders } from "./_internal/random-hex";
 import type {
   EndpointArg,
   FileRouter,
@@ -73,6 +74,7 @@ export const future_genUploader = <TRouter extends FileRouter>(
     const endpoint = typeof slug === "function" ? slug(routeRegistry) : slug;
     const fetchFn: FetchEsque = initOpts?.fetch ?? window.fetch;
 
+    const traceHeaders = generateTraceHeaders();
     const pExit = await requestPresignedUrls({
       endpoint: String(endpoint),
       files: options.files,
@@ -80,6 +82,7 @@ export const future_genUploader = <TRouter extends FileRouter>(
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       input: (options as any).input as inferEndpointInput<TRouter[TEndpoint]>,
       headers: options.headers,
+      traceHeaders,
     }).pipe(Micro.provideService(FetchContext, fetchFn), (effect) =>
       Micro.runPromiseExit(
         effect,
@@ -109,6 +112,7 @@ export const future_genUploader = <TRouter extends FileRouter>(
         files: pendingFiles,
         input: options.input,
         onEvent: options.onEvent,
+        traceHeaders,
         XHRImpl: globalThis.XMLHttpRequest,
       }).pipe(Micro.provideService(FetchContext, fetchFn));
 

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -16,6 +16,7 @@ import {
 import * as pkgJson from "../package.json";
 import type { Deferred } from "./_internal/deferred";
 import { createDeferred } from "./_internal/deferred";
+import { generateTraceHeaders } from "./_internal/random-hex";
 import { uploadFile, uploadFilesInternal } from "./_internal/upload-browser";
 import { createUTReporter } from "./_internal/ut-reporter";
 import type {
@@ -110,11 +111,12 @@ export const genUploader = <TRouter extends FileRouter>(
 
     const endpoint = typeof slug === "function" ? slug(routeRegistry) : slug;
 
+    const traceHeaders = generateTraceHeaders();
     const utReporter = createUTReporter({
       endpoint: String(endpoint),
       package: initOpts?.package ?? "uploadthing/client",
       url: resolveMaybeUrlArg(initOpts?.url),
-      headers: opts.headers,
+      headers: { ...traceHeaders, ...opts.headers },
     });
     const fetchFn: FetchEsque = initOpts?.fetch ?? window.fetch;
 
@@ -136,6 +138,7 @@ export const genUploader = <TRouter extends FileRouter>(
 
     const uploadEffect = (file: File, presigned: NewPresignedUrl) =>
       uploadFile(file, presigned, {
+        traceHeaders,
         onUploadProgress: (progressEvent) => {
           totalLoaded += progressEvent.delta;
           opts.onUploadProgress?.({

--- a/packages/uploadthing/src/client.ts
+++ b/packages/uploadthing/src/client.ts
@@ -116,7 +116,8 @@ export const genUploader = <TRouter extends FileRouter>(
       endpoint: String(endpoint),
       package: initOpts?.package ?? "uploadthing/client",
       url: resolveMaybeUrlArg(initOpts?.url),
-      headers: { ...traceHeaders, ...opts.headers },
+      headers: opts.headers,
+      traceHeaders,
     });
     const fetchFn: FetchEsque = initOpts?.fetch ?? window.fetch;
 

--- a/packages/uploadthing/test/browser/client.test.ts
+++ b/packages/uploadthing/test/browser/client.test.ts
@@ -234,6 +234,8 @@ describe("uploadFiles", () => {
       Object.fromEntries(middlewareMock.mock.calls[0]![0]!.req.headers),
     ).toMatchObject({
       authorization: "Bearer my-auth-token",
+      b3: expect.any(String),
+      traceparent: expect.any(String),
       "x-uploadthing-package": "vitest",
       "x-uploadthing-version": expect.stringMatching(/\d+\.\d+\.\d+/),
     });


### PR DESCRIPTION
we don't send any spans from client code but the h3 header just allows to see correlation in logs for the upload and register requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for generating and including trace headers in all upload requests, enhancing traceability across distributed systems.

- **Refactor**
  - Updated upload functions to consistently propagate trace headers throughout the upload process, ensuring they are included in both reporting and file upload requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->