### PR TITLE
chore(security): bumping effect to 3.20.0 because of GHSA-38f7-945m-qr2g

### DIFF
--- a/examples/backend-adapters/server/package.json
+++ b/examples/backend-adapters/server/package.json
@@ -21,7 +21,7 @@
     "@sinclair/typebox": "^0.34.13",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
-    "effect": "3.17.7",
+    "effect": "3.20.0",
     "elysia": "^1.2.9",
     "express": "^5.0.1",
     "fastify": "^5.2.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@uploadthing/mime-types": "workspace:*",
-    "effect": "3.17.7",
+    "effect": "3.20.0",
     "sqids": "^0.3.0"
   },
   "devDependencies": {

--- a/packages/uploadthing/package.json
+++ b/packages/uploadthing/package.json
@@ -163,7 +163,7 @@
     "@standard-schema/spec": "1.0.0-beta.4",
     "@uploadthing/mime-types": "workspace:*",
     "@uploadthing/shared": "workspace:*",
-    "effect": "3.17.7"
+    "effect": "3.20.0"
   },
   "devDependencies": {
     "@effect/vitest": "0.25.1",

--- a/playground-v6/package.json
+++ b/playground-v6/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@uploadthing/react": "npm:@uploadthing/react@6",
     "clsx": "2.1.1",
-    "effect": "3.17.7",
+    "effect": "3.20.0",
     "next": "canary",
     "react": "19.2.2",
     "react-dom": "19.2.2",

--- a/playground/package.json
+++ b/playground/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@uploadthing/react": "workspace:*",
     "class-variance-authority": "^0.7.1",
-    "effect": "3.17.7",
+    "effect": "3.20.0",
     "lucide-react": "^0.469.0",
     "next": "canary",
     "react": "19.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,10 +295,10 @@ importers:
     dependencies:
       '@effect/platform':
         specifier: 0.90.3
-        version: 0.90.3(effect@3.17.7)
+        version: 0.90.3(effect@3.20.0)
       '@effect/platform-node':
         specifier: 0.96.0
-        version: 0.96.0(@effect/cluster@0.30.2(@effect/platform@0.90.3(effect@3.17.7))(@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7))(@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7))(effect@3.17.7))(@effect/platform@0.90.3(effect@3.17.7))(@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7))(@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7))(effect@3.17.7)
+        version: 0.96.0(@effect/cluster@0.30.2(@effect/platform@0.90.3(effect@3.20.0))(@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(@effect/platform@0.90.3(effect@3.20.0))(@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
       '@elysiajs/cors':
         specifier: ^1.2.0
         version: 1.2.0(elysia@1.2.9(@sinclair/typebox@0.34.13)(openapi-types@12.1.3)(typescript@5.8.3))
@@ -318,8 +318,8 @@ importers:
         specifier: ^16.4.5
         version: 16.5.0
       effect:
-        specifier: 3.17.7
-        version: 3.17.7
+        specifier: 3.20.0
+        version: 3.20.0
       elysia:
         specifier: ^1.2.9
         version: 1.2.9(@sinclair/typebox@0.34.13)(openapi-types@12.1.3)(typescript@5.8.3)
@@ -1477,15 +1477,15 @@ importers:
         specifier: workspace:*
         version: link:../mime-types
       effect:
-        specifier: 3.17.7
-        version: 3.17.7
+        specifier: 3.20.0
+        version: 3.20.0
       sqids:
         specifier: ^0.3.0
         version: 0.3.0
     devDependencies:
       '@effect/vitest':
         specifier: 0.25.1
-        version: 0.25.1(effect@3.17.7)(vitest@3.2.4)
+        version: 0.25.1(effect@3.20.0)(vitest@3.2.4)
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -1625,7 +1625,7 @@ importers:
     dependencies:
       '@effect/platform':
         specifier: 0.90.3
-        version: 0.90.3(effect@3.17.7)
+        version: 0.90.3(effect@3.20.0)
       '@standard-schema/spec':
         specifier: 1.0.0-beta.4
         version: 1.0.0-beta.4
@@ -1636,12 +1636,12 @@ importers:
         specifier: workspace:*
         version: link:../shared
       effect:
-        specifier: 3.17.7
-        version: 3.17.7
+        specifier: 3.20.0
+        version: 3.20.0
     devDependencies:
       '@effect/vitest':
         specifier: 0.25.1
-        version: 0.25.1(effect@3.17.7)(vitest@3.2.4)
+        version: 0.25.1(effect@3.20.0)(vitest@3.2.4)
       '@remix-run/server-runtime':
         specifier: ^2.12.0
         version: 2.15.2(typescript@5.8.3)
@@ -1770,14 +1770,14 @@ importers:
         specifier: ^0.7.1
         version: 0.7.1
       effect:
-        specifier: 3.17.7
-        version: 3.17.7
+        specifier: 3.20.0
+        version: 3.20.0
       lucide-react:
         specifier: ^0.469.0
         version: 0.469.0(react@19.2.2)
       next:
         specifier: canary
-        version: 15.4.2-canary.51(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
+        version: 16.2.1-canary.43(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
       react:
         specifier: 19.2.2
         version: 19.2.2
@@ -1826,16 +1826,16 @@ importers:
     dependencies:
       '@uploadthing/react':
         specifier: npm:@uploadthing/react@6
-        version: 6.8.0(next@15.4.2-canary.51(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2))(react@19.2.2)(solid-js@1.9.3)(uploadthing@6.13.3(@effect/platform@0.90.3(effect@3.17.7))(express@5.0.1)(fastify@5.2.0)(h3@1.15.3)(next@15.4.2-canary.51(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2))(tailwindcss@4.0.0))(vue@3.5.13(typescript@5.8.3))
+        version: 6.8.0(next@16.2.1-canary.43(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2))(react@19.2.2)(solid-js@1.9.3)(uploadthing@6.13.3(@effect/platform@0.90.3(effect@3.20.0))(express@5.0.1)(fastify@5.2.0)(h3@1.15.3)(next@16.2.1-canary.43(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2))(tailwindcss@4.0.0))(vue@3.5.13(typescript@5.8.3))
       clsx:
         specifier: 2.1.1
         version: 2.1.1
       effect:
-        specifier: 3.17.7
-        version: 3.17.7
+        specifier: 3.20.0
+        version: 3.20.0
       next:
         specifier: canary
-        version: 15.4.2-canary.51(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
+        version: 16.2.1-canary.43(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
       react:
         specifier: 19.2.2
         version: 19.2.2
@@ -1844,7 +1844,7 @@ importers:
         version: 19.2.2(react@19.2.2)
       uploadthing:
         specifier: npm:uploadthing@6
-        version: 6.13.3(@effect/platform@0.90.3(effect@3.17.7))(express@5.0.1)(fastify@5.2.0)(h3@1.15.3)(next@15.4.2-canary.51(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2))(tailwindcss@4.0.0)
+        version: 6.13.3(@effect/platform@0.90.3(effect@3.20.0))(express@5.0.1)(fastify@5.2.0)(h3@1.15.3)(next@16.2.1-canary.43(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2))(tailwindcss@4.0.0)
       zod:
         specifier: ^3.24.1
         version: 3.25.67
@@ -1926,8 +1926,8 @@ importers:
         specifier: 0.35.2
         version: 0.35.2
       effect:
-        specifier: 3.17.7
-        version: 3.17.7
+        specifier: 3.20.0
+        version: 3.20.0
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -2959,6 +2959,7 @@ packages:
   '@clerk/clerk-react@5.22.2':
     resolution: {integrity: sha512-RcfK5KEZZYMRpXlu94etWCW9jiw+FzjHHq7r1apL4DF9uq3g+YxnM7jeFap3THnulb7un+Ninc0tZkmDLqrAlg==}
     engines: {node: '>=18.17.0'}
+    deprecated: 'This package is no longer supported. Please use @clerk/react instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3'
     peerDependencies:
       react: ^18.0.0 || ^19.0.0 || ^19.0.0-0
       react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-0
@@ -2982,6 +2983,7 @@ packages:
   '@clerk/remix@4.4.6':
     resolution: {integrity: sha512-7Z4wb4YaCouSwZBtFjA48UFLChTo9ucbRbZKrlYhy0eiXAjcR9RTLzZSWO/b5ZUtodITiPvDdtex2IvSl+XVtA==}
     engines: {node: '>=18.17.0'}
+    deprecated: This package has been deprecated - please use the @clerk/react-router SDK
     peerDependencies:
       '@remix-run/react': ^2.0.0
       '@remix-run/server-runtime': ^2.0.0
@@ -3004,6 +3006,7 @@ packages:
   '@clerk/types@4.41.1':
     resolution: {integrity: sha512-Vz1jkHPUzJCVqR/Vmnjpab6hTsfV/Gt2y5W88Pv22xCyeFgmXwxqwu9dLyxMio32ekajRKI9S9hX5LxO0Vsx/Q==}
     engines: {node: '>=18.17.0'}
+    deprecated: 'This package is no longer supported. Please import types from @clerk/shared/types instead. See the upgrade guide for more info: https://clerk.com/docs/guides/development/upgrading/upgrade-guides/core-3'
 
   '@cloudflare/kv-asset-handler@0.3.4':
     resolution: {integrity: sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==}
@@ -3251,6 +3254,9 @@ packages:
 
   '@emnapi/runtime@1.4.5':
     resolution: {integrity: sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==}
+
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
 
   '@emnapi/wasi-threads@1.0.4':
     resolution: {integrity: sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==}
@@ -4455,7 +4461,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.18.31':
     resolution: {integrity: sha512-v9llw9fT3Uv+TCM6Xllo54t672CuYtinEQZ2LPJ2EJsCwuTc4Cd2gXQaouuIVD21VoeGQnr5JtJuWbF97sBKzQ==}
@@ -4727,6 +4733,10 @@ packages:
       '@vue/compiler-sfc':
         optional: true
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
   '@img/sharp-darwin-arm64@0.33.5':
     resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -4735,6 +4745,12 @@ packages:
 
   '@img/sharp-darwin-arm64@0.34.3':
     resolution: {integrity: sha512-ryFMfvxxpQRsgZJqBd4wsttYQbCxsJksrv9Lw/v798JcQ8+w84mBWuXwl+TT0WJ/WrYOLaYpwQXi3sA9nTIaIg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [darwin]
@@ -4751,6 +4767,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
   '@img/sharp-libvips-darwin-arm64@1.0.4':
     resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
     cpu: [arm64]
@@ -4758,6 +4780,11 @@ packages:
 
   '@img/sharp-libvips-darwin-arm64@1.2.0':
     resolution: {integrity: sha512-sBZmpwmxqwlqG9ueWFXtockhsxefaV6O84BMOrhtg/YqbTaRdqDE7hxraVE3y6gVM4eExmfzW4a8el9ArLeEiQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
     os: [darwin]
 
@@ -4771,6 +4798,11 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
   '@img/sharp-libvips-linux-arm64@1.0.4':
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
@@ -4778,6 +4810,11 @@ packages:
 
   '@img/sharp-libvips-linux-arm64@1.2.0':
     resolution: {integrity: sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
 
@@ -4791,9 +4828,24 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
   '@img/sharp-libvips-linux-ppc64@1.2.0':
     resolution: {integrity: sha512-Xod/7KaDDHkYu2phxxfeEPXfVXFKx70EAFZ0qyUdOjCcxbjqyJOEUpDe6RIyaunGxT34Anf9ue/wuWOqBW2WcQ==}
     cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
     os: [linux]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
@@ -4803,6 +4855,11 @@ packages:
 
   '@img/sharp-libvips-linux-s390x@1.2.0':
     resolution: {integrity: sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
 
@@ -4816,6 +4873,11 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
@@ -4823,6 +4885,11 @@ packages:
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.0':
     resolution: {integrity: sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
 
@@ -4836,6 +4903,11 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -4844,6 +4916,12 @@ packages:
 
   '@img/sharp-linux-arm64@0.34.3':
     resolution: {integrity: sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
@@ -4860,10 +4938,28 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
   '@img/sharp-linux-ppc64@0.34.3':
     resolution: {integrity: sha512-GLtbLQMCNC5nxuImPR2+RgrviwKwVql28FWZIW1zWruy6zLgA5/x2ZXk3mxj58X/tszVF69KK0Is83V8YgWhLA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
     os: [linux]
 
   '@img/sharp-linux-s390x@0.33.5':
@@ -4874,6 +4970,12 @@ packages:
 
   '@img/sharp-linux-s390x@0.34.3':
     resolution: {integrity: sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
@@ -4890,6 +4992,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -4898,6 +5006,12 @@ packages:
 
   '@img/sharp-linuxmusl-arm64@0.34.3':
     resolution: {integrity: sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
@@ -4914,6 +5028,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -4924,8 +5044,19 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
 
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
   '@img/sharp-win32-arm64@0.34.3':
     resolution: {integrity: sha512-MjnHPnbqMXNC2UgeLJtX4XqoVHHlZNd+nPt1kRPmj63wURegwBhZlApELdtxM2OIZDRv/DFtLcNhVbd1z8GYXQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [win32]
@@ -4942,6 +5073,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@img/sharp-win32-x64@0.33.5':
     resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -4950,6 +5087,12 @@ packages:
 
   '@img/sharp-win32-x64@0.34.3':
     resolution: {integrity: sha512-OWwz05d++TxzLEv4VnsTz5CmZ6mI6S05sfQGEMrNrQcOEERbX46332IvE7pO/EUiw7jUrrS40z/M7kPyjfl04g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
@@ -5056,6 +5199,7 @@ packages:
   '@koa/router@12.0.2':
     resolution: {integrity: sha512-sYcHglGKTxGF+hQ6x67xDfkE9o+NhVlRHBqq6gLywaMc6CojK/5vFZByphdonKinYlMLkEkacm+HEse9HzwgTA==}
     engines: {node: '>= 12'}
+    deprecated: Please upgrade to v15 or higher. All reported bugs in this version are fixed in newer releases, dependencies have been updated, and security has been improved.
 
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
@@ -5277,11 +5421,11 @@ packages:
   '@next/env@13.5.6':
     resolution: {integrity: sha512-Yac/bV5sBGkkEXmAX5FWPS9Mmo2rthrOPRQQNfycJPkjUAUclomCPH7QFVCDQ4Mp2k2K1SSM6m0zrxYrOwtFQw==}
 
-  '@next/env@15.4.2-canary.51':
-    resolution: {integrity: sha512-xiO1sTeqYlXaa39tTUe7KsWAe/9Fzg9zjVsHUDgfO8wl+5hN7sE9sxZLSw2+or2s85ozaU4g2loIJTBpOX8ROg==}
-
   '@next/env@15.5.8':
     resolution: {integrity: sha512-ejZHa3ogTxcy851dFoNtfB5B2h7AbSAtHbR5CymUlnz4yW1QjHNufVpvTu8PTnWBKFKjrd4k6Gbi2SsCiJKvxw==}
+
+  '@next/env@16.2.1-canary.43':
+    resolution: {integrity: sha512-ZrRwD0T5HlwFf5f3MtqODl/NsLU4JKZYNH1nOzvCdeiGuNfOZS6fhtStcBEDZZuv4+MRa905GCwooQv/dM2KoA==}
 
   '@next/eslint-plugin-next@15.5.8':
     resolution: {integrity: sha512-PBv6j6YxyC9cFgZKSGFlFydQ+lzzR3Fs1GBr9Z2YzoZK7dH/K8ebRtZiN4pV+b8MbSJiHjZYTKVPKF/UzNgrOA==}
@@ -5297,22 +5441,16 @@ packages:
       '@mdx-js/react':
         optional: true
 
-  '@next/swc-darwin-arm64@15.4.2-canary.51':
-    resolution: {integrity: sha512-9wKXXuJGQuNlNFrHdsSXMMEWA4zlXs7I2AcNk8MEQZbLIhaqE4pAyoLcXIyHWfbU+rQM49zAsRNF8jGkVxVKSw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@next/swc-darwin-arm64@15.5.7':
     resolution: {integrity: sha512-IZwtxCEpI91HVU/rAUOOobWSZv4P2DeTtNaCdHqLcTJU4wdNXgAySvKa/qJCgR5m6KI8UsKDXtO2B31jcaw1Yw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.4.2-canary.51':
-    resolution: {integrity: sha512-MlR5N02MF/XL56MeLLkmGre8cAmWbHVeJkdj+Sjf6DVirT3NPzGfZNsj3MOq5fDy0O1Z0gKdTxrFndU4bSN91g==}
+  '@next/swc-darwin-arm64@16.2.1-canary.43':
+    resolution: {integrity: sha512-tprEMQaAKeqVhuIfdYs95Fqn20FSxpkEpvXAvuHc0a0idEfz6QcxYR5pi7coCSd5rt90628ORTatFhN12BJL8w==}
     engines: {node: '>= 10'}
-    cpu: [x64]
+    cpu: [arm64]
     os: [darwin]
 
   '@next/swc-darwin-x64@15.5.7':
@@ -5321,11 +5459,11 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.4.2-canary.51':
-    resolution: {integrity: sha512-iR8XYOUC0MWXIbW+gN8MRoI/yPb4HfccHGkVgz7hQsGgOTm33NqO01Bf1abm7ezhLpNHdw5oukLwGsQM3VdYkw==}
+  '@next/swc-darwin-x64@16.2.1-canary.43':
+    resolution: {integrity: sha512-+4r/3otHgqsytuIs2WCcKKMy9340Se9+doleyPtQ2eacnkBd02uGLJ4Y4qBnOm6Edh5YaDFvAfgUxkv41yTtQw==}
     engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
+    cpu: [x64]
+    os: [darwin]
 
   '@next/swc-linux-arm64-gnu@15.5.7':
     resolution: {integrity: sha512-NCslw3GrNIw7OgmRBxHtdWFQYhexoUCq+0oS2ccjyYLtcn1SzGzeM54jpTFonIMUjNbHmpKpziXnpxhSWLcmBA==}
@@ -5333,8 +5471,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.4.2-canary.51':
-    resolution: {integrity: sha512-JALxctWDmZeUeb37tbphg1o4VSnzOvFanJMDDhlzcCogE/uKhyCBVcoUKb1Ifc1dQv2O47ow24PGUU4xOJZAAw==}
+  '@next/swc-linux-arm64-gnu@16.2.1-canary.43':
+    resolution: {integrity: sha512-n4wVamy9liboUkRVVMxyyaUIjGX3MYXbhcJXB4Nn5BlsF8MG8ZctqPXAe1L8oKeNLGCZZObjt5N3EndYNE95sg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -5345,10 +5483,10 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.4.2-canary.51':
-    resolution: {integrity: sha512-cJlwlNLQ6aQfzjjMRmPPA40ozrxpiXeNzflHlYPYDvr7OMNVWsg4JnKZsQudlldDZ6jcXaOpmru4u+LXkjAulg==}
+  '@next/swc-linux-arm64-musl@16.2.1-canary.43':
+    resolution: {integrity: sha512-8XB7TOLPVQvty2X7HARo7Ri/GfpIayI6YqC0fbq1di+o7/wK1PRK7i0FOJCyiSe3KuzxC2C91j6jGIBaJ6srKg==}
     engines: {node: '>= 10'}
-    cpu: [x64]
+    cpu: [arm64]
     os: [linux]
 
   '@next/swc-linux-x64-gnu@15.5.7':
@@ -5357,8 +5495,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.4.2-canary.51':
-    resolution: {integrity: sha512-bIvIPAC5bLjtqPuHyxifx524xBK0HelgqZKsXhGQM3mVBfIxGt1E78KYSRdGPDoZba8+i0TtgEsz7oH+FJnWpQ==}
+  '@next/swc-linux-x64-gnu@16.2.1-canary.43':
+    resolution: {integrity: sha512-es6OT/e1gAjZi3xcyYolyl9ixIRKgOpUY6EDXeTM9+w2COHadgdcLR1N5m+VfOYurBrNNyJFUIvK0I6pdDv7Fw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -5369,11 +5507,11 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.4.2-canary.51':
-    resolution: {integrity: sha512-wfa1TYSGMiSR2HgRfvQMa5p/Mw+J9DfYsTy/qxZucXq8mbbb7W2FFvYMjYBd9gMe0mBsiailrEWU9fq2g2qlUQ==}
+  '@next/swc-linux-x64-musl@16.2.1-canary.43':
+    resolution: {integrity: sha512-ba0E/oX0DSUN5iwzzfiZfedULA24GJQe6MoyKFsaqphJFOGwYpmShS756fxWcicp3f9oq4Jk8AavXjXL55t5yg==}
     engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
+    cpu: [x64]
+    os: [linux]
 
   '@next/swc-win32-arm64-msvc@15.5.7':
     resolution: {integrity: sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==}
@@ -5381,14 +5519,20 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.4.2-canary.51':
-    resolution: {integrity: sha512-XBlsGCdEW/MTvy0Zpn/2O43Gs60ZvKgkTgN2gT+BYkGLHGVyM8BpkMbaOpMocsk8rGgndZnqJFaGLoFBZZMNrQ==}
+  '@next/swc-win32-arm64-msvc@16.2.1-canary.43':
+    resolution: {integrity: sha512-pFoaqB++21eE9woqEDRAXjTDvJSKnnbL2IL/sM6NPFByp+bPOu2aWTmuvDJvgsWh0Xo+WpBynjPSy/NR2NhUTA==}
     engines: {node: '>= 10'}
-    cpu: [x64]
+    cpu: [arm64]
     os: [win32]
 
   '@next/swc-win32-x64-msvc@15.5.7':
     resolution: {integrity: sha512-gMzgBX164I6DN+9/PGA+9dQiwmTkE4TloBNx8Kv9UiGARsr9Nba7IpcBRA1iTV9vwlYnrE3Uy6I7Aj6qLjQuqw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@16.2.1-canary.43':
+    resolution: {integrity: sha512-NfHb85lFxONazdH8Rwqp21I1ViXuoWNqDm/yr3vqZpnnRLs720nCxVXlmH+L6tex5crVEUEpakWteTaJh8norw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -8660,11 +8804,12 @@ packages:
   '@xmldom/xmldom@0.7.13':
     resolution: {integrity: sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==}
     engines: {node: '>=10.0.0'}
-    deprecated: this version is no longer supported, please update to at least 0.8.*
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -9108,6 +9253,11 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  baseline-browser-mapping@2.10.19:
+    resolution: {integrity: sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
 
   basic-auth@2.0.1:
     resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
@@ -9929,6 +10079,7 @@ packages:
 
   dax-sh@0.39.2:
     resolution: {integrity: sha512-gpuGEkBQM+5y6p4cWaw9+ePy5TNon+fdwFVtTI8leU3UhwhsBfPewRxMXGuQNC+M2b/MDGMlfgpqynkcd0C3FQ==}
+    deprecated: This package has moved to simply be 'dax' instead of 'dax-sh'
 
   dayjs@1.11.13:
     resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
@@ -10147,6 +10298,10 @@ packages:
 
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
+    engines: {node: '>=8'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   detect-node-es@1.1.0:
@@ -10402,8 +10557,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  effect@3.17.7:
-    resolution: {integrity: sha512-dpt0ONUn3zzAuul6k4nC/coTTw27AL5nhkORXgTi6NfMPzqWYa1M05oKmOMTxpVSTKepqXVcW9vIwkuaaqx9zA==}
+  effect@3.20.0:
+    resolution: {integrity: sha512-qMLfDJscrNG8p/aw+IkT9W7fgj50Z4wG5bLBy0Txsxz8iUHjDIkOgO3SV0WZfnQbNG2VJYb0b+rDLMrhM4+Krw==}
 
   effect@3.4.8:
     resolution: {integrity: sha512-qOQNrSSN3ITuAtARtN2Ldq6E5f42splY9VV18LqpKOXMwQCCEWkXdns4by3D2CJnDXQD2KCE0iGcRR2KowiQIA==}
@@ -11571,20 +11726,21 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.1.6:
     resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -12712,6 +12868,7 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   light-my-request@6.4.0:
@@ -13876,9 +14033,10 @@ packages:
       react: ^18.2.0
       react-dom: ^18.2.0
 
-  next@15.4.2-canary.51:
-    resolution: {integrity: sha512-0danfHCbTvU5cAXiSQWPow2AXgFC11ymChQzgMEBqqSd+1v/hBc2TASlB+x5GhUF/wLxmCe9861kcbqocEDDEQ==}
+  next@15.5.8:
+    resolution: {integrity: sha512-Tma2R50eiM7Fx6fbDeHiThq7sPgl06mBr76j6Ga0lMFGrmaLitFsy31kykgb8Z++DR2uIEKi2RZ0iyjIwFd15Q==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -13897,9 +14055,9 @@ packages:
       sass:
         optional: true
 
-  next@15.5.8:
-    resolution: {integrity: sha512-Tma2R50eiM7Fx6fbDeHiThq7sPgl06mBr76j6Ga0lMFGrmaLitFsy31kykgb8Z++DR2uIEKi2RZ0iyjIwFd15Q==}
-    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+  next@16.2.1-canary.43:
+    resolution: {integrity: sha512-tUjaU9AbgO37xFBP9Ipr1AaIesmldYp/3S9u27GZjHML7uzp3msOtvsY0E2cZ6dvecxiLfLqK7mFchE6Af3iiQ==}
+    engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -16182,6 +16340,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
     engines: {node: '>= 0.8.0'}
@@ -16272,6 +16435,10 @@ packages:
 
   sharp@0.34.3:
     resolution: {integrity: sha512-eX2IQ6nFohW4DbvHIOLRB3MHFpYqaqvXd3Tp5e/T/dSH83fxaNJQRvDMhASmkNTsNTVF2/OOopzRCt7xokgPfg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@1.2.0:
@@ -16827,10 +16994,12 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   temp-dir@1.0.0:
     resolution: {integrity: sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==}
@@ -17470,6 +17639,7 @@ packages:
 
   unplugin-vue-router@0.10.9:
     resolution: {integrity: sha512-DXmC0GMcROOnCmN56GRvi1bkkG1BnVs4xJqNvucBUeZkmB245URvtxOfbo3H6q4SOUQQbLPYWd6InzvjRh363A==}
+    deprecated: 'Merged into vuejs/router. Migrate: https://router.vuejs.org/guide/migration/v4-to-v5.html'
     peerDependencies:
       vue-router: ^4.4.0
     peerDependenciesMeta:
@@ -18174,6 +18344,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
@@ -20157,45 +20328,45 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
-  '@effect/cluster@0.30.2(@effect/platform@0.90.3(effect@3.17.7))(@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7))(@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7))(effect@3.17.7)':
+  '@effect/cluster@0.30.2(@effect/platform@0.90.3(effect@3.20.0))(@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)':
     dependencies:
-      '@effect/platform': 0.90.3(effect@3.17.7)
-      '@effect/rpc': 0.56.2(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)
-      '@effect/sql': 0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)
-      effect: 3.17.7
+      '@effect/platform': 0.90.3(effect@3.20.0)
+      '@effect/rpc': 0.56.2(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)
+      '@effect/sql': 0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)
+      effect: 3.20.0
 
-  '@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)(ioredis@5.6.1)':
+  '@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)(ioredis@5.6.1)':
     dependencies:
-      '@effect/platform': 0.90.3(effect@3.17.7)
-      effect: 3.17.7
+      '@effect/platform': 0.90.3(effect@3.20.0)
+      effect: 3.20.0
       uuid: 11.1.0
     optionalDependencies:
       ioredis: 5.6.1
 
   '@effect/language-service@0.35.2': {}
 
-  '@effect/platform-node-shared@0.49.0(@effect/cluster@0.30.2(@effect/platform@0.90.3(effect@3.17.7))(@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7))(@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7))(effect@3.17.7))(@effect/platform@0.90.3(effect@3.17.7))(@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7))(@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7))(effect@3.17.7)':
+  '@effect/platform-node-shared@0.49.0(@effect/cluster@0.30.2(@effect/platform@0.90.3(effect@3.20.0))(@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(@effect/platform@0.90.3(effect@3.20.0))(@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)':
     dependencies:
-      '@effect/cluster': 0.30.2(@effect/platform@0.90.3(effect@3.17.7))(@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7))(@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7))(effect@3.17.7)
-      '@effect/platform': 0.90.3(effect@3.17.7)
-      '@effect/rpc': 0.56.2(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)
-      '@effect/sql': 0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)
+      '@effect/cluster': 0.30.2(@effect/platform@0.90.3(effect@3.20.0))(@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
+      '@effect/platform': 0.90.3(effect@3.20.0)
+      '@effect/rpc': 0.56.2(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)
+      '@effect/sql': 0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)
       '@parcel/watcher': 2.5.1
-      effect: 3.17.7
+      effect: 3.20.0
       multipasta: 0.2.7
       ws: 8.18.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@0.96.0(@effect/cluster@0.30.2(@effect/platform@0.90.3(effect@3.17.7))(@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7))(@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7))(effect@3.17.7))(@effect/platform@0.90.3(effect@3.17.7))(@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7))(@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7))(effect@3.17.7)':
+  '@effect/platform-node@0.96.0(@effect/cluster@0.30.2(@effect/platform@0.90.3(effect@3.20.0))(@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(@effect/platform@0.90.3(effect@3.20.0))(@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)':
     dependencies:
-      '@effect/cluster': 0.30.2(@effect/platform@0.90.3(effect@3.17.7))(@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7))(@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7))(effect@3.17.7)
-      '@effect/platform': 0.90.3(effect@3.17.7)
-      '@effect/platform-node-shared': 0.49.0(@effect/cluster@0.30.2(@effect/platform@0.90.3(effect@3.17.7))(@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7))(@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7))(effect@3.17.7))(@effect/platform@0.90.3(effect@3.17.7))(@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7))(@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7))(effect@3.17.7)
-      '@effect/rpc': 0.56.2(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)
-      '@effect/sql': 0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)
-      effect: 3.17.7
+      '@effect/cluster': 0.30.2(@effect/platform@0.90.3(effect@3.20.0))(@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
+      '@effect/platform': 0.90.3(effect@3.20.0)
+      '@effect/platform-node-shared': 0.49.0(@effect/cluster@0.30.2(@effect/platform@0.90.3(effect@3.20.0))(@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0))(effect@3.20.0))(@effect/platform@0.90.3(effect@3.20.0))(@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0))(@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0))(effect@3.20.0)
+      '@effect/rpc': 0.56.2(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)
+      '@effect/sql': 0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)
+      effect: 3.20.0
       mime: 3.0.0
       undici: 7.10.0
       ws: 8.18.2
@@ -20203,35 +20374,35 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform@0.90.3(effect@3.17.7)':
+  '@effect/platform@0.90.3(effect@3.20.0)':
     dependencies:
       '@opentelemetry/semantic-conventions': 1.36.0
-      effect: 3.17.7
+      effect: 3.20.0
       find-my-way-ts: 0.1.6
       msgpackr: 1.11.4
       multipasta: 0.2.7
 
-  '@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)':
+  '@effect/rpc@0.56.2(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)':
     dependencies:
-      '@effect/platform': 0.90.3(effect@3.17.7)
-      effect: 3.17.7
+      '@effect/platform': 0.90.3(effect@3.20.0)
+      effect: 3.20.0
 
   '@effect/schema@0.68.18(effect@3.4.8)':
     dependencies:
       effect: 3.4.8
       fast-check: 3.23.2
 
-  '@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)':
+  '@effect/sql@0.33.14(@effect/experimental@0.44.14(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)(ioredis@5.6.1))(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)':
     dependencies:
-      '@effect/experimental': 0.44.14(@effect/platform@0.90.3(effect@3.17.7))(effect@3.17.7)(ioredis@5.6.1)
-      '@effect/platform': 0.90.3(effect@3.17.7)
+      '@effect/experimental': 0.44.14(@effect/platform@0.90.3(effect@3.20.0))(effect@3.20.0)(ioredis@5.6.1)
+      '@effect/platform': 0.90.3(effect@3.20.0)
       '@opentelemetry/semantic-conventions': 1.36.0
-      effect: 3.17.7
+      effect: 3.20.0
       uuid: 11.1.0
 
-  '@effect/vitest@0.25.1(effect@3.17.7)(vitest@3.2.4)':
+  '@effect/vitest@0.25.1(effect@3.20.0)(vitest@3.2.4)':
     dependencies:
-      effect: 3.17.7
+      effect: 3.20.0
       vitest: 3.2.4(@types/node@22.12.0)(@vitest/browser@3.2.4)(happy-dom@16.3.0)(jiti@2.4.2)(lightningcss@1.29.3)(msw@2.7.5(@types/node@22.12.0)(typescript@5.8.3))(terser@5.37.0)(tsx@4.19.2)(yaml@2.7.0)
 
   '@egjs/agent@2.4.3': {}
@@ -20282,6 +20453,11 @@ snapshots:
     optional: true
 
   '@emnapi/runtime@1.4.5':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -21087,7 +21263,7 @@ snapshots:
       resolve: 1.22.10
       resolve-from: 5.0.0
       resolve.exports: 2.0.3
-      semver: 7.7.2
+      semver: 7.7.4
       send: 0.19.1
       slugify: 1.6.6
       source-map-support: 0.5.21
@@ -21144,7 +21320,7 @@ snapshots:
       getenv: 1.0.0
       glob: 10.4.5
       resolve-from: 5.0.0
-      semver: 7.7.2
+      semver: 7.7.4
       slash: 3.0.0
       slugify: 1.6.6
       xcode: 3.0.1
@@ -21168,7 +21344,7 @@ snapshots:
       require-from-string: 2.0.2
       resolve-from: 5.0.0
       resolve-workspace-root: 2.0.0
-      semver: 7.7.2
+      semver: 7.7.4
       slugify: 1.6.6
       sucrase: 3.35.0
     transitivePeerDependencies:
@@ -21238,7 +21414,7 @@ snapshots:
       minimatch: 3.1.2
       p-limit: 3.1.0
       resolve-from: 5.0.0
-      semver: 7.7.2
+      semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
 
@@ -21266,7 +21442,7 @@ snapshots:
       jimp-compact: 0.16.1
       parse-png: 2.1.0
       resolve-from: 5.0.0
-      semver: 7.7.2
+      semver: 7.7.4
       temp-dir: 2.0.0
       unique-string: 2.0.0
 
@@ -21398,7 +21574,7 @@ snapshots:
       debug: 4.4.1
       fs-extra: 9.1.0
       resolve-from: 5.0.0
-      semver: 7.7.2
+      semver: 7.7.4
       xml2js: 0.6.0
     transitivePeerDependencies:
       - supports-color
@@ -21609,6 +21785,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@img/colour@1.1.0':
+    optional: true
+
   '@img/sharp-darwin-arm64@0.33.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.0.4
@@ -21617,6 +21796,11 @@ snapshots:
   '@img/sharp-darwin-arm64@0.34.3':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.2.0
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
     optional: true
 
   '@img/sharp-darwin-x64@0.33.5':
@@ -21629,10 +21813,18 @@ snapshots:
       '@img/sharp-libvips-darwin-x64': 1.2.0
     optional: true
 
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
   '@img/sharp-libvips-darwin-arm64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-darwin-arm64@1.2.0':
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
     optional: true
 
   '@img/sharp-libvips-darwin-x64@1.0.4':
@@ -21641,10 +21833,16 @@ snapshots:
   '@img/sharp-libvips-darwin-x64@1.2.0':
     optional: true
 
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
   '@img/sharp-libvips-linux-arm64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-linux-arm64@1.2.0':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
     optional: true
 
   '@img/sharp-libvips-linux-arm@1.0.5':
@@ -21653,7 +21851,16 @@ snapshots:
   '@img/sharp-libvips-linux-arm@1.2.0':
     optional: true
 
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
   '@img/sharp-libvips-linux-ppc64@1.2.0':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
@@ -21662,10 +21869,16 @@ snapshots:
   '@img/sharp-libvips-linux-s390x@1.2.0':
     optional: true
 
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
   '@img/sharp-libvips-linux-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.2.0':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
@@ -21674,10 +21887,16 @@ snapshots:
   '@img/sharp-libvips-linuxmusl-arm64@1.2.0':
     optional: true
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.0':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     optional: true
 
   '@img/sharp-linux-arm64@0.33.5':
@@ -21690,6 +21909,11 @@ snapshots:
       '@img/sharp-libvips-linux-arm64': 1.2.0
     optional: true
 
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
   '@img/sharp-linux-arm@0.33.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.0.5
@@ -21700,9 +21924,24 @@ snapshots:
       '@img/sharp-libvips-linux-arm': 1.2.0
     optional: true
 
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
   '@img/sharp-linux-ppc64@0.34.3':
     optionalDependencies:
       '@img/sharp-libvips-linux-ppc64': 1.2.0
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
     optional: true
 
   '@img/sharp-linux-s390x@0.33.5':
@@ -21715,6 +21954,11 @@ snapshots:
       '@img/sharp-libvips-linux-s390x': 1.2.0
     optional: true
 
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
   '@img/sharp-linux-x64@0.33.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.0.4
@@ -21723,6 +21967,11 @@ snapshots:
   '@img/sharp-linux-x64@0.34.3':
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.2.0
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
     optional: true
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
@@ -21735,6 +21984,11 @@ snapshots:
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.0
     optional: true
 
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
   '@img/sharp-linuxmusl-x64@0.33.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.0.4
@@ -21743,6 +21997,11 @@ snapshots:
   '@img/sharp-linuxmusl-x64@0.34.3':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.2.0
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
     optional: true
 
   '@img/sharp-wasm32@0.33.5':
@@ -21755,7 +22014,15 @@ snapshots:
       '@emnapi/runtime': 1.4.5
     optional: true
 
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.9.2
+    optional: true
+
   '@img/sharp-win32-arm64@0.34.3':
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
     optional: true
 
   '@img/sharp-win32-ia32@0.33.5':
@@ -21764,10 +22031,16 @@ snapshots:
   '@img/sharp-win32-ia32@0.34.3':
     optional: true
 
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
   '@img/sharp-win32-x64@0.33.5':
     optional: true
 
   '@img/sharp-win32-x64@0.34.3':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
     optional: true
 
   '@inquirer/confirm@5.1.1(@types/node@22.12.0)':
@@ -22075,7 +22348,7 @@ snapshots:
   '@mapbox/node-pre-gyp@2.0.0(encoding@0.1.13)':
     dependencies:
       consola: 3.4.2
-      detect-libc: 2.0.3
+      detect-libc: 2.0.4
       https-proxy-agent: 7.0.6
       node-fetch: 2.7.0(encoding@0.1.13)
       nopt: 8.0.0
@@ -22287,9 +22560,9 @@ snapshots:
 
   '@next/env@13.5.6': {}
 
-  '@next/env@15.4.2-canary.51': {}
-
   '@next/env@15.5.8': {}
+
+  '@next/env@16.2.1-canary.43': {}
 
   '@next/eslint-plugin-next@15.5.8':
     dependencies:
@@ -22302,52 +22575,52 @@ snapshots:
       '@mdx-js/loader': 3.1.0(webpack@5.97.1)
       '@mdx-js/react': 3.1.0(@types/react@19.2.7)(react@19.2.2)
 
-  '@next/swc-darwin-arm64@15.4.2-canary.51':
-    optional: true
-
   '@next/swc-darwin-arm64@15.5.7':
     optional: true
 
-  '@next/swc-darwin-x64@15.4.2-canary.51':
+  '@next/swc-darwin-arm64@16.2.1-canary.43':
     optional: true
 
   '@next/swc-darwin-x64@15.5.7':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.4.2-canary.51':
+  '@next/swc-darwin-x64@16.2.1-canary.43':
     optional: true
 
   '@next/swc-linux-arm64-gnu@15.5.7':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.4.2-canary.51':
+  '@next/swc-linux-arm64-gnu@16.2.1-canary.43':
     optional: true
 
   '@next/swc-linux-arm64-musl@15.5.7':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.4.2-canary.51':
+  '@next/swc-linux-arm64-musl@16.2.1-canary.43':
     optional: true
 
   '@next/swc-linux-x64-gnu@15.5.7':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.4.2-canary.51':
+  '@next/swc-linux-x64-gnu@16.2.1-canary.43':
     optional: true
 
   '@next/swc-linux-x64-musl@15.5.7':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.4.2-canary.51':
+  '@next/swc-linux-x64-musl@16.2.1-canary.43':
     optional: true
 
   '@next/swc-win32-arm64-msvc@15.5.7':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.4.2-canary.51':
+  '@next/swc-win32-arm64-msvc@16.2.1-canary.43':
     optional: true
 
   '@next/swc-win32-x64-msvc@15.5.7':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@16.2.1-canary.43':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -26587,16 +26860,16 @@ snapshots:
 
   '@uploadthing/mime-types@0.2.10': {}
 
-  '@uploadthing/react@6.8.0(next@15.4.2-canary.51(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2))(react@19.2.2)(solid-js@1.9.3)(uploadthing@6.13.3(@effect/platform@0.90.3(effect@3.17.7))(express@5.0.1)(fastify@5.2.0)(h3@1.15.3)(next@15.4.2-canary.51(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2))(tailwindcss@4.0.0))(vue@3.5.13(typescript@5.8.3))':
+  '@uploadthing/react@6.8.0(next@16.2.1-canary.43(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2))(react@19.2.2)(solid-js@1.9.3)(uploadthing@6.13.3(@effect/platform@0.90.3(effect@3.20.0))(express@5.0.1)(fastify@5.2.0)(h3@1.15.3)(next@16.2.1-canary.43(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2))(tailwindcss@4.0.0))(vue@3.5.13(typescript@5.8.3))':
     dependencies:
       '@uploadthing/dropzone': 0.4.1(react@19.2.2)(solid-js@1.9.3)(vue@3.5.13(typescript@5.8.3))
       '@uploadthing/shared': 6.7.9
       file-selector: 0.6.0
       react: 19.2.2
       tailwind-merge: 2.6.0
-      uploadthing: 6.13.3(@effect/platform@0.90.3(effect@3.17.7))(express@5.0.1)(fastify@5.2.0)(h3@1.15.3)(next@15.4.2-canary.51(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2))(tailwindcss@4.0.0)
+      uploadthing: 6.13.3(@effect/platform@0.90.3(effect@3.20.0))(express@5.0.1)(fastify@5.2.0)(h3@1.15.3)(next@16.2.1-canary.43(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2))(tailwindcss@4.0.0)
     optionalDependencies:
-      next: 15.4.2-canary.51(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
+      next: 16.2.1-canary.43(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
     transitivePeerDependencies:
       - solid-js
       - svelte
@@ -27855,6 +28128,8 @@ snapshots:
 
   base64-js@1.5.1: {}
 
+  baseline-browser-mapping@2.10.19: {}
+
   basic-auth@2.0.1:
     dependencies:
       safe-buffer: 5.1.2
@@ -28953,7 +29228,9 @@ snapshots:
 
   detect-libc@2.0.3: {}
 
-  detect-libc@2.0.4:
+  detect-libc@2.0.4: {}
+
+  detect-libc@2.1.2:
     optional: true
 
   detect-node-es@1.1.0: {}
@@ -29128,7 +29405,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  effect@3.17.7:
+  effect@3.20.0:
     dependencies:
       '@standard-schema/spec': 1.0.0
       fast-check: 3.23.2
@@ -33901,30 +34178,6 @@ snapshots:
       react: 19.2.2
       react-dom: 19.2.2(react@19.2.2)
 
-  next@15.4.2-canary.51(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2):
-    dependencies:
-      '@next/env': 15.4.2-canary.51
-      '@swc/helpers': 0.5.15
-      caniuse-lite: 1.0.30001696
-      postcss: 8.4.31
-      react: 19.2.2
-      react-dom: 19.2.2(react@19.2.2)
-      styled-jsx: 5.1.6(react@19.2.2)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 15.4.2-canary.51
-      '@next/swc-darwin-x64': 15.4.2-canary.51
-      '@next/swc-linux-arm64-gnu': 15.4.2-canary.51
-      '@next/swc-linux-arm64-musl': 15.4.2-canary.51
-      '@next/swc-linux-x64-gnu': 15.4.2-canary.51
-      '@next/swc-linux-x64-musl': 15.4.2-canary.51
-      '@next/swc-win32-arm64-msvc': 15.4.2-canary.51
-      '@next/swc-win32-x64-msvc': 15.4.2-canary.51
-      '@playwright/test': 1.52.0
-      sharp: 0.34.3
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
   next@15.5.8(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2):
     dependencies:
       '@next/env': 15.5.8
@@ -33945,6 +34198,31 @@ snapshots:
       '@next/swc-win32-x64-msvc': 15.5.7
       '@playwright/test': 1.52.0
       sharp: 0.34.3
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  next@16.2.1-canary.43(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2):
+    dependencies:
+      '@next/env': 16.2.1-canary.43
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.19
+      caniuse-lite: 1.0.30001696
+      postcss: 8.4.31
+      react: 19.2.2
+      react-dom: 19.2.2(react@19.2.2)
+      styled-jsx: 5.1.6(react@19.2.2)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.1-canary.43
+      '@next/swc-darwin-x64': 16.2.1-canary.43
+      '@next/swc-linux-arm64-gnu': 16.2.1-canary.43
+      '@next/swc-linux-arm64-musl': 16.2.1-canary.43
+      '@next/swc-linux-x64-gnu': 16.2.1-canary.43
+      '@next/swc-linux-x64-musl': 16.2.1-canary.43
+      '@next/swc-win32-arm64-msvc': 16.2.1-canary.43
+      '@next/swc-win32-x64-msvc': 16.2.1-canary.43
+      '@playwright/test': 1.52.0
+      sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -34090,7 +34368,7 @@ snapshots:
 
   node-gyp-build-optional-packages@5.2.2:
     dependencies:
-      detect-libc: 2.0.3
+      detect-libc: 2.0.4
     optional: true
 
   node-gyp-build@4.6.0: {}
@@ -36888,6 +37166,8 @@ snapshots:
 
   semver@7.7.2: {}
 
+  semver@7.7.4: {}
+
   send@0.18.0:
     dependencies:
       debug: 2.6.9
@@ -37088,6 +37368,38 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.3
       '@img/sharp-win32-ia32': 0.34.3
       '@img/sharp-win32-x64': 0.34.3
+    optional: true
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
     optional: true
 
   shebang-command@1.2.0:
@@ -38595,7 +38907,7 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  uploadthing@6.13.3(@effect/platform@0.90.3(effect@3.17.7))(express@5.0.1)(fastify@5.2.0)(h3@1.15.3)(next@15.4.2-canary.51(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2))(tailwindcss@4.0.0):
+  uploadthing@6.13.3(@effect/platform@0.90.3(effect@3.20.0))(express@5.0.1)(fastify@5.2.0)(h3@1.15.3)(next@16.2.1-canary.43(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2))(tailwindcss@4.0.0):
     dependencies:
       '@effect/schema': 0.68.18(effect@3.4.8)
       '@uploadthing/mime-types': 0.2.10
@@ -38604,11 +38916,11 @@ snapshots:
       effect: 3.4.8
       std-env: 3.9.0
     optionalDependencies:
-      '@effect/platform': 0.90.3(effect@3.17.7)
+      '@effect/platform': 0.90.3(effect@3.20.0)
       express: 5.0.1
       fastify: 5.2.0
       h3: 1.15.3
-      next: 15.4.2-canary.51(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
+      next: 16.2.1-canary.43(@playwright/test@1.52.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2)
       tailwindcss: 4.0.0
 
   uqr@0.1.2: {}

--- a/tooling/tsconfig/package.json
+++ b/tooling/tsconfig/package.json
@@ -7,7 +7,7 @@
   ],
   "dependencies": {
     "@effect/language-service": "0.35.2",
-    "effect": "3.17.7",
+    "effect": "3.20.0",
     "typescript": "5.8.3"
   }
 }


### PR DESCRIPTION
This PR attemps to fix a high security issue described on https://github.com/advisories/GHSA-38f7-945m-qr2g that's related to `effect` npm package that's widely used in this repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Effect library dependency to version 3.20.0 across all packages, examples, and tooling configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->