### PR TITLE
fix: fix typos in the docs

### DIFF
--- a/docs/src/app/(docs)/api-reference/client/page.mdx
+++ b/docs/src/app/(docs)/api-reference/client/page.mdx
@@ -48,7 +48,7 @@ is an options object:
 await uploadFiles((routeRegistry) => routeRegistry.routeEndpoint, { ... })
 ```
 
-Using a callback function allows `Go to Defintion` on `routeEndpoint` to take
+Using a callback function allows `Go to Definition` on `routeEndpoint` to take
 you straight to your backend file route definition, which is not possible when
 using a string literal parameter.
 

--- a/docs/src/app/(docs)/api-reference/expo/page.mdx
+++ b/docs/src/app/(docs)/api-reference/expo/page.mdx
@@ -171,7 +171,7 @@ export function MultiUploader() {
 }
 ```
 
-### Paramerers
+### Parameters
 
 <Properties>
   <Property name="endpoint" type="keyof UploadRouter" required>

--- a/docs/src/app/(docs)/api-reference/react/page.mdx
+++ b/docs/src/app/(docs)/api-reference/react/page.mdx
@@ -223,7 +223,7 @@ export const OurUploadButton = () => (
       await uploadFiles((routeRegistry) => routeRegistry.routeEndpoint, { ... })
       ```
 
-      Using a callback function allows `Go to Defintion` on `routeEndpoint` to take
+      Using a callback function allows `Go to Definition` on `routeEndpoint` to take
       you straight to your backend file route definition, which is not possible when
       using a string literal parameter.
 
@@ -382,7 +382,7 @@ export const OurUploadDropzone = () => (
       await uploadFiles((routeRegistry) => routeRegistry.routeEndpoint, { ... })
       ```
 
-      Using a callback function allows `Go to Defintion` on `routeEndpoint` to take
+      Using a callback function allows `Go to Definition` on `routeEndpoint` to take
       you straight to your backend file route definition, which is not possible when
       using a string literal parameter.
 
@@ -514,7 +514,7 @@ The endpoint arg may be a string literal or a callback function:
 useUploadThing((routeRegistry) => routeRegistry.routeEndpoint, { ... })
 ```
 
-Using a callback function allows `Go to Defintion` on `routeEndpoint` to take
+Using a callback function allows `Go to Definition` on `routeEndpoint` to take
 you straight to your backend file route definition, which is not possible when
 using a string literal parameter.
 

--- a/docs/src/app/(docs)/api-reference/ut-api/page.mdx
+++ b/docs/src/app/(docs)/api-reference/ut-api/page.mdx
@@ -24,7 +24,7 @@ API but better.
 
 <Note>
   Prior to `v5.7`, the `UTApi` was exported as an object called `utapi` without
-  any custom intialization support.
+  any custom initialization support.
 </Note>
 
 To get started, initialize an instance of `UTApi`.

--- a/docs/src/app/(docs)/concepts/auth-security/page.mdx
+++ b/docs/src/app/(docs)/concepts/auth-security/page.mdx
@@ -16,7 +16,7 @@ flow.
 <Warning>
   Do not protect the entire `/api/uploadthing` route from being called by
   unauthenticated users. The endpoint is called as a webhook by our server and
-  thus must be publically available.
+  thus must be publicly available.
 </Warning>
 
 ## Protecting the endpoint from spoofing

--- a/docs/src/app/(docs)/concepts/error-handling/page.mdx
+++ b/docs/src/app/(docs)/concepts/error-handling/page.mdx
@@ -99,8 +99,8 @@ type UploadThingErrorOptions<T> =
       message?: string;
       /**
        * The original error that caused this, if any.
-       */
-      cause?: unkown;
+  */
+      cause?: unknown;
       /**
        * Data associated with the error
        */

--- a/docs/src/app/(docs)/concepts/regions-acl/page.mdx
+++ b/docs/src/app/(docs)/concepts/regions-acl/page.mdx
@@ -29,7 +29,7 @@ The following regions are currently supported by UploadThing:
 | EU Central - Zurich             | zrh1         |
 | EU West - Dublin                | dub1         |
 | US East - Ohio                  | cle1         |
-| US West - San Fransisco         | sfo1         |
+| US West - San Francisco         | sfo1         |
 | US West - Seattle **(default)** | sea1         |
 
 ### Configuring region

--- a/docs/src/app/(docs)/file-routes/page.mdx
+++ b/docs/src/app/(docs)/file-routes/page.mdx
@@ -68,7 +68,7 @@ export type UploadRouter = typeof uploadRouter;
 ## Route Config {{ since: '5.0' }}
 
 The `f` function takes two arguments. The first can be an array of `FileType`,
-or a record mapping each `FileType` with a route config. The route config allow
+or a record mapping each `FileType` with a route config. The route config allows
 more granular control, for example what files can be uploaded and how many of
 them can be uploaded for a given upload. The array syntax will fallback to
 applying the [defaults](#defaults) to all file types.
@@ -173,7 +173,7 @@ f(["image"])
 
 You can pass a schema validator to validate user input from the client. This
 data comes from the client when the upload starts. If validation here fails, an
-error will be thrown and none of your `middleware` n'or `onUploadComplete`
+error will be thrown and none of your `middleware` nor `onUploadComplete`
 functions will be executed.
 
 Historically, only [Zod](https://github.com/colinhacks/zod) was supported, but
@@ -198,7 +198,7 @@ since `uploadthing@7.4` the following validators are supported:
 
 The input is validated on **your** server and only leaves your server if you
 pass it along from the `.middleware` to the `.onUploadComplete`. If you only use
-the input in the middleware without returning it, the Uploadthing server won't
+the input in the middleware without returning it, the UploadThing server won't
 have any knowledge of it.
 
 ## `middleware` {{ since: '5.0' }}
@@ -238,7 +238,7 @@ f(["image"])
 
 As of `v6.4`, you can also tag your metadata using the `UTFiles` symbol to
 override the uploaded files attributes. This can be used to either rename the
-file, or set a custom identifer for the file:
+file, or set a custom identifier for the file:
 
 ```ts
 import { UTFiles } from "uploadthing/server";
@@ -255,7 +255,7 @@ f(["image"])
     return { foo: "bar" as const, [UTFiles]: fileOverrides };
   })
   .onUploadComplete(async ({ metadata, file }) => {
-    // The UTFIles symbol is stripped from the metadata
+    // The UTFiles symbol is stripped from the metadata
     metadata; // { foo: "bar" }
     file.customId; // myIdentifier
   });
@@ -285,7 +285,7 @@ accessible here. Please note that `onUploadComplete` is the end of the chain,
 each route must have one and it must be the last method in the builder chain.
 
 As of v6.0, you can return JSON serializable data from this function, which will
-be passed to the clientside `onClientUploadComplete` callback.
+be passed to the client-side `onClientUploadComplete` callback.
 
 The function is called with a single object argument with the following
 properties:

--- a/docs/src/app/(docs)/uploading-files/page.mdx
+++ b/docs/src/app/(docs)/uploading-files/page.mdx
@@ -35,7 +35,7 @@ UploadThing.
   before continuing the upload process.
 </Note>
 
-The easiest way to get started with client-side uploads it to define a
+The easiest way to get started with client-side uploads is to define a
 [File Router](/file-routes), expose it on your server using one of our adapters
 [route handlers](/api-reference/server#create-route-handler), and then upload
 the files using our built-in components or upload helpers. Here are some
@@ -521,7 +521,7 @@ After you have verified the request is authentic, run the `onUploadComplete`
 function for the file route. The data returned from the callback can then be
 submitted back to the UploadThing API using the `/callback-result` endpoint.
 Once the data has been submitted, the client upload request will finish assuming
-the `awaitServerData` flag was set to `true` when registerring the upload in a
+the `awaitServerData` flag was set to `true` when registering the upload in a
 previous step.
 
 Congratulations, you have now uploaded your files to UploadThing.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Fixed typos, grammar, and capitalization across Client, React, UT API, Concepts (Auth/Security, Regions & ACL), File Routes, and Uploading Files pages.
  - Corrected headings (“Parameters”), phrases (“Go to Definition”), and region name (“San Francisco”).
  - Updated Expo useImageUploader docs: removed onInsufficientPermissions from OpenImagePickerOptions.
  - Corrected type in Error Handling docs: cause?: unknown.
  - Standardized terminology (UploadThing, client-side) and identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->