### PR TITLE
feat: add configuration option to use appId in path instead of subdomain

### DIFF
--- a/.changeset/cold-apples-lay.md
+++ b/.changeset/cold-apples-lay.md
@@ -2,4 +2,4 @@
 "uploadthing": patch
 ---
 
-Let the user decide if they want the appID as a subdomain on UTFS URL for self-hosted versions
+Let the user decide if they want the appID as a subdomain or path on UTFS URL for self-hosted versions

--- a/.changeset/cold-apples-lay.md
+++ b/.changeset/cold-apples-lay.md
@@ -2,4 +2,4 @@
 "uploadthing": patch
 ---
 
-Let the decide to they want the appID as a subdomain on Utfs url
+Let the decide to they want the appID as a subdomain on Utfs url for self hosted versions

--- a/.changeset/cold-apples-lay.md
+++ b/.changeset/cold-apples-lay.md
@@ -1,0 +1,5 @@
+---
+"uploadthing": patch
+---
+
+Let the decide to they want the appID as a subdomain on Utfs url

--- a/.changeset/cold-apples-lay.md
+++ b/.changeset/cold-apples-lay.md
@@ -2,4 +2,4 @@
 "uploadthing": patch
 ---
 
-Let the decide to they want the appID as a subdomain on Utfs url for self hosted versions
+Let the user decide if they want the appID as a subdomain on UTFS URL for self-hosted versions

--- a/docs/src/app/(docs)/v7/page.mdx
+++ b/docs/src/app/(docs)/v7/page.mdx
@@ -18,7 +18,8 @@ with a nearly full rewrite of the internals.
 - Resumable uploads are now supported
 - We've re-architected the backend to require less round-trips to the
   UploadThing server, take advantage of modern web advancements, and removed all
-  polling logic. All of these changes results in a much faster upload experience.
+  polling logic. All of these changes results in a much faster upload
+  experience.
 - We've begun work on a self-hosted version of UploadThing (more info coming
   soon)
 

--- a/packages/uploadthing/src/_internal/config.ts
+++ b/packages/uploadthing/src/_internal/config.ts
@@ -107,7 +107,6 @@ export const UfsHost = Config.string("ufsHost").pipe(
 );
 
 export const UrlAppIdLocation = Config.literal(
-  "urlAppIdLocation",
   "subdomain",
   "path",
-)().pipe(Config.withDefault("subdomain"));
+)("appIdLocation").pipe(Config.withDefault("subdomain"));

--- a/packages/uploadthing/src/_internal/config.ts
+++ b/packages/uploadthing/src/_internal/config.ts
@@ -105,6 +105,14 @@ export const UtfsHost = Config.string("utfsHost").pipe(
 export const UfsHost = Config.string("ufsHost").pipe(
   Config.withDefault("ufs.sh"),
 );
-export const DoAppIDInUrls = Config.boolean("doAppIDInURLS").pipe(
-  Config.withDefault(true),
-);
+export const UrlAppIdLocation = Config.string("urlAppIdLocation")
+  .pipe(
+    Config.withDefault("subdomain"),
+    Config.mapAttempt((loc) => {
+      if (loc === "subdomain" || loc === "path") return loc;
+      throw new Error(
+        `Invalid UPLOADTHING_URL_APPID_LOCATION: "${loc}". ` +
+        `Must be "subdomain" or "path".`
+      );
+    })
+  );

--- a/packages/uploadthing/src/_internal/config.ts
+++ b/packages/uploadthing/src/_internal/config.ts
@@ -105,3 +105,4 @@ export const UtfsHost = Config.string("utfsHost").pipe(
 export const UfsHost = Config.string("ufsHost").pipe(
   Config.withDefault("ufs.sh"),
 );
+export const DoAppIDInUrls = Config.boolean("doAppIDInURLS").pipe(Config.withDefault(true));

--- a/packages/uploadthing/src/_internal/config.ts
+++ b/packages/uploadthing/src/_internal/config.ts
@@ -105,7 +105,8 @@ export const UtfsHost = Config.string("utfsHost").pipe(
 export const UfsHost = Config.string("ufsHost").pipe(
   Config.withDefault("ufs.sh"),
 );
-export const UrlAppIdLocation = Config.literal("subdomain", "path")
-  .pipe(
-    Config.withDefault("subdomain")
-  );
+export const UrlAppIdLocation = Config.literal(
+  "urlAppIdLocation",
+  "subdomain",
+  "path",
+)().pipe(Config.withDefault("subdomain"));

--- a/packages/uploadthing/src/_internal/config.ts
+++ b/packages/uploadthing/src/_internal/config.ts
@@ -105,4 +105,6 @@ export const UtfsHost = Config.string("utfsHost").pipe(
 export const UfsHost = Config.string("ufsHost").pipe(
   Config.withDefault("ufs.sh"),
 );
-export const DoAppIDInUrls = Config.boolean("doAppIDInURLS").pipe(Config.withDefault(true));
+export const DoAppIDInUrls = Config.boolean("doAppIDInURLS").pipe(
+  Config.withDefault(true),
+);

--- a/packages/uploadthing/src/_internal/config.ts
+++ b/packages/uploadthing/src/_internal/config.ts
@@ -105,13 +105,7 @@ export const UtfsHost = Config.string("utfsHost").pipe(
 export const UfsHost = Config.string("ufsHost").pipe(
   Config.withDefault("ufs.sh"),
 );
-export const UrlAppIdLocation = Config.string("urlAppIdLocation").pipe(
-  Config.withDefault("subdomain"),
-  Config.mapAttempt((loc) => {
-    if (loc === "subdomain" || loc === "path") return loc;
-    throw new Error(
-      `Invalid UPLOADTHING_URL_APPID_LOCATION: "${loc}". ` +
-        `Must be "subdomain" or "path".`,
-    );
-  }),
-);
+export const UrlAppIdLocation = Config.literal("subdomain", "path")
+  .pipe(
+    Config.withDefault("subdomain")
+  );

--- a/packages/uploadthing/src/_internal/config.ts
+++ b/packages/uploadthing/src/_internal/config.ts
@@ -105,6 +105,7 @@ export const UtfsHost = Config.string("utfsHost").pipe(
 export const UfsHost = Config.string("ufsHost").pipe(
   Config.withDefault("ufs.sh"),
 );
+
 export const UrlAppIdLocation = Config.literal(
   "urlAppIdLocation",
   "subdomain",

--- a/packages/uploadthing/src/_internal/config.ts
+++ b/packages/uploadthing/src/_internal/config.ts
@@ -105,14 +105,13 @@ export const UtfsHost = Config.string("utfsHost").pipe(
 export const UfsHost = Config.string("ufsHost").pipe(
   Config.withDefault("ufs.sh"),
 );
-export const UrlAppIdLocation = Config.string("urlAppIdLocation")
-  .pipe(
-    Config.withDefault("subdomain"),
-    Config.mapAttempt((loc) => {
-      if (loc === "subdomain" || loc === "path") return loc;
-      throw new Error(
-        `Invalid UPLOADTHING_URL_APPID_LOCATION: "${loc}". ` +
-        `Must be "subdomain" or "path".`
-      );
-    })
-  );
+export const UrlAppIdLocation = Config.string("urlAppIdLocation").pipe(
+  Config.withDefault("subdomain"),
+  Config.mapAttempt((loc) => {
+    if (loc === "subdomain" || loc === "path") return loc;
+    throw new Error(
+      `Invalid UPLOADTHING_URL_APPID_LOCATION: "${loc}". ` +
+        `Must be "subdomain" or "path".`,
+    );
+  }),
+);

--- a/packages/uploadthing/src/_internal/config.ts
+++ b/packages/uploadthing/src/_internal/config.ts
@@ -106,7 +106,7 @@ export const UfsHost = Config.string("ufsHost").pipe(
   Config.withDefault("ufs.sh"),
 );
 
-export const UrlAppIdLocation = Config.literal(
+export const UfsAppIdLocation = Config.literal(
   "subdomain",
   "path",
-)("appIdLocation").pipe(Config.withDefault("subdomain"));
+)("ufsAppIdLocation").pipe(Config.withDefault("subdomain"));

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -20,9 +20,9 @@ import {
 
 import {
   ApiUrl,
-   UrlAppIdLocation,
   UfsHost,
   UPLOADTHING_VERSION,
+  UrlAppIdLocation,
   UTToken,
 } from "../_internal/config";
 import { logHttpClientError, logHttpClientResponse } from "../_internal/logger";

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -20,7 +20,7 @@ import {
 
 import {
   ApiUrl,
-  DoAppIDInUrls,
+   UrlAppIdLocation,
   UfsHost,
   UPLOADTHING_VERSION,
   UTToken,
@@ -435,12 +435,14 @@ export class UTApi {
 
     const program = Effect.gen(function* () {
       const { apiKey, appId } = yield* UTToken;
+      const location = yield* UrlAppIdLocation;
       const ufsHost = yield* UfsHost;
-      const doAppID = Boolean(yield* DoAppIDInUrls);
       const proto = ufsHost.includes("local") ? "http" : "https";
-      const urlBase = doAppID
-        ? `${proto}://${appId}.${ufsHost}/f/${key}`
-        : `${proto}://${ufsHost}/f/${key}`;
+      // build either subdomain or path style
+      const urlBase =
+        location === "subdomain"
+          ? `${proto}://${appId}.${ufsHost}/f/${key}`
+          : `${proto}://${ufsHost}/f/${appId}/${key}`;
       const ufsUrl = yield* generateSignedURL(urlBase, apiKey, {
         ttlInSeconds: expiresIn,
       });

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -442,7 +442,7 @@ export class UTApi {
       const urlBase =
         location === "subdomain"
           ? `${proto}://${appId}.${ufsHost}/f/${key}`
-          : `${proto}://${ufsHost}/f/${appId}/${key}`;
+          : `${proto}://${ufsHost}/a/${appId}/${key}`;
       const ufsUrl = yield* generateSignedURL(urlBase, apiKey, {
         ttlInSeconds: expiresIn,
       });

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -438,7 +438,7 @@ export class UTApi {
       const location = yield* UrlAppIdLocation;
       const ufsHost = yield* UfsHost;
       const proto = ufsHost.includes("local") ? "http" : "https";
-      // build either subdomain or path style
+      // either subdomain or path style
       const urlBase =
         location === "subdomain"
           ? `${proto}://${appId}.${ufsHost}/f/${key}`

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -21,10 +21,10 @@ import {
 
 import {
   ApiUrl,
+  DoAppIDInUrls,
   UfsHost,
   UPLOADTHING_VERSION,
   UTToken,
-  DoAppIDInUrls,
 } from "../_internal/config";
 import { logHttpClientError, logHttpClientResponse } from "../_internal/logger";
 import { makeRuntime } from "../_internal/runtime";
@@ -442,13 +442,9 @@ export class UTApi {
       const urlBase = doAppID
         ? `${proto}://${appId}.${ufsHost}/f/${key}`
         : `${proto}://${ufsHost}/f/${key}`;
-      const ufsUrl = yield* generateSignedURL(
-        urlBase,
-        apiKey,
-        {
-          ttlInSeconds: expiresIn,
-        },
-      );
+      const ufsUrl = yield* generateSignedURL(urlBase, apiKey, {
+        ttlInSeconds: expiresIn,
+      });
 
       return {
         ufsUrl,

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -24,6 +24,7 @@ import {
   UfsHost,
   UPLOADTHING_VERSION,
   UTToken,
+  DoAppIDInUrls,
 } from "../_internal/config";
 import { logHttpClientError, logHttpClientResponse } from "../_internal/logger";
 import { makeRuntime } from "../_internal/runtime";
@@ -436,10 +437,13 @@ export class UTApi {
     const program = Effect.gen(function* () {
       const { apiKey, appId } = yield* UTToken;
       const ufsHost = yield* UfsHost;
-
+      const doAppID = Boolean(yield* DoAppIDInUrls);
       const proto = ufsHost.includes("local") ? "http" : "https";
+      const urlBase = doAppID
+        ? `${proto}://${appId}.${ufsHost}/f/${key}`
+        : `${proto}://${ufsHost}/f/${key}`;
       const ufsUrl = yield* generateSignedURL(
-        `${proto}://${appId}.${ufsHost}/f/${key}`,
+        urlBase,
         apiKey,
         {
           ttlInSeconds: expiresIn,

--- a/packages/uploadthing/src/sdk/index.ts
+++ b/packages/uploadthing/src/sdk/index.ts
@@ -20,9 +20,9 @@ import {
 
 import {
   ApiUrl,
+  UfsAppIdLocation,
   UfsHost,
   UPLOADTHING_VERSION,
-  UrlAppIdLocation,
   UTToken,
 } from "../_internal/config";
 import { logHttpClientError, logHttpClientResponse } from "../_internal/logger";
@@ -435,7 +435,7 @@ export class UTApi {
 
     const program = Effect.gen(function* () {
       const { apiKey, appId } = yield* UTToken;
-      const appIdLocation = yield* UrlAppIdLocation;
+      const appIdLocation = yield* UfsAppIdLocation;
       const ufsHost = yield* UfsHost;
 
       const proto = ufsHost.includes("local") ? "http" : "https";

--- a/packages/uploadthing/src/sdk/types.ts
+++ b/packages/uploadthing/src/sdk/types.ts
@@ -50,6 +50,16 @@ export interface UTApiOptions {
    * URL override for the ingest server
    */
   ingestUrl?: string;
+  /**
+   * Hostname override for the CDN hosting the files
+   * @default "ufs.sh"
+   */
+  ufsHost?: string;
+  /**
+   * Where to put the appId in the URL.
+   * @default "subdomain"
+   */
+  appIdLocation?: "subdomain" | "path";
 }
 
 export type UrlWithOverrides = {

--- a/packages/uploadthing/src/sdk/types.ts
+++ b/packages/uploadthing/src/sdk/types.ts
@@ -59,7 +59,7 @@ export interface UTApiOptions {
    * Where to put the appId in the URL.
    * @default "subdomain"
    */
-  appIdLocation?: "subdomain" | "path";
+  ufsAppIdLocation?: "subdomain" | "path";
 }
 
 export type UrlWithOverrides = {

--- a/packages/uploadthing/test/node/sdk.test.ts
+++ b/packages/uploadthing/test/node/sdk.test.ts
@@ -411,7 +411,7 @@ describe("generateSignedURL", () => {
   it("puts appId in path if appIdLocation is path", async () => {
     const utapi = new UTApi({
       token: testToken.encoded,
-      appIdLocation: "path",
+      ufsAppIdLocation: "path",
       ufsHost: "mycdn.com",
     });
     const result = await utapi.generateSignedURL("foo");

--- a/packages/uploadthing/test/node/sdk.test.ts
+++ b/packages/uploadthing/test/node/sdk.test.ts
@@ -408,6 +408,20 @@ describe("generateSignedURL", () => {
     expect(result.ufsUrl).toMatch(/[?&]signature=[A-Za-z0-9-_]+/);
   });
 
+  it("puts appId in path if appIdLocation is path", async () => {
+    const utapi = new UTApi({
+      token: testToken.encoded,
+      appIdLocation: "path",
+      ufsHost: "mycdn.com",
+    });
+    const result = await utapi.generateSignedURL("foo");
+
+    expect(result).toEqual({
+      ufsUrl: expect.stringMatching("https://mycdn.com/a/app-1/foo"),
+    });
+    expect(result.ufsUrl).toMatch(/[?&]signature=[A-Za-z0-9-_]+/);
+  });
+
   it("throws if expiresIn is invalid", async () => {
     const utapi = new UTApi({ token: testToken.encoded });
     await expect(() =>

--- a/playground/.env.example
+++ b/playground/.env.example
@@ -4,6 +4,6 @@ UPLOADTHING_LOG_LEVEL=Debug
 # Local
 # UPLOADTHING_INGEST_URL=http://localhost:3001
 # UPLOADTHING_API_URL=http://localhost:3000
-# UPLOADTHING_UFS_URL_APP_ID_LOCATION=path
+# UPLOADTHING_UFS_APP_ID_LOCATION=path
 # Staging
 # UPLOADTHING_API_URL=https://api.ut-staging.com

--- a/playground/.env.example
+++ b/playground/.env.example
@@ -4,6 +4,6 @@ UPLOADTHING_LOG_LEVEL=Debug
 # Local
 # UPLOADTHING_INGEST_URL=http://localhost:3001
 # UPLOADTHING_API_URL=http://localhost:3000
-
+# UPLAODTHING_DO_APP_ID_IN_URLS=true
 # Staging
 # UPLOADTHING_API_URL=https://api.ut-staging.com

--- a/playground/.env.example
+++ b/playground/.env.example
@@ -4,6 +4,6 @@ UPLOADTHING_LOG_LEVEL=Debug
 # Local
 # UPLOADTHING_INGEST_URL=http://localhost:3001
 # UPLOADTHING_API_URL=http://localhost:3000
-# UPLOADTHING_URL_APP_ID_LOCATION=path
+# UPLOADTHING_UFS_URL_APP_ID_LOCATION=path
 # Staging
 # UPLOADTHING_API_URL=https://api.ut-staging.com

--- a/playground/.env.example
+++ b/playground/.env.example
@@ -4,6 +4,6 @@ UPLOADTHING_LOG_LEVEL=Debug
 # Local
 # UPLOADTHING_INGEST_URL=http://localhost:3001
 # UPLOADTHING_API_URL=http://localhost:3000
-# UPLAODTHING_DO_APP_ID_IN_URLS=true
+# UPLOADTHING_DO_APP_ID_IN_URLS=true
 # Staging
 # UPLOADTHING_API_URL=https://api.ut-staging.com

--- a/playground/.env.example
+++ b/playground/.env.example
@@ -4,6 +4,6 @@ UPLOADTHING_LOG_LEVEL=Debug
 # Local
 # UPLOADTHING_INGEST_URL=http://localhost:3001
 # UPLOADTHING_API_URL=http://localhost:3000
-# UPLOADTHING_DO_APP_ID_IN_URLS=true
+# UPLOADTHING_URL_APP_ID_LOCATION=path
 # Staging
 # UPLOADTHING_API_URL=https://api.ut-staging.com


### PR DESCRIPTION
# Why this is necessary
I'm developing a self hosted version that doesn't use the appID in the subdomain


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable option to control whether the app ID is included as a subdomain or path segment in UploadThing File Server (UTFS) URLs for self-hosted deployments.

- **Documentation**
  - Updated example environment configuration to include the new option for toggling app ID placement in URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->