### PR TITLE
docs(elysia): caution callout for parse: 'none' refactor footgun

### DIFF
--- a/docs/src/app/(docs)/backend-adapters/fetch/page.mdx
+++ b/docs/src/app/(docs)/backend-adapters/fetch/page.mdx
@@ -120,6 +120,35 @@ new Elysia()
   });
 ```
 
+<Note>
+  **Heads up if you refactor the handler shape.** The example above works
+  because Elysia's static analyzer leaves `ev.request` alone. If you
+  rewrite either route to the more idiomatic destructured form —
+  `({ request }) => handlers(request)` — the analyzer infers the route
+  reads `body` and Elysia pre-parses the request via `request.json()`,
+  consuming the stream before UploadThing's handler can read it. The
+  client sees a silent empty-body 400.
+
+  The fix is to opt out of body parsing for the route by passing
+  `{ parse: "none" }` as the third argument:
+
+  ```ts
+  .get("/api/uploadthing", ({ request }) => handlers(request), {
+    parse: "none",
+  })
+  .post("/api/uploadthing", ({ request }) => handlers(request), {
+    parse: "none",
+  })
+  ```
+
+  This is the same option Elysia uses internally for its own
+  [`.mount()` method](https://elysiajs.com/patterns/mount.html) and is
+  documented under
+  [explicit parsers](https://elysiajs.com/essential/life-cycle.html#explicit-parser).
+  See [elysiajs/elysia#1252](https://github.com/elysiajs/elysia/issues/1252)
+  for background.
+</Note>
+
 ### Hono
 
 ```ts

--- a/examples/backend-adapters/server/src/elysia.ts
+++ b/examples/backend-adapters/server/src/elysia.ts
@@ -9,6 +9,14 @@ const handler = createRouteHandler({
   router: uploadRouter,
 });
 
+// The `(ev) => handler(ev.request)` shape is intentional — it keeps
+// Elysia's static analyzer from inferring the route reads `body` and
+// pre-parsing the request, which would consume the stream before
+// UploadThing's handler reads it. If you rewrite to the idiomatic
+// `({ request }) => handler(request)`, add `{ parse: "none" }` as the
+// route's third arg to opt out of body parsing. See the Elysia callout
+// in docs/src/app/(docs)/backend-adapters/fetch/page.mdx and
+// elysiajs/elysia#1252.
 new Elysia()
   .get("/api", () => "Hello from Elysia!")
   .get("/api/uploadthing", (ev) => handler(ev.request))


### PR DESCRIPTION
## Summary

The Elysia example currently uses `(ev) => handlers(ev.request)`, which works fine. But the moment a user refactors either route to the more idiomatic destructured form `({ request }) => handlers(request)`, the route silently breaks: Elysia's static analyzer (sucrose) flips `inference.body = true`, Elysia compiles in a `request.json()` before the handler runs, and UploadThing's handler receives a consumed stream — surfacing as an empty-body 400 at the client with no actionable log.

This PR keeps the working example untouched and adds:

- A `<Note>` callout in the Elysia docs section explaining the gotcha and showing the `{ parse: "none" }` opt-out for users who do refactor.
- An inline comment in `examples/backend-adapters/server/src/elysia.ts` noting why the `ev.request` shape is intentional.

No package changes; no changeset (mirrors the docs-only pattern of #976).

## Why this is worth flagging

The failure mode is genuinely hard to debug:

1. The error has no log on the server side — UT silently returns 400.
2. The response carries no `x-uploadthing-version` header (it never reached UT's handler), so it isn't obviously a UT issue.
3. The fix isn't documented in either UT or Elysia by name. Elysia has a docs page on [explicit parsers](https://elysiajs.com/essential/life-cycle.html#explicit-parser), but it doesn't explain that an analyzer-driven `inference.body = true` is what triggers them in the first place.

Most Elysia users naturally write `({ request }) =>` over `(ev) =>` — it's the recommended style across the rest of the Elysia ecosystem and docs. Without this callout, copy-pasting the docs example then "cleaning it up" silently breaks uploads.

## Root cause (for the record)

`node_modules/elysia/dist/sucrose.mjs` lines 179–198. The relevant regexes:

```js
captureFunction = /\w\((?:.*?)?<param>(?:.*?)?\)/gs
exactParameter  = /<param>(,|\))/gs
```

For `(ev) => handlers(ev.request)`:
- `mainParameter = "ev"`, body = `"handlers(ev.request)"`
- `exactParameter` requires `ev,` or `ev)`. Body has `ev.` → no match.
- `inference.body` stays false → Elysia doesn't pre-parse → UT works.

For `({ request }) => handlers(request)`:
- `mainParameter = "request"`, body = `"handlers(request)"`
- `exactParameter` matches `request)`.
- All nine inference flags get flipped (defensive overestimate) including `body`.
- `hasBody` becomes true at compose.mjs:258 → Elysia injects `request.json()` → stream consumed → UT errors.

## References

- [elysiajs/elysia#1252](https://github.com/elysiajs/elysia/issues/1252) — closed-as-expected discussion where SaltyAom recommends `parse: 'none'` as the permanent fix for "hand the raw request to a 3rd-party framework" use cases.
- [Elysia explicit parsers docs](https://elysiajs.com/essential/life-cycle.html#explicit-parser)
- Elysia's own [`.mount()` method](https://github.com/elysiajs/elysia/blob/main/src/index.ts) uses `parse: 'none'` for the same reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Elysia backend adapter documentation with clarification on handler configuration to prevent request body parsing issues.
  * Added guidance on proper route configuration options for `.get`/`.post` definitions.
  * Improved code examples with explanatory comments on request stream handling patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->