### PR TITLE
fix: tabs crashing when switching between tab panels

### DIFF
--- a/docs/src/components/mdx.tsx
+++ b/docs/src/components/mdx.tsx
@@ -123,7 +123,16 @@ export function Tabs({
     </TabGroup>
   );
 }
-export const Tab = TabPanel;
+
+export function Tab({ children }: { children: React.ReactNode }) {
+  return (
+    <TabPanel>
+      <div className="[&>:first-child]:mt-0 [&>:last-child]:mb-0">
+        {children}
+      </div>
+    </TabPanel>
+  );
+}
 
 export function Row({ children }: { children: React.ReactNode }) {
   return (


### PR DESCRIPTION
fixes #1248 

## Problem

The tabs were crashing with a `React.Children.only` error whenever you clicked to switch tabs. This happened because the `Tab` component was directly aliased to Headless UI's `TabPanel`, which expects exactly one child element. But when MDX processes the content, it creates multiple sibling elements (text nodes, code blocks, etc.), which breaks that requirement.

## Solution

Changed the `Tab` component from a direct alias to a wrapper function that wraps all children in a single `div`. This way `TabPanel` always gets exactly one child, no matter how many elements MDX creates inside the tab content.

## Changes

- Updated `Tab` in `src/components/mdx.tsx` to wrap children in a container div
- Added spacing utilities to maintain proper layout

## Testing

Tested by clicking through all tabs on the getting started pages. Tabs now switch without errors.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Tab component styling to ensure proper spacing of content inside tabs, eliminating excess margins on the first and last child elements within tab panels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->