### PR TITLE
feat: optional `nonce` prop for `NextSSRPlugin`

### DIFF
--- a/.changeset/gorgeous-birds-reflect.md
+++ b/.changeset/gorgeous-birds-reflect.md
@@ -1,0 +1,5 @@
+---
+"@uploadthing/react": patch
+---
+
+fix: prevent `NextSSRPlugin` script being inserted multiple times

--- a/.changeset/lazy-lions-reply.md
+++ b/.changeset/lazy-lions-reply.md
@@ -1,0 +1,5 @@
+---
+"@uploadthing/react": patch
+---
+
+feat: optional `nonce` prop for `NextSSRPlugin`

--- a/packages/react/src/next-ssr-plugin.tsx
+++ b/packages/react/src/next-ssr-plugin.tsx
@@ -9,7 +9,10 @@ declare const globalThis: {
   __UPLOADTHING?: EndpointMetadata;
 };
 
-export function NextSSRPlugin(props: { routerConfig: EndpointMetadata }) {
+export function NextSSRPlugin(props: {
+  routerConfig: EndpointMetadata;
+  nonce?: string;
+}) {
   const id = useId();
 
   // Set routerConfig on server globalThis
@@ -22,7 +25,11 @@ export function NextSSRPlugin(props: { routerConfig: EndpointMetadata }) {
     ];
 
     return (
-      <script key={id} dangerouslySetInnerHTML={{ __html: html.join("") }} />
+      <script
+        key={id}
+        nonce={props.nonce}
+        dangerouslySetInnerHTML={{ __html: html.join("") }}
+      />
     );
   });
 

--- a/packages/react/src/next-ssr-plugin.tsx
+++ b/packages/react/src/next-ssr-plugin.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useId } from "react";
+import { useId, useRef } from "react";
 import { useServerInsertedHTML } from "next/navigation";
 
 import type { EndpointMetadata } from "@uploadthing/shared";
@@ -14,11 +14,15 @@ export function NextSSRPlugin(props: {
   nonce?: string;
 }) {
   const id = useId();
+  const isInserted = useRef(false);
 
   // Set routerConfig on server globalThis
   globalThis.__UPLOADTHING = props.routerConfig;
 
   useServerInsertedHTML(() => {
+    if (isInserted.current) return;
+    isInserted.current = true;
+
     const html = [
       // Hydrate routerConfig on client globalThis
       `globalThis.__UPLOADTHING = ${JSON.stringify(props.routerConfig)};`,


### PR DESCRIPTION
This adds an optional `nonce` prop to `NextSSRplugin` which is added onto the script tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The server-side rendering plugin now accepts an optional nonce prop, applied to its injected script tag.
* **Bug Fixes**
  * Prevents the plugin’s injected script from being inserted multiple times during SSR.
* **Chores**
  * Published a patch release for the above updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->