### PR TITLE
fix: prevent internal access of deprecated getters

### DIFF
--- a/.changeset/tall-months-switch.md
+++ b/.changeset/tall-months-switch.md
@@ -1,0 +1,6 @@
+---
+"uploadthing": patch
+---
+
+Fix deprecation warning being triggered on every upload due to deprecated
+getters being accessed internally.

--- a/packages/uploadthing/src/_internal/upload-server.ts
+++ b/packages/uploadthing/src/_internal/upload-server.ts
@@ -47,6 +47,12 @@ export const uploadWithoutProgress = (
 
     return {
       ...json,
+      get _internalUrl() {
+        return json.url;
+      },
+      get _internalAppUrl() {
+        return json.appUrl;
+      },
       get url() {
         logDeprecationWarning(
           "`file.url` is deprecated and will be removed in uploadthing v9. Use `file.ufsUrl` instead.",

--- a/packages/uploadthing/src/_internal/upload-server.ts
+++ b/packages/uploadthing/src/_internal/upload-server.ts
@@ -47,12 +47,8 @@ export const uploadWithoutProgress = (
 
     return {
       ...json,
-      get _internalUrl() {
-        return json.url;
-      },
-      get _internalAppUrl() {
-        return json.appUrl;
-      },
+      _internalUrl: json.url,
+      _internalAppUrl: json.appUrl,
       get url() {
         logDeprecationWarning(
           "`file.url` is deprecated and will be removed in uploadthing v9. Use `file.ufsUrl` instead.",

--- a/packages/uploadthing/src/sdk/utils.ts
+++ b/packages/uploadthing/src/sdk/utils.ts
@@ -15,6 +15,7 @@ import type {
   MaybeUrl,
   SerializedUploadThingError,
 } from "@uploadthing/shared";
+import { logDeprecationWarning } from "uploadthing/_internal/deprecations";
 
 import { IngestUrl, UTToken } from "../_internal/config";
 import { uploadWithoutProgress } from "../_internal/upload-server";
@@ -146,8 +147,18 @@ export const uploadFile = (
 
     return {
       key: presigned.key,
-      url: response.url,
-      appUrl: response.appUrl,
+      get url() {
+        logDeprecationWarning(
+          "`file.url` is deprecated and will be removed in uploadthing v9. Use `file.ufsUrl` instead.",
+        );
+        return response._internalUrl;
+      },
+      get appUrl() {
+        logDeprecationWarning(
+          "`file.appUrl` is deprecated and will be removed in uploadthing v9. Use `file.ufsUrl` instead.",
+        );
+        return response._internalAppUrl;
+      },
       ufsUrl: response.ufsUrl,
       lastModified: file.lastModified ?? Date.now(),
       name: file.name,


### PR DESCRIPTION
The deprecated `url` and `appUrl` getters from uploadWithoutProgress were being accessed internally by the uploadFile utility, triggering deprecation console warnings even if the end user is not accessing those getters. This keeps the deprecation warnings by shifting them onto the object returned by uploadFile, while accessing them internally through getters marked "_internal" that do not trigger the warning.

See comment on issue from discord [here](https://discord.com/channels/966627436387266600/1102510616326967306/1388169037522931722)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where deprecation warnings appeared on every upload.

* **New Features**
  * Added new non-deprecated properties for file URLs that avoid triggering warnings.

* **Style**
  * Introduced deprecation warnings for certain file URL properties, guiding users to recommended alternatives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->