### PR TITLE
Fix custom lint rule for effect imports

### DIFF
--- a/packages/uploadthing/test-effect-import.js
+++ b/packages/uploadthing/test-effect-import.js
@@ -1,0 +1,1 @@
+import test from "effect";

--- a/tooling/eslint-config/base.js
+++ b/tooling/eslint-config/base.js
@@ -11,6 +11,13 @@ export function noSelfImport(packageName) {
       "no-restricted-imports": [
         "error",
         {
+          paths: [
+            {
+              name: "effect",
+              message:
+                'Use alias imports instead (import * as X from "effect/X")',
+            },
+          ],
           patterns: [
             {
               group: [`${packageName}`, `${packageName}/*`],


### PR DESCRIPTION
The `no-restricted-imports` ESLint rule was not correctly catching top-level `effect` library imports.

The issue stemmed from ESLint's configuration merging behavior. The `noSelfImport()` function in `tooling/eslint-config/base.js` was intended to add a self-import restriction but was inadvertently *overriding* the existing `no-restricted-imports` rule, which included a `paths` restriction for "effect". Because `noSelfImport()` only defined `patterns` and not `paths`, the `effect` restriction was lost when the configurations merged.

The fix involved modifying the `noSelfImport()` function in `tooling/eslint-config/base.js`. The function was updated to explicitly include both:
*   The `paths` restriction for the `effect` library, with the message `'Use alias imports instead (import * as X from "effect/X")'`.
*   Its original `patterns` restriction for self-imports.

This ensures that when `noSelfImport()` is applied, both the `effect` import restriction and the package self-import restriction are active, correctly preventing top-level `effect` imports while allowing the recommended aliased imports.