### PR TITLE
fix: include file extensions in accept attribute for better cross-browser compatibility

### DIFF
--- a/packages/shared/test/component-utils.test.ts
+++ b/packages/shared/test/component-utils.test.ts
@@ -1,7 +1,10 @@
 import * as E from "effect/Effect";
 import { describe, expect, it } from "vitest";
 
-import { generateMimeTypes } from "../src/component-utils";
+import {
+  generateClientDropzoneAccept,
+  generateMimeTypes,
+} from "../src/component-utils";
 import { fillInputRouteConfig } from "../src/utils";
 
 describe("generateMimeTypes", () => {
@@ -36,5 +39,58 @@ describe("generateMimeTypes", () => {
     expect(videoMimes).toContain("video/*");
     expect(videoMimes).toContain("video/mp4");
     expect(videoMimes).toContain("video/webm");
+  });
+});
+
+describe("generateClientDropzoneAccept", () => {
+  it("includes file extensions for specific MIME types", () => {
+    const result = generateClientDropzoneAccept(["application/java-archive"]);
+    expect(result).toEqual({
+      "application/java-archive": [".jar", ".war", ".ear"],
+    });
+  });
+
+  it("includes file extensions for application/pdf via 'pdf' shorthand", () => {
+    const result = generateClientDropzoneAccept(["pdf"]);
+    expect(result).toEqual({
+      "application/pdf": [".pdf"],
+    });
+  });
+
+  it("returns empty object for blob type", () => {
+    const result = generateClientDropzoneAccept(["blob"]);
+    expect(result).toEqual({});
+  });
+
+  it("includes extensions for generic types like 'image'", () => {
+    const result = generateClientDropzoneAccept(["image"]);
+    const keys = Object.keys(result);
+    expect(keys).toHaveLength(1);
+
+    const extensions = Object.values(result)[0]!;
+    expect(extensions).toContain(".png");
+    expect(extensions).toContain(".jpg");
+    expect(extensions).toContain(".gif");
+    expect(extensions).toContain(".webp");
+  });
+
+  it("handles MIME types with no known extensions gracefully", () => {
+    const result = generateClientDropzoneAccept(["application/x-unknown-type"]);
+    expect(result).toEqual({
+      "application/x-unknown-type": [],
+    });
+  });
+
+  it("handles multiple file types", () => {
+    const result = generateClientDropzoneAccept([
+      "application/java-archive",
+      "pdf",
+    ]);
+    expect(result["application/java-archive"]).toEqual([
+      ".jar",
+      ".war",
+      ".ear",
+    ]);
+    expect(result["application/pdf"]).toEqual([".pdf"]);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1157. Also addresses #949 and #267.

**Problem:** On Windows/Chrome, certain MIME types like `application/java-archive` are not properly mapped to file extensions in the native file picker. When the HTML `<input accept="application/java-archive">` attribute contains only the MIME type, the file picker shows "All Files (*.*)" instead of filtering to `.jar` files.

**Fix:** `generateClientDropzoneAccept()` now populates the extension arrays using the existing `@uploadthing/mime-types` extension data via the lazy `getExtensions()` getter. For example:

```
// Before
{ "application/java-archive": [] }

// After
{ "application/java-archive": [".jar", ".war", ".ear"] }
```

When `acceptPropAsAcceptAttr()` flattens the `AcceptProp`, it already handles extensions (the `isExt()` check), so the resulting `accept` attribute becomes `"application/java-archive,.jar,.war,.ear"` — which Windows/Chrome can properly filter.

## Changes

- **`packages/shared/src/component-utils.ts`**: Import `getExtensions` from `@uploadthing/mime-types` and use it in `generateClientDropzoneAccept()` to look up file extensions for each MIME type. Handles comma-joined strings from generic types (e.g. `"image"`) by splitting and collecting extensions for each sub-type.
- **`packages/shared/test/component-utils.test.ts`**: Added 6 tests for `generateClientDropzoneAccept` covering specific MIME types, the `pdf` shorthand, `blob` type, generic types like `image`, unknown MIME types, and multiple file types.

## Notes

- Uses the lazy `getExtensions()` getter rather than importing the full `application` module directly, keeping bundle impact minimal
- No changes to `dropzone-utils.ts` — the existing `acceptPropAsAcceptAttr()` already handles extensions correctly
- All existing tests continue to pass

## Disclosure

This PR was authored with the assistance of Claude (LLM) to help understand the codebase and structure the implementation and description.