### PR TITLE
fix(docs): include @uploadthing/react in Tailwind content

### DIFF
--- a/docs/tailwind.config.ts
+++ b/docs/tailwind.config.ts
@@ -6,7 +6,11 @@ import { withUt } from "uploadthing/tw";
 import typographyStyles from "./typography";
 
 export default withUt({
-  content: ["./src/**/*.{js,mjs,jsx,ts,tsx,mdx}"],
+  content: [
+    "./src/**/*.{js,mjs,jsx,ts,tsx,mdx}",
+    // UploadThing components
+    "./node_modules/@uploadthing/react/dist/**/*.{js,mjs}",
+  ],
   darkMode: "selector",
   theme: {
     fontSize: {


### PR DESCRIPTION
The blue color was missing because Tailwind wasn’t picking up the styles from `@uploadthing/react`. The button classes like `bg-blue-600`, `bg-blue-400`, and text-white are defined inside that package, and Tailwind only keeps classes it finds while scanning files. 

The docs use `withUt()`, which normally adds the UploadThing content path using `require.resolve("@uploadthing/react")`. But in this setup, Tailwind wasn’t scanning the built dist files, so those classes were removed during build. That’s why the buttons lost their blue styles.

To fix it, the Tailwind config in docs/tailwind.config.ts was updated. The following path was added to the content array: `./node_modules/@uploadthing/react/dist/**/*.{js,mjs}`. This makes sure Tailwind always scans the installed UploadThing React build and keeps the button styles. After restarting or rebuilding the docs app, the blue buttons show up again.

Closes #1250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Tailwind CSS configuration to ensure UploadThing component styles are properly included in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->